### PR TITLE
feat(tools): simulate background shells

### DIFF
--- a/.changeset/bright-shells-wait.md
+++ b/.changeset/bright-shells-wait.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": minor
+---
+
+Return simulated background shells immediately, continue their handlers asynchronously, notify the session when they finish, and cancel them when Drive shuts down.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ real implementations. Each `progress` value replaces the visible tool output;
 send accumulated output when earlier lines should remain visible.
 Supported adapters are `shell`, `webfetch`, and `websearch`; each handler
 receives its canonical typed V2 input and maintains an independent call index.
+When a shell call sets `background: true`, Drive returns immediately with the
+OpenCode tool call ID as `shellID`, keeps the handler running, and injects the
+terminal `completed`, `error`, or `cancelled` result into the session
+automatically. Background handlers are cancelled when Drive shuts down.
 
 Type-check every new or edited script before running it:
 

--- a/src/tool/controller.ts
+++ b/src/tool/controller.ts
@@ -26,6 +26,17 @@ type Event =
   | { readonly type: "progress"; readonly result: Result }
   | { readonly type: "success"; readonly result: Result }
   | { readonly type: "failure"; readonly message: string }
+type BackgroundCompletion = {
+  readonly shellID: string
+  readonly command: string
+  readonly state: "completed" | "error" | "cancelled"
+  readonly output: string
+}
+type BackgroundJob = {
+  readonly input: string
+  readonly completion: Promise<BackgroundCompletion>
+  readonly cancel: () => void
+}
 type Definition = {
   readonly schema: typeof ShellInput | typeof WebFetchInput | typeof WebSearchInput
   readonly invoke: (
@@ -37,6 +48,13 @@ type Definition = {
 }
 
 const MAX_EVENT_BYTES = 1024 * 1024
+const ExecutionRequest = Schema.Struct({
+  input: Schema.Unknown,
+  context: Schema.Struct({
+    callID: Schema.String,
+  }),
+})
+const encoder = new TextEncoder()
 
 export interface Controller {
   readonly configure: (config: OpenCodeConfig) => void
@@ -127,6 +145,8 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
   const token = crypto.randomUUID()
   const indexes = new Map<string, number>()
   const active = new Set<AbortController>()
+  const background = new Map<string, BackgroundJob>()
+  let closing = false
   const server = yield* Effect.acquireRelease(
     Effect.sync(() =>
       Bun.serve({
@@ -136,24 +156,39 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
         fetch(request) {
           if (request.headers.get("authorization") !== `Bearer ${token}`)
             return new Response("Unauthorized", { status: 401 })
-          const name = new URL(request.url).pathname.match(/^\/execute\/([^/]+)$/)?.[1]
+          if (closing && request.method === "POST")
+            return new Response("Tool controller is stopping", { status: 503 })
+          const pathname = new URL(request.url).pathname
+          const shellID = pathname.match(/^\/background\/([^/]+)$/)?.[1]
+          if (request.method === "GET" && shellID !== undefined) {
+            const job = background.get(shellID)
+            if (job === undefined) return new Response("Background shell not found", { status: 404 })
+            server.timeout(request, 0)
+            return job.completion.then((completion) => Response.json(completion))
+          }
+          if (request.method === "DELETE" && shellID !== undefined) {
+            background.delete(shellID)
+            return new Response(null, { status: 204 })
+          }
+          const name = pathname.match(/^\/execute\/([^/]+)$/)?.[1]
           const definition = name === undefined ? undefined : definitions.get(name)
           if (request.method !== "POST" || name === undefined)
             return new Response("Not found", { status: 404 })
           if (definition === undefined)
             return new Response("Tool handler not registered", { status: 404 })
-          const index = indexes.get(name) ?? 0
-          indexes.set(name, index + 1)
-          return execute(request, definition, index, active)
+          return execute(request, name, definition, indexes, active, background)
         },
       }),
     ),
     (server) =>
       Effect.gen(function* () {
+        closing = true
         yield* Effect.sync(() => {
           for (const controller of active)
             controller.abort(new Error("Drive tool controller stopped"))
         })
+        yield* Effect.promise(() => Promise.allSettled([...background.values()].map((job) => job.completion)))
+        background.clear()
         yield* Effect.promise(() => server.stop(true))
       }),
   )
@@ -184,11 +219,12 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
 
 function execute(
   request: Request,
+  name: string,
   definition: Definition,
-  index: number,
+  indexes: Map<string, number>,
   active: Set<AbortController>,
+  background: Map<string, BackgroundJob>,
 ) {
-  const encoder = new TextEncoder()
   const transport = new TransformStream<Uint8Array, Uint8Array>()
   const writer = transport.writable.getWriter()
   const controller = new AbortController()
@@ -196,13 +232,38 @@ function execute(
   active.add(controller)
   const send = (event: Event) =>
     Effect.suspend(() => {
-      const frame = encoder.encode(`${JSON.stringify(event)}\n`)
-      if (frame.byteLength > MAX_EVENT_BYTES)
-        return Effect.die(new Error(`Drive tool event exceeds ${MAX_EVENT_BYTES} bytes`))
+      const frame = encodeEvent(event)
       return Effect.promise(() => writer.write(frame))
     })
+  let launched: BackgroundJob | undefined
   const result = Effect.gen(function* () {
-    const input = yield* Effect.promise(() => request.json())
+    const body = yield* Schema.decodeUnknownEffect(ExecutionRequest)(yield* Effect.promise(() => request.json()))
+    const input = body.input
+    if (name === "shell" && isBackgroundShell(input)) {
+      const shellID = body.context.callID
+      if (shellID.length === 0) return yield* Effect.die(new Error("Background shell requires a tool call ID"))
+      const key = JSON.stringify(input)
+      const existing = background.get(shellID)
+      if (existing !== undefined) {
+        if (existing.input !== key)
+          return yield* Effect.die(new Error(`Background shell ID reused with different input: ${shellID}`))
+        return {
+          output: "The command was moved to the background.",
+          shellID,
+          status: "running" as const,
+        }
+      }
+      const index = nextIndex(indexes, name)
+      const job = startBackgroundShell(definition, input, index, shellID, key, active)
+      background.set(shellID, job)
+      launched = job
+      return {
+        output: "The command was moved to the background.",
+        shellID,
+        status: "running" as const,
+      }
+    }
+    const index = nextIndex(indexes, name)
     return yield* definition.invoke(input, index, signal, (value) => send({ type: "progress", result: value }))
   })
   void writer.closed.catch((cause) => controller.abort(cause))
@@ -212,22 +273,17 @@ function execute(
       if (Exit.isSuccess(exit))
         await Effect.runPromise(send({ type: "success", result: exit.value }), { signal })
       else {
-        const failure = Cause.findErrorOption(exit.cause)
-        const error = Option.isSome(failure) ? failure.value : Cause.squash(exit.cause)
         await Effect.runPromise(
           send({
             type: "failure",
-            message: error instanceof Failure
-              ? error.message
-              : error instanceof Error
-                ? error.message
-                : String(error),
+            message: causeMessage(exit.cause),
           }),
           { signal },
         )
       }
       await writer.close()
     } catch (cause) {
+      if (launched !== undefined) launched.cancel()
       await writer.abort(cause).catch(() => undefined)
     } finally {
       active.delete(controller)
@@ -236,4 +292,96 @@ function execute(
   return new Response(transport.readable, {
     headers: { "content-type": "application/x-ndjson" },
   })
+}
+
+function isBackgroundShell(input: unknown): input is { readonly command: string; readonly background: true } {
+  return typeof input === "object" && input !== null && "background" in input && input.background === true &&
+    "command" in input && typeof input.command === "string"
+}
+
+function startBackgroundShell(
+  definition: Definition,
+  input: { readonly command: string; readonly background: true },
+  index: number,
+  shellID: string,
+  inputKey: string,
+  active: Set<AbortController>,
+): BackgroundJob {
+  const controller = new AbortController()
+  active.add(controller)
+  let output = ""
+  const result = definition.invoke(input, index, controller.signal, (value) =>
+    Effect.sync(() => {
+      encodeEvent({ type: "progress", result: value })
+      output = value.output
+    }))
+  const completion = Effect.runPromise(Effect.exit(result), { signal: controller.signal })
+    .then((exit): BackgroundCompletion => {
+      if (Exit.isSuccess(exit)) {
+        encodeEvent({ type: "success", result: exit.value })
+        return { shellID, command: input.command, state: "completed", output: exit.value.output }
+      }
+      if (controller.signal.aborted)
+        return { shellID, command: input.command, state: "cancelled", output: output || "Command cancelled" }
+      const message = causeMessage(exit.cause)
+      return {
+        shellID,
+        command: input.command,
+        state: "error",
+        output: errorOutput(output, message),
+      }
+    })
+    .catch((cause): BackgroundCompletion => ({
+      shellID,
+      command: input.command,
+      state: controller.signal.aborted ? "cancelled" : "error",
+      output: errorOutput(output, cause instanceof Error ? cause.message : String(cause)),
+    }))
+    .finally(() => active.delete(controller))
+  return {
+    input: inputKey,
+    completion,
+    cancel: () => controller.abort(new Error("Background shell launch disconnected")),
+  }
+}
+
+function nextIndex(indexes: Map<string, number>, name: string): number {
+  const index = indexes.get(name) ?? 0
+  indexes.set(name, index + 1)
+  return index
+}
+
+function encodeEvent(event: Event): Uint8Array {
+  const frame = encoder.encode(`${JSON.stringify(event)}\n`)
+  if (frame.byteLength > MAX_EVENT_BYTES)
+    throw new Error(`Drive tool event exceeds ${MAX_EVENT_BYTES} bytes`)
+  return frame
+}
+
+function boundedOutput(output: string): string {
+  const bytes = Buffer.from(output)
+  return bytes.byteLength <= MAX_EVENT_BYTES
+    ? output
+    : bytes.subarray(0, MAX_EVENT_BYTES).toString("utf8")
+}
+
+function errorOutput(output: string, message: string): string {
+  if (!output) return boundedOutput(message)
+  const suffix = `\n${message}`
+  const suffixBytes = Buffer.from(suffix)
+  if (suffixBytes.byteLength >= MAX_EVENT_BYTES) return boundedOutput(message)
+  const prefix = Buffer.from(output.replace(/\n$/, ""))
+    .subarray(0, MAX_EVENT_BYTES - suffixBytes.byteLength)
+    .toString("utf8")
+  return `${prefix}${suffix}`
+}
+
+function causeMessage(cause: Cause.Cause<unknown>): string {
+  const failure = Cause.findErrorOption(cause)
+  const error = Option.isSome(failure) ? failure.value : Cause.squash(cause)
+  return error instanceof Failure
+    ? error.message
+    : error instanceof Error
+      ? error.message
+      : String(error)
 }

--- a/src/tool/plugin.js
+++ b/src/tool/plugin.js
@@ -1,6 +1,8 @@
-import { Effect, Schema } from "effect"
+import { Effect, Schedule, Schema, Scope } from "effect"
 
 const MAX_BUFFER_CHARS = 1024 * 1024
+const BACKGROUND_INSTRUCTION =
+  "You will be notified automatically when the command finishes. DO NOT sleep, poll, or proactively check on its progress."
 const descriptions = {
   shell: "Executes a shell command.",
   webfetch: "Fetch content from an HTTP or HTTPS URL and return it as text, markdown, or HTML.",
@@ -13,7 +15,10 @@ class ToolFailure extends Schema.TaggedErrorClass()("LLM.ToolFailure", {
 
 const output = (result) => ({
   structured: result,
-  content: [{ type: "text", text: result.output }],
+  content: [
+    { type: "text", text: result.output },
+    ...(result.status === "running" ? [{ type: "text", text: BACKGROUND_INSTRUCTION }] : []),
+  ],
 })
 
 const failure = (cause) =>
@@ -27,7 +32,55 @@ const parse = (line) =>
     catch: (cause) => failure(cause),
   })
 
-const execute = (options, name, input, context) =>
+const waitForBackground = (options, shellID) =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(`${options.endpoint}/background/${shellID}`, {
+          headers: { authorization: `Bearer ${options.token}` },
+          signal,
+        }),
+      catch: failure,
+    })
+    if (!response.ok)
+      return yield* new ToolFailure({ message: `Drive background shell returned HTTP ${response.status}` })
+    return yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: failure,
+    })
+  })
+
+const notifyWhenDone = (ctx, options, sessionID, shellID) =>
+  Effect.gen(function* () {
+    const completion = yield* waitForBackground(options, shellID).pipe(
+      Effect.retry({ times: 3, schedule: Schedule.spaced("100 millis") }),
+    )
+    yield* ctx.session
+      .synthetic({
+        id: `msg_${shellID}_completion`,
+        sessionID,
+        text: `<shell id="${shellID}" state="${completion.state}" command="${completion.command}">\n${completion.output}\n</shell>`,
+        description: completion.command,
+        metadata: { source: "shell", state: completion.state },
+      })
+      .pipe(Effect.retry({ times: 3, schedule: Schedule.spaced("100 millis") }))
+    yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(`${options.endpoint}/background/${shellID}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${options.token}` },
+          signal,
+        }).then((response) => {
+          if (!response.ok)
+            throw new Error(`Drive background shell acknowledgement returned HTTP ${response.status}`)
+        }),
+      catch: failure,
+    }).pipe(Effect.retry({ times: 3, schedule: Schedule.spaced("100 millis") }))
+  }).pipe(
+    Effect.catch((cause) => Effect.logError("Drive background shell notification failed", cause)),
+  )
+
+const execute = (ctx, scope, options, name, input, context) =>
   Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
       try: (signal) =>
