### PR TITLE
feat(tools): add Effect web adapters

### DIFF
--- a/.changeset/quiet-tools-listen.md
+++ b/.changeset/quiet-tools-listen.md
@@ -2,4 +2,4 @@
 "opencode-drive": minor
 ---
 
-Add deterministic shell tool handlers with progress, success, and failure simulation.
+Add deterministic shell, web fetch, and web search handlers with progress, success, failure, and interruption simulation.

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ export default defineScript({
 Only registered tools are replaced. Unhandled tools continue to use OpenCode's
 real implementations. Each `progress` value replaces the visible tool output;
 send accumulated output when earlier lines should remain visible.
+Supported adapters are `shell`, `webfetch`, and `websearch`; each handler
+receives its canonical typed V2 input and maintains an independent call index.
 
 Type-check every new or edited script before running it:
 

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -149,7 +149,8 @@ const tools = (registry: Tool.Registry) => {
 export default OpenCodeDriver.use({ tools }, (driver) => program(driver))
 ```
 
-The same `tools` callback is accepted by `defineScript`.
+The same `tools` callback is accepted by `defineScript`. Supported adapters are
+`shell`, `webfetch`, and `websearch`; unregistered tools remain real.
 Each progress value replaces the visible tool output, so send accumulated text
 when earlier lines should remain visible.
 

--- a/src/tool/controller.ts
+++ b/src/tool/controller.ts
@@ -9,15 +9,32 @@ import {
   Failure,
   ShellInput,
   ShellResult,
+  WebFetchInput,
+  WebFetchResult,
+  WebSearchInput,
+  WebSearchResult,
+  type Registration,
   type Registry,
   type Setup,
   type ShellHandler,
+  type WebFetchHandler,
+  type WebSearchHandler,
 } from "./types.js"
 
+type Result = ShellResult | WebFetchResult | WebSearchResult
 type Event =
-  | { readonly type: "progress"; readonly result: ShellResult }
-  | { readonly type: "success"; readonly result: ShellResult }
+  | { readonly type: "progress"; readonly result: Result }
+  | { readonly type: "success"; readonly result: Result }
   | { readonly type: "failure"; readonly message: string }
+type Definition = {
+  readonly schema: typeof ShellInput | typeof WebFetchInput | typeof WebSearchInput
+  readonly invoke: (
+    input: unknown,
+    index: number,
+    signal: AbortSignal,
+    progress: (result: Result) => Effect.Effect<void>,
+  ) => Effect.Effect<Result, unknown>
+}
 
 const MAX_EVENT_BYTES = 1024 * 1024
 
@@ -38,38 +55,96 @@ export function composeSetup(
 }
 
 export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
-  const handlers = new Map<string, ShellHandler>()
-  const registry: Registry = {
-    handle(name, handler) {
-      if (handlers.has(name)) throw new Error(`tool handler already registered: ${name}`)
-      handlers.set(name, handler)
-    },
+  const definitions = new Map<string, Definition>()
+  const add = (name: string, definition: Definition) => {
+    if (definitions.has(name)) throw new Error(`tool handler already registered: ${name}`)
+    definitions.set(name, definition)
   }
+  function handle(name: "shell", handler: ShellHandler): void
+  function handle(name: "webfetch", handler: WebFetchHandler): void
+  function handle(name: "websearch", handler: WebSearchHandler): void
+  function handle(...registration: Registration) {
+      switch (registration[0]) {
+        case "shell": {
+          const handler = registration[1]
+          add("shell", {
+            schema: ShellInput,
+            invoke: (raw, index, signal, progress) =>
+              Effect.gen(function* () {
+                const input = yield* Schema.decodeUnknownEffect(ShellInput)(raw)
+                const result = yield* handler({
+                  input,
+                  index,
+                  signal,
+                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+                })
+                return yield* Schema.decodeUnknownEffect(ShellResult)(result)
+              }),
+          })
+          return
+        }
+        case "webfetch": {
+          const handler = registration[1]
+          add("webfetch", {
+            schema: WebFetchInput,
+            invoke: (raw, index, signal, progress) =>
+              Effect.gen(function* () {
+                const input = yield* Schema.decodeUnknownEffect(WebFetchInput)(raw)
+                const result = yield* handler({
+                  input,
+                  index,
+                  signal,
+                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+                })
+                return yield* Schema.decodeUnknownEffect(WebFetchResult)(result)
+              }),
+          })
+          return
+        }
+        case "websearch": {
+          const handler = registration[1]
+          add("websearch", {
+            schema: WebSearchInput,
+            invoke: (raw, index, signal, progress) =>
+              Effect.gen(function* () {
+                const input = yield* Schema.decodeUnknownEffect(WebSearchInput)(raw)
+                const result = yield* handler({
+                  input,
+                  index,
+                  signal,
+                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+                })
+                return yield* Schema.decodeUnknownEffect(WebSearchResult)(result)
+              }),
+          })
+        }
+      }
+  }
+  const registry: Registry = { handle }
   setup?.(registry)
-
-  if (handlers.size === 0) {
-    return { configure() {} } satisfies Controller
-  }
+  if (definitions.size === 0) return { configure() {} } satisfies Controller
 
   const token = crypto.randomUUID()
-  let nextIndex = 0
+  const indexes = new Map<string, number>()
   const active = new Set<AbortController>()
   const server = yield* Effect.acquireRelease(
     Effect.sync(() =>
       Bun.serve({
         hostname: "127.0.0.1",
         port: 0,
+        idleTimeout: 255,
         fetch(request) {
           if (request.headers.get("authorization") !== `Bearer ${token}`)
             return new Response("Unauthorized", { status: 401 })
-          const url = new URL(request.url)
-          const name = url.pathname.match(/^\/execute\/([^/]+)$/)?.[1]
-          const handler = name === undefined ? undefined : handlers.get(name)
+          const name = new URL(request.url).pathname.match(/^\/execute\/([^/]+)$/)?.[1]
+          const definition = name === undefined ? undefined : definitions.get(name)
           if (request.method !== "POST" || name === undefined)
             return new Response("Not found", { status: 404 })
-          if (handler === undefined)
+          if (definition === undefined)
             return new Response("Tool handler not registered", { status: 404 })
-          return execute(request, handler, nextIndex++, active)
+          const index = indexes.get(name) ?? 0
+          indexes.set(name, index + 1)
+          return execute(request, definition, index, active)
         },
       }),
     ),
@@ -84,8 +159,11 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
   )
   const endpoint = `http://${server.hostname}:${server.port}`
   const plugin = fileURLToPath(new URL("./plugin.js", import.meta.url))
-  const shellSchema: JsonValue = JSON.parse(
-    JSON.stringify(Schema.toJsonSchemaDocument(ShellInput).schema),
+  const schemas = Object.fromEntries(
+    [...definitions].map(([name, definition]) => [
+      name,
+      JSON.parse(JSON.stringify(Schema.toJsonSchemaDocument(definition.schema).schema)),
+    ]),
   )
 
   return {
@@ -97,14 +175,7 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
         ...(current ?? []),
         {
           package: plugin,
-          options: {
-            endpoint,
-            token,
-            tools: [...handlers.keys()],
-            schemas: {
-              shell: shellSchema,
-            },
-          },
+          options: { endpoint, token, tools: [...definitions.keys()], schemas },
         },
       ] as JsonValue
     },
@@ -113,7 +184,7 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
 
 function execute(
   request: Request,
-  handler: ShellHandler,
+  definition: Definition,
   index: number,
   active: Set<AbortController>,
 ) {
@@ -131,18 +202,8 @@ function execute(
       return Effect.promise(() => writer.write(frame))
     })
   const result = Effect.gen(function* () {
-    const input = yield* Schema.decodeUnknownEffect(ShellInput)(yield* Effect.promise(() => request.json()))
-    const result = yield* handler({
-      input,
-      index,
-      signal,
-      progress: (value) =>
-        send({
-          type: "progress",
-          result: typeof value === "string" ? { output: value } : value,
-        }),
-    })
-    return yield* Schema.decodeUnknownEffect(ShellResult)(result)
+    const input = yield* Effect.promise(() => request.json())
+    return yield* definition.invoke(input, index, signal, (value) => send({ type: "progress", result: value }))
   })
   void writer.closed.catch((cause) => controller.abort(cause))
   void (async () => {

--- a/src/tool/plugin.js
+++ b/src/tool/plugin.js
@@ -1,72 +1,103 @@
+import { Effect, Schema } from "effect"
+
+const MAX_BUFFER_CHARS = 1024 * 1024
+const descriptions = {
+  shell: "Executes a shell command.",
+  webfetch: "Fetch content from an HTTP or HTTPS URL and return it as text, markdown, or HTML.",
+  websearch: "Search the web using the session's local web search provider.",
+}
+
+class ToolFailure extends Schema.TaggedErrorClass()("LLM.ToolFailure", {
+  message: Schema.String,
+}) {}
+
 const output = (result) => ({
-  structured: {
-    exit: result.exit ?? 0,
-    ...(result.shellID === undefined ? {} : { shellID: result.shellID }),
-    truncated: result.truncated ?? false,
-    ...(result.timeout === undefined ? {} : { timeout: result.timeout }),
-  },
+  structured: result,
   content: [{ type: "text", text: result.output }],
 })
 
-const MAX_BUFFER_CHARS = 1024 * 1024
+const failure = (cause) =>
+  cause instanceof ToolFailure
+    ? cause
+    : new ToolFailure({ message: cause instanceof Error ? cause.message : String(cause) })
 
-async function execute(options, name, input, context) {
-  const response = await fetch(`${options.endpoint}/execute/${name}`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${options.token}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(input),
+const parse = (line) =>
+  Effect.try({
+    try: () => JSON.parse(line),
+    catch: (cause) => failure(cause),
   })
-  if (!response.ok || !response.body)
-    throw new Error(`Drive tool handler returned HTTP ${response.status}`)
 
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ""
-  let result
-  let complete = false
-  try {
-    while (true) {
-      const chunk = await reader.read()
-      buffer += decoder.decode(chunk.value, { stream: !chunk.done })
-      if (buffer.length > MAX_BUFFER_CHARS)
-        throw new Error(`Drive tool event exceeds ${MAX_BUFFER_CHARS} characters`)
-      let newline
-      while ((newline = buffer.indexOf("\n")) !== -1) {
-        const line = buffer.slice(0, newline)
-        buffer = buffer.slice(newline + 1)
-        if (!line) continue
-        const event = JSON.parse(line)
-        if (event.type === "progress") await context.progress(output(event.result))
-        if (event.type === "success") result = event.result
-        if (event.type === "failure") throw new Error(event.message)
-      }
-      if (chunk.done) break
-    }
-    if (!result) throw new Error("Drive tool handler ended without a result")
-    complete = true
-    return output(result)
-  } finally {
-    if (!complete) await reader.cancel().catch(() => undefined)
-    reader.releaseLock()
-  }
-}
+const execute = (options, name, input, context) =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(`${options.endpoint}/execute/${name}`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${options.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(input),
+          signal,
+        }),
+      catch: failure,
+    })
+    if (!response.ok || !response.body)
+      return yield* new ToolFailure({ message: `Drive tool handler returned HTTP ${response.status}` })
+
+    const reader = response.body.getReader()
+    return yield* Effect.acquireUseRelease(
+      Effect.succeed(reader),
+      (reader) =>
+        Effect.gen(function* () {
+          const decoder = new TextDecoder()
+          let buffer = ""
+          let result
+          while (true) {
+            const chunk = yield* Effect.tryPromise({
+              try: () => reader.read(),
+              catch: failure,
+            })
+            buffer += decoder.decode(chunk.value, { stream: !chunk.done })
+            if (buffer.length > MAX_BUFFER_CHARS)
+              return yield* new ToolFailure({
+                message: `Drive tool event exceeds ${MAX_BUFFER_CHARS} characters`,
+              })
+            let newline
+            while ((newline = buffer.indexOf("\n")) !== -1) {
+              const line = buffer.slice(0, newline)
+              buffer = buffer.slice(newline + 1)
+              if (!line) continue
+              const event = yield* parse(line)
+              if (event.type === "progress") yield* context.progress(output(event.result))
+              if (event.type === "success") result = event.result
+              if (event.type === "failure")
+                return yield* new ToolFailure({ message: event.message })
+            }
+            if (chunk.done) break
+          }
+          if (!result)
+            return yield* new ToolFailure({ message: "Drive tool handler ended without a result" })
+          return output(result)
+        }),
+      (reader) => Effect.promise(() => reader.cancel().catch(() => undefined)),
+    )
+  })
 
 export default {
   id: "opencode-drive.tool-handlers",
-  async setup(ctx) {
-    const options = ctx.options
-    await ctx.tool.transform((tools) => {
-      if (!options.tools.includes("shell")) return
-      tools.add({
-        name: "shell",
-        description: "Executes a shell command.",
-        jsonSchema: options.schemas.shell,
-        options: { codemode: false },
-        execute: (input, context) => execute(options, "shell", input, context),
-      })
-    })
-  },
+  effect: (ctx) =>
+    ctx.tool.transform((tools) => {
+      for (const name of ctx.options.tools) {
+        tools.addDynamic(
+          name,
+          {
+            description: descriptions[name],
+            jsonSchema: ctx.options.schemas[name],
+            execute: (input, context) => execute(ctx.options, name, input, context),
+          },
+          { codemode: false },
+        )
+      }
+    }),
 }

--- a/src/tool/plugin.js
+++ b/src/tool/plugin.js
@@ -89,7 +89,7 @@ export default {
   effect: (ctx) =>
     ctx.tool.transform((tools) => {
       for (const name of ctx.options.tools) {
-        tools.addDynamic(
+        tools.add(
           name,
           {
             description: descriptions[name],

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -1,13 +1,17 @@
+import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
-import type * as Effect from "effect/Effect"
+
+const PositiveInt = Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0))
 
 export const ShellInput = Schema.Struct({
-  command: Schema.String,
-  workdir: Schema.optional(Schema.String),
+  command: Schema.String.annotate({ description: "Shell command string to execute" }),
+  workdir: Schema.optional(Schema.String).annotate({
+    description: "Working directory. Defaults to the active Location; relative paths resolve from that Location.",
+  }),
   timeout: Schema.optional(
     Schema.Number.check(Schema.isFinite(), Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(600_000)),
-  ),
-  background: Schema.optional(Schema.Boolean),
+  ).annotate({ description: "Optional timeout in milliseconds. Zero means unlimited. May not exceed 600000." }),
+  background: Schema.optional(Schema.Boolean).annotate({ description: "Run the command in the background." }),
 })
 export interface ShellInput extends Schema.Schema.Type<typeof ShellInput> {}
 
@@ -22,25 +26,70 @@ export const ShellResult = Schema.Struct({
 })
 export interface ShellResult extends Schema.Schema.Type<typeof ShellResult> {}
 
+export const WebFetchInput = Schema.Struct({
+  url: Schema.String.annotate({ description: "The HTTP or HTTPS URL to fetch content from" }),
+  format: Schema.Literals(["text", "markdown", "html"])
+    .annotate({ description: "The format to return the content in. Defaults to markdown." })
+    .pipe(Schema.withDecodingDefault(Effect.succeed("markdown" as const))),
+  timeout: Schema.optional(
+    Schema.Number.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(120)),
+  ).annotate({ description: "Optional timeout in seconds (maximum: 120)" }),
+})
+export interface WebFetchInput extends Schema.Schema.Type<typeof WebFetchInput> {}
+
+export const WebFetchResult = Schema.Struct({
+  output: Schema.String,
+  url: Schema.optional(Schema.String),
+  contentType: Schema.optional(Schema.String),
+  format: Schema.optional(Schema.Literals(["text", "markdown", "html"])),
+})
+export interface WebFetchResult extends Schema.Schema.Type<typeof WebFetchResult> {}
+
+export const WebSearchInput = Schema.Struct({
+  query: Schema.String.annotate({ description: "Websearch query" }),
+  numResults: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(20))),
+  livecrawl: Schema.optional(Schema.Literals(["fallback", "preferred"])),
+  type: Schema.optional(Schema.Literals(["auto", "fast", "deep"])),
+  contextMaxCharacters: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(50_000))),
+})
+export interface WebSearchInput extends Schema.Schema.Type<typeof WebSearchInput> {}
+
+export const WebSearchResult = Schema.Struct({
+  output: Schema.String,
+  provider: Schema.optional(Schema.Literals(["exa", "parallel"])),
+})
+export interface WebSearchResult extends Schema.Schema.Type<typeof WebSearchResult> {}
+
 export class Failure extends Schema.TaggedErrorClass<Failure>()(
   "OpenCodeDrive.ToolFailure",
   { message: Schema.String },
 ) {}
 
-export interface ShellContext {
-  readonly input: ShellInput
+export interface Context<Input, Result> {
+  readonly input: Input
   /** Zero-based invocation index for this handler. */
   readonly index: number
   readonly signal: AbortSignal
-  readonly progress: (output: string | ShellResult) => Effect.Effect<void>
+  readonly progress: (output: string | Result) => Effect.Effect<void>
 }
 
-export type ShellHandler = (
-  context: ShellContext,
-) => Effect.Effect<ShellResult, Failure>
+export type Handler<Input, Result> = (
+  context: Context<Input, Result>,
+) => Effect.Effect<Result, Failure>
+
+export type ShellHandler = Handler<ShellInput, ShellResult>
+export type WebFetchHandler = Handler<WebFetchInput, WebFetchResult>
+export type WebSearchHandler = Handler<WebSearchInput, WebSearchResult>
+
+export type Registration =
+  | readonly [name: "shell", handler: ShellHandler]
+  | readonly [name: "webfetch", handler: WebFetchHandler]
+  | readonly [name: "websearch", handler: WebSearchHandler]
 
 export interface Registry {
   handle(name: "shell", handler: ShellHandler): void
+  handle(name: "webfetch", handler: WebFetchHandler): void
+  handle(name: "websearch", handler: WebSearchHandler): void
 }
 
 export type Setup = (tools: Registry) => void

--- a/test/tool/controller.test.ts
+++ b/test/tool/controller.test.ts
@@ -63,3 +63,87 @@ it.effect("does not inject a plugin without handlers", () =>
     }),
   ),
 )
