### PR TITLE
fix: preserve development server command

### DIFF
--- a/src/instance/instance.ts
+++ b/src/instance/instance.ts
@@ -118,6 +118,7 @@ export async function launchInstance(options: LaunchOptions) {
   let child: ReturnType<typeof spawn> | undefined
   const clients = new Map<string, Bun.Subprocess>()
   const launching = new Set<string>()
+  let serverChild: Bun.Subprocess | undefined
   let serverStarted = false
   let serverStarting = false
   let serverStopping = false
@@ -148,26 +149,19 @@ export async function launchInstance(options: LaunchOptions) {
           ui: `ws://127.0.0.1:${await freePort()}`,
           backend: endpoints.backend,
         }, undefined)
-        const service = spawn(
+        serverChild = spawn(
           serviceName,
-          [...command, "service", "start"],
-          "service-start",
+          [...command, "serve", "--service"],
+          "service",
         )
-        const status = await service.exited
-        if (status !== 0)
-          throw new Error(`OpenCode service start exited with status ${status}`)
-        child = service
+        child = serverChild
         await waitForWebSocket(
           endpoints.backend,
-          new Promise<number>(() => undefined),
+          serverChild.exited,
           60_000,
         ).catch(async (error) => {
-          const stopped = spawn(
-            serviceName,
-            [...command, "service", "stop"],
-            "service-stop",
-          )
-          await stopped.exited.catch(() => undefined)
+          await terminate(serverChild!)
+          serverChild = undefined
           throw error
         })
         serverStarted = true
@@ -182,14 +176,8 @@ export async function launchInstance(options: LaunchOptions) {
         throw new Error("the script server is not running")
       serverStopping = true
       try {
-        const stopped = spawn(
-          serviceName,
-          [...command, "service", "stop"],
-          "service-stop",
-        )
-        const status = await stopped.exited
-        if (status !== 0)
-          throw new Error(`OpenCode service stop exited with status ${status}`)
+        await terminate(serverChild!)
+        serverChild = undefined
         serverStarted = false
       } finally {
         serverStopping = false
@@ -262,8 +250,8 @@ export async function launchInstance(options: LaunchOptions) {
           await Promise.all([...clients.values()].map(terminate))
           clients.clear()
           if (serverStarted) {
-            const stopped = spawn(serviceName, [...command, "service", "stop"], "service-stop")
-            await stopped.exited.catch(() => undefined)
+            await terminate(serverChild!)
+            serverChild = undefined
             serverStarted = false
             child = undefined
           }
@@ -302,14 +290,7 @@ export async function launchInstance(options: LaunchOptions) {
         if (restarting) await restarting.catch(() => undefined)
         await Promise.all([...clients.values()].map(terminate))
         if (!options.scripted) await terminate(this.child)
-        if (options.scripted && serverStarted) {
-          const stopped = spawn(
-            serviceName,
-            [...command, "service", "stop"],
-            "service-stop",
-          )
-          await stopped.exited.catch(() => undefined)
-        }
+        if (options.scripted && serverStarted) await terminate(serverChild!)
         await stopService(join(artifacts, "home", ".local", "state"))
       })()
       return stopping

--- a/test/cli/integration.test.ts
+++ b/test/cli/integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, realpath, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import {
@@ -497,7 +497,13 @@ describe("opencode-drive", () => {
     expect(await Bun.file(join(artifacts, "seeded-at-launch.txt")).text()).toBe(
       "export const seeded = true\n",
     )
-    expect(await Bun.file(join(artifacts, "child-cwd.txt")).text()).toBe(join(artifacts, "files"))
+    expect(await realpath(await Bun.file(join(artifacts, "child-cwd.txt")).text())).toBe(
+      await realpath(join(artifacts, "files")),
+    )
+    expect(await Bun.file(join(artifacts, "service-argv.json")).json()).toEqual([
+      "serve",
+      "--service",
+    ])
     const pid = Number(await Bun.file(join(artifacts, "child.pid")).text())
     expect(running(pid)).toBe(false)
     expect(await Bun.file(join(root, "registry", `${name}.json`)).exists()).toBe(false)

--- a/test/fixtures/fake-opencode.ts
+++ b/test/fixtures/fake-opencode.ts
@@ -1,45 +1,14 @@
 const serviceMode = process.env.OPENCODE_DRIVE_SCRIPTED === "1"
-const operation = process.argv[2]
-if (
-  serviceMode &&
-  process.argv.at(-2) === "service" &&
-  process.argv.at(-1) === "start"
-) {
-  const service = Bun.spawn([
-    process.execPath,
-    process.argv[1]!,
-    ...process.argv.slice(2, -2),
-    "__service",
-  ], {
-    cwd: process.cwd(),
-    env: process.env,
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "ignore",
-  })
-  service.unref()
-  process.exit(0)
-}
-if (
-  serviceMode &&
-  process.argv.at(-2) === "service" &&
-  process.argv.at(-1) === "stop"
-) {
-  const pid = Number(
-    await Bun.file(`${process.env.OPENCODE_TEST_HOME}/service.pid`)
-      .text()
-      .catch(() => ""),
-  )
-  if (Number.isInteger(pid)) process.kill(pid, "SIGTERM")
-  process.exit(0)
-}
 const role = serviceMode
-  ? process.argv.at(-1) === "__service"
+  ? process.argv.at(-2) === "serve" && process.argv.at(-1) === "--service"
     ? "service"
     : "client"
   : "legacy"
 if (role === "service" && process.env.OPENCODE_TEST_HOME)
-  await Bun.write(`${process.env.OPENCODE_TEST_HOME}/service.pid`, String(process.pid))
+  await Promise.all([
+    Bun.write(`${process.env.OPENCODE_TEST_HOME}/service.pid`, String(process.pid)),
+    Bun.write(`${process.env.OPENCODE_TEST_HOME}/service-argv.json`, JSON.stringify(process.argv.slice(2))),
+  ])
 
 const screen = { value: `Fake OpenCode${role === "client" ? ` ${process.env.OPENCODE_DRIVE}` : ""}` }
 const drive = await resolveDrive()


### PR DESCRIPTION
## Summary

- launch scripted OpenCode servers directly with `serve --service`
- keep Drive ownership of the server process through stop, restart, and cleanup
- preserve the complete `--dev` Bun command, including `--conditions=browser` and the OpenTUI preload

## Problem

Scripted `--dev` runs currently invoke `<dev command> service start`. OpenCode then reconstructs a detached server command from `process.execPath` and `process.argv[1]`, dropping the Bun conditions and preload arguments that Drive added. The detached server exits before registration, and Drive reports `OpenCode service start exited with status 1`.

Launching `<dev command> serve --service` directly avoids the lossy second launch and gives Drive direct lifecycle ownership.

## Testing

- `bun run test` (53 passed)
- exercised a real scripted, recorded run against the current OpenCode V2 development checkout
- verified server kill/relaunch and multiple-client integration coverage

Related future simulation work: #1.