@@ -37,7 +90,10 @@ const execute = (options, name, input, context) =>
             authorization: `Bearer ${options.token}`,
             "content-type": "application/json",
           },
-          body: JSON.stringify(input),
+          body: JSON.stringify({
+            input,
+            context: { callID: context.callID },
+          }),
           signal,
         }),
       catch: failure,
@@ -78,6 +134,10 @@ const execute = (options, name, input, context) =>
           }
           if (!result)
             return yield* new ToolFailure({ message: "Drive tool handler ended without a result" })
+          if (name === "shell" && result.status === "running" && result.shellID)
+            yield* notifyWhenDone(ctx, options, context.sessionID, result.shellID).pipe(
+              Effect.forkIn(scope, { startImmediately: true }),
+            )
           return output(result)
         }),
       (reader) => Effect.promise(() => reader.cancel().catch(() => undefined)),
@@ -87,17 +147,20 @@ const execute = (options, name, input, context) =>
 export default {
   id: "opencode-drive.tool-handlers",
   effect: (ctx) =>
-    ctx.tool.transform((tools) => {
-      for (const name of ctx.options.tools) {
-        tools.add(
-          name,
-          {
-            description: descriptions[name],
-            jsonSchema: ctx.options.schemas[name],
-            execute: (input, context) => execute(ctx.options, name, input, context),
-          },
-          { codemode: false },
-        )
-      }
+    Effect.gen(function* () {
+      const scope = yield* Scope.Scope
+      yield* ctx.tool.transform((tools) => {
+        for (const name of ctx.options.tools) {
+          tools.add(
+            name,
+            {
+              description: descriptions[name],
+              jsonSchema: ctx.options.schemas[name],
+              execute: (input, context) => execute(ctx, scope, ctx.options, name, input, context),
+            },
+            { codemode: false },
+          )
+        }
+      })
     }),
 }

--- a/test/tool/controller.test.ts
+++ b/test/tool/controller.test.ts
@@ -1,8 +1,21 @@
 import { expect, it } from "@effect/vitest"
 import { Effect } from "effect"
+import * as Exit from "effect/Exit"
+import * as Scope from "effect/Scope"
 import * as ToolController from "../../src/tool/controller.js"
 import { Failure } from "../../src/tool/index.js"
+import plugin from "../../src/tool/plugin.js"
 import type { OpenCodeConfig } from "../../src/script/types.js"
+
+interface RegisteredTool {
+  readonly execute: (
+    input: unknown,
+    context: { readonly sessionID: string; readonly callID: string },
+  ) => Effect.Effect<{
+    readonly structured: unknown
+    readonly content: ReadonlyArray<{ readonly type: string; readonly text: string }>
+  }, unknown>
+}
 
 it.effect("streams progress before shell success and failure", () =>
   Effect.scoped(
@@ -36,7 +49,10 @@ it.effect("streams progress before shell success and failure", () =>
               authorization: `Bearer ${injected.options.token}`,
               "content-type": "application/json",
             },
-            body: JSON.stringify({ command }),
+            body: JSON.stringify({
+              input: { command },
+              context: { callID: `call_${command}` },
+            }),
           })
           return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
         })