+
+it.effect("routes typed webfetch and websearch handlers independently", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("webfetch", ({ input, index }) =>
+          Effect.succeed({ output: `${index}:${input.format}:${input.url}` }),
+        )
+        tools.handle("websearch", ({ input, index }) =>
+          Effect.succeed({ output: `${index}:${input.query}`, provider: "exa" }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string; tools: string[] }
+      }>)[0]!
+      expect(injected.options.tools).toEqual(["webfetch", "websearch"])
+
+      const invoke = (name: string, input: unknown) =>
+        Effect.promise(async () => {
+          const response = await fetch(`${injected.options.endpoint}/execute/${name}`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${injected.options.token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(input),
+          })
+          return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+        })
+
+      expect(yield* invoke("webfetch", { url: "https://example.com" })).toEqual([
+        {
+          type: "success",
+          result: { output: "0:markdown:https://example.com" },
+        },
+      ])
+      expect(yield* invoke("websearch", { query: "effect typescript" })).toEqual([
+        {
+          type: "success",
+          result: { output: "0:effect typescript", provider: "exa" },
+        },
+      ])
+    }),
+  ),
+)
+
+it.effect("aborts a handler when its transport disconnects", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const started = Promise.withResolvers<void>()
+      const aborted = Promise.withResolvers<void>()
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", ({ signal }) =>
+          Effect.gen(function* () {
+            signal.addEventListener("abort", () => aborted.resolve(), { once: true })
+            started.resolve()
+            return yield* Effect.never
+          }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const request = new AbortController()
+      const response = fetch(`${injected.options.endpoint}/execute/shell`, {
+        method: "POST",
+        signal: request.signal,
+        headers: {
+          authorization: `Bearer ${injected.options.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ command: "wait" }),
+      }).catch(() => undefined)
+      yield* Effect.promise(() => started.promise)
+      request.abort()
+      yield* Effect.promise(() => aborted.promise)
+      yield* Effect.promise(() => response)
+    }),
+  ),
+)


### PR DESCRIPTION
## What

Move Drive's injected tool adapter from the Promise plugin API to the native Effect plugin API, and add deterministic `webfetch` and `websearch` handlers alongside `shell`.

```ts
tools.handle("webfetch", ({ input, index, progress, signal }) =>
  Effect.gen(function* () {
    yield* progress(`Fetching ${input.url}\n`)
    return { output: "Controlled response", format: input.format }
  }),
)
```

Supported adapters now have canonical typed V2 inputs and independent call indexes:

- `shell`
- `webfetch`
- `websearch`

## Before / After

**Before:** Drive used the structural Promise plugin API inherited from the prototype. That made registration easy, but Promise execution did not carry Effect interruption through fetch and reader cleanup.

**After:** Drive ships an Effect plugin. Fetch uses Effect's cancellation signal, stream readers are scope-released, expected failures use the `LLM.ToolFailure` channel, and transport disconnect immediately aborts the Drive handler's exposed signal.

## How

- Registers a raw JSON structural tool declaration through the ordinary Effect `draft.add` API from anomalyco/opencode#37202.
- Generalizes the controller registry over shell, fetch, and search definitions while retaining typed public overloads.
- Generates each model-visible JSON Schema from its Effect schema.
- Keeps per-tool invocation indexes independent.
- Uses canonical V2 input fields, defaults, enums, and bounds.
- Maps progress and terminal results through the same authenticated, backpressured transport.
- Raises the loopback server idle timeout so intentionally slow simulated effects can remain active.

## Scope

Background shell jobs are intentionally excluded. They require retained job state, `shellID`, output/status observation, and completion notifications rather than an atomic tool settlement.

This PR depends on anomalyco/opencode#37202.

## Testing

- `bun run check`
- `bun run test` (115 Effect tests and 45 CLI integration tests)
- `bun pm pack --dry-run`
- Real V2 run against the OpenCode dependency branch with all three adapters in one model sequence
- Re-ran the sequence against anomalyco/opencode#37202 using ordinary structural registration
- Verified no real shell command, HTTP fetch, or web search executed
- Transport cancellation test verifies disconnect aborts the handler signal

## Demo

The shell command, invalid fetch URL, and impossible search query all return controlled Drive-side results.

![Effect tool adapters](https://github.com/user-attachments/assets/48ef726d-dc69-420b-a560-715b0a9a9d6a)
