### PR TITLE
fix(recording): render background completion arrow

### DIFF
--- a/.changeset/fix-background-arrow.md
+++ b/.changeset/fix-background-arrow.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Render the background completion arrow correctly in exported recordings.

--- a/src/recording/render.ts
+++ b/src/recording/render.ts
@@ -61,12 +61,20 @@ function baselineOffset(context: Measurable, font: string) {
   return offset
 }
 
-function drawBlockElement(context: SKRSContext2D, char: string, x: number, y: number) {
+function drawFixedGlyph(context: SKRSContext2D, char: string, x: number, y: number) {
   if (char === "█") context.fillRect(x, y, CellWidth, CellHeight)
   else if (char === "▀") context.fillRect(x, y, CellWidth, CellHeight / 2)
   else if (char === "▄") context.fillRect(x, y + CellHeight / 2, CellWidth, CellHeight / 2)
   else if (char === "■") context.fillRect(x + 1, y + 6, 8, 8)
   else if (char === "⬝") context.fillRect(x + 4, y + 9, 2, 2)
+  else if (char === "↳") {
+    context.fillRect(x + 1, y + 4, 1, 10)
+    context.fillRect(x + 1, y + 13, 8, 1)
+    context.fillRect(x + 6, y + 11, 1, 1)
+    context.fillRect(x + 7, y + 12, 1, 1)
+    context.fillRect(x + 7, y + 14, 1, 1)
+    context.fillRect(x + 6, y + 15, 1, 1)
+  }
   else return false
   return true
 }
@@ -121,7 +129,7 @@ export function renderFrame(frame: CapturedFrame, options: RenderFrameOptions = 
       for (const char of span.text) {
         const cells = Math.min(Math.max(1, Bun.stringWidth(char)), remaining)
         const x = column * CellWidth
-        if (!drawBlockElement(context, char, x, y))
+        if (!drawFixedGlyph(context, char, x, y))
           context.fillText(
             char,
             x + (cells * CellWidth) / 2,

--- a/test/recording/export.test.ts
+++ b/test/recording/export.test.ts
@@ -204,6 +204,29 @@ test("renders distinct fallback glyphs centered in their cells", async () => {
   expect(new Set(masks).size).toBe(symbols.length)
 })
 
+test("renders the background completion arrow at fixed cell coordinates", async () => {
+  const image = await loadImage(
+    renderFrame({
+      cols: 1,
+      rows: 1,
+      cursor: { row: 0, col: 0, visible: false },
+      lines: [{ spans: [{ text: "↳", width: 1, fg: 0x12abef, bg: 0x010203, attributes: 0 }] }],
+    }),
+  )
+  const canvas = createCanvas(10, 20)
+  const context = canvas.getContext("2d")
+  context.drawImage(image, 0, 0)
+  const pixels = context.getImageData(0, 0, 10, 20).data
+  const ink = Array.from({ length: 200 }, (_, index) => index).filter((index) => {
+    const offset = index * 4
+    return pixels[offset] === 0x12 && pixels[offset + 1] === 0xab && pixels[offset + 2] === 0xef
+  })
+
+  expect(ink).toEqual([
+    41, 51, 61, 71, 81, 91, 101, 111, 116, 121, 127, 131, 132, 133, 134, 135, 136, 137, 138, 147, 156,
+  ])
+})
+
 test("renders the Kit loader block and dots at fixed cell sizes", async () => {
   const glyphs = [..."■⬝"]
   const image = await loadImage(


### PR DESCRIPTION
### What

Render OpenCode’s intended `↳` background-completion icon correctly in exported Drive recordings instead of showing a missing-glyph box.

### Before / After

**Before:** Commit Mono does not contain U+21B3, and the canvas font fallback produced `.notdef`. Background shell and subagent completion notices appeared as a boxed placeholder in exported MP4s.

![Before: missing-glyph box](https://github.com/user-attachments/assets/876f0c1d-093f-490d-b393-9453df48a9b2)

**After:** The recording renderer draws `↳` deterministically on the existing 10×20 terminal cell grid, preserving the intended icon independently of host font fallback.

![After: background completion arrow](https://github.com/user-attachments/assets/4d884da5-3fb1-4d91-8f68-d3f65ba06300)

### How

- `src/recording/render.ts` extends the fixed-glyph renderer already used for block and loader symbols.
- `test/recording/export.test.ts` pins the arrow’s exact foreground pixel coordinates.
- A patch changeset records the user-visible recording fix.

### Scope

This changes exported Drive recordings only. It does not replace OpenCode’s icon or alter OpenCode’s live TUI rendering.

### Testing

- `bun run --bun vitest run test/recording/export.test.ts` (12 pass)
- `bun run typecheck`
- `bun run lint` (0 warnings, 0 errors)
- `bun run test` (121 Effect/unit tests and 45 CLI integration tests)
- Real isolated OpenCode dev run with a simulated model and background shell; the script asserted `↳ Shell finished` before export
- Required simplify review completed with no remaining findings

### Demo

The simulated model launches a real background shell. The exported recording shows the corrected `↳ Shell finished` notice after asynchronous completion.

https://github.com/user-attachments/assets/1396ea6d-7bd8-4452-ab09-d17b6524e128