@@ -90,7 +106,10 @@ it.effect("routes typed webfetch and websearch handlers independently", () =>
               authorization: `Bearer ${injected.options.token}`,
               "content-type": "application/json",
             },
-            body: JSON.stringify(input),
+            body: JSON.stringify({
+              input,
+              context: { callID: `call_${name}` },
+            }),
           })
           return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
         })
@@ -109,6 +128,256 @@ it.effect("routes typed webfetch and websearch handlers independently", () =>
       ])
     }),
   ),
+)
+
+it.effect("settles background shells immediately and retains their completion", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const release = Promise.withResolvers<void>()
+      let aborted = false
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", ({ input, signal, progress }) =>
+          Effect.gen(function* () {
+            signal.addEventListener("abort", () => (aborted = true), { once: true })
+            yield* progress("still running\n")
+            yield* Effect.promise(() => release.promise)
+            return { output: `${input.command} complete\n`, exit: 0 }
+          }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const headers = {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      }
+      const started = yield* Effect.promise(async () => {
+        const response = await fetch(`${injected.options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            input: { command: "compile", background: true },
+            context: { callID: "call_background" },
+          }),
+        })
+        return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+      })
+      expect(started).toEqual([
+        {
+          type: "success",
+          result: {
+            output: "The command was moved to the background.",
+            shellID: "call_background",
+            status: "running",
+          },
+        },
+      ])
+      expect(aborted).toBe(false)
+
+      const completion = fetch(`${injected.options.endpoint}/background/call_background`, { headers })
+        .then((response) => response.json())
+      release.resolve()
+      expect(yield* Effect.promise(() => completion)).toEqual({
+        shellID: "call_background",
+        command: "compile",
+        state: "completed",
+        output: "compile complete\n",
+      })
+    }),
+  ),
+)
+
+it.effect("reports background failures with retained progress output", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", ({ progress }) =>
+          Effect.gen(function* () {
+            yield* progress("partial output\n")
+            return yield* new Failure({ message: "controlled background failure" })
+          }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const headers = {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      }
+      yield* Effect.promise(() =>
+        fetch(`${injected.options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            input: { command: "fail", background: true },
+            context: { callID: "call_failure" },
+          }),
+        }).then((response) => response.text()),
+      )
+      const completion = yield* Effect.promise(() =>
+        fetch(`${injected.options.endpoint}/background/call_failure`, { headers }).then((response) => response.json()),
+      )
+      expect(completion).toEqual({
+        shellID: "call_failure",
+        command: "fail",
+        state: "error",
+        output: "partial output\ncontrolled background failure",
+      })
+    }),
+  ),
+)
+
+it.effect("bounds retained background output", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", ({ progress }) =>
+          Effect.gen(function* () {
+            yield* progress("x".repeat(1024 * 1024))
+            return { output: "unreachable" }
+          }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const headers = {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      }
+      yield* Effect.promise(() =>
+        fetch(`${injected.options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            input: { command: "verbose", background: true },
+            context: { callID: "call_verbose" },
+          }),
+        }).then((response) => response.text()),
+      )
+      const completion = yield* Effect.promise(() =>
+        fetch(`${injected.options.endpoint}/background/call_verbose`, { headers }).then((response) => response.json()),
+      )
+      expect(completion).toEqual({
+        shellID: "call_verbose",
+        command: "verbose",
+        state: "error",
+        output: "Drive tool event exceeds 1048576 bytes",
+      })
+    }),
+  ),
+)
+
+it.effect("notifies OpenCode when a registered background shell completes", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const release = Promise.withResolvers<void>()
+      const notified = Promise.withResolvers<unknown>()
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", () =>
+          Effect.gen(function* () {
+            yield* Effect.promise(() => release.promise)
+            return { output: "plugin completion\n", exit: 0 }
+          }),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const options = (config.plugins as Array<{ options: unknown }>)[0]!.options
+      let shell: RegisteredTool | undefined
+      yield* plugin.effect({
+        options,
+        tool: {
+          transform: (register: (tools: { add: (name: string, tool: RegisteredTool) => void }) => void) =>
+            Effect.sync(() =>
+              register({
+                add: (name, tool) => {
+                  if (name === "shell") shell = tool
+                },
+              }),
+            ),
+        },
+        session: {
+          synthetic: (input: unknown) => Effect.sync(() => notified.resolve(input)),
+        },
+      })
+      if (shell === undefined) return yield* Effect.die(new Error("shell tool was not registered"))
+
+      const started = yield* shell.execute(
+        { command: "plugin", background: true },
+        { sessionID: "ses_plugin", callID: "call_plugin" },
+      )
+      expect(started).toEqual({
+        structured: {
+          output: "The command was moved to the background.",
+          shellID: "call_plugin",
+          status: "running",
+        },
+        content: [
+          { type: "text", text: "The command was moved to the background." },
+          {
+            type: "text",
+            text: "You will be notified automatically when the command finishes. DO NOT sleep, poll, or proactively check on its progress.",
+          },
+        ],
+      })
+
+      release.resolve()
+      expect(yield* Effect.promise(() => notified.promise)).toEqual({
+        id: "msg_call_plugin_completion",
+        sessionID: "ses_plugin",
+        text: '<shell id="call_plugin" state="completed" command="plugin">\nplugin completion\n\n</shell>',
+        description: "plugin",
+        metadata: { source: "shell", state: "completed" },
+      })
+    }),
+  ),
+)
+
+it.effect("cancels retained background shells when the controller stops", () =>
+  Effect.gen(function* () {
+    const started = Promise.withResolvers<void>()
+    const aborted = Promise.withResolvers<void>()
+    const scope = yield* Scope.make()
+    const controller = yield* ToolController.make((tools) => {
+      tools.handle("shell", ({ signal }) =>
+        Effect.gen(function* () {
+          signal.addEventListener("abort", () => aborted.resolve(), { once: true })
+          started.resolve()
+          return yield* Effect.never
+        }),
+      )
+    }).pipe(Scope.provide(scope))
+    const config: OpenCodeConfig = {}
+    controller.configure(config)
+    const injected = (config.plugins as Array<{
+      options: { endpoint: string; token: string }
+    }>)[0]!
+    yield* Effect.promise(() =>
+      fetch(`${injected.options.endpoint}/execute/shell`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${injected.options.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          input: { command: "wait", background: true },
+          context: { callID: "call_shutdown" },
+        }),
+      }).then((response) => response.text()),
+    )
+    yield* Effect.promise(() => started.promise)
+    yield* Scope.close(scope, Exit.void)
+    yield* Effect.promise(() => aborted.promise)
+  }),
 )
 
 it.effect("aborts a handler when its transport disconnects", () =>
@@ -138,7 +407,10 @@ it.effect("aborts a handler when its transport disconnects", () =>
           authorization: `Bearer ${injected.options.token}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ command: "wait" }),
+        body: JSON.stringify({
+          input: { command: "wait" },
+          context: { callID: "call_disconnect" },
+        }),
       }).catch(() => undefined)
       yield* Effect.promise(() => started.promise)
       request.abort()


### PR DESCRIPTION
**What**
Simulated `shell` handlers now support canonical OpenCode background execution. A call with `background: true` settles immediately with the OpenCode call ID as `shellID`, continues in Drive, and automatically delivers its terminal completion back to the session without polling.

**How**
- Retain background handlers independently from the launch transport and cancel them on Drive shutdown.
- Expose an authenticated completion wait with no idle timeout and explicit post-notification acknowledgement.
- Bound retained output to the existing 1 MiB event limit and preserve failure reasons after progress output.
- Make launch and synthetic delivery retries idempotent by call ID and deterministic message ID.
- Fork completion watchers into the plugin activation scope and call `ctx.session.synthetic` with canonical `<shell ...>` input.
- Add a minor Changeset and document background behavior.

**Scope**
Only simulated `shell` handlers gain background lifecycle behavior. Foreground shell, web fetch, and web search execution retain their existing behavior.

**Testing**
- `bun run test`: 120 Effect tests and 45 CLI integration tests
- `bun run check`: lint and typecheck
- `bun pm pack --dry-run`
- Real isolated OpenCode V2 run against the merged synthetic-session plugin API: verified immediate shell settlement, a model turn while the handler remained blocked, synthetic completion admission, and the completion-triggered model turn

**Flow**
```mermaid
sequenceDiagram
  participant Model
  participant Plugin as Drive plugin
  participant Controller as Drive controller
  participant Session as OpenCode session
  Model->>Plugin: shell(background=true)
  Plugin->>Controller: execute(input, callID)
  Controller-->>Plugin: running(shellID=callID)
  Plugin-->>Model: moved to background
  Controller->>Controller: retain handler until terminal state
  Plugin->>Controller: wait for completion
  Controller-->>Plugin: completed/error/cancelled
  Plugin->>Session: synthetic(<shell ...>)
  Plugin->>Controller: acknowledge completion
```