### PR TITLE
feat(scripts)!: make the API Effect-only

### DIFF
--- a/.changeset/effect-only-scripts.md
+++ b/.changeset/effect-only-scripts.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": major
+---
+
+Make the script API Effect-only. Script setup and run callbacks, UI, LLM, filesystem, server, and client operations now return Effects; LLM serve handlers return Streams; and script cancellation uses Effect interruption without a Promise compatibility shim.

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ export default Effect.scoped(
 )
 ```
 
-Use `opencode-drive check ./legacy-script.ts` and `start --script` for the
-Promise `defineScript` adapter described below.
+Use `opencode-drive check ./drive.ts` and `start --script` for the Effect-native
+`defineScript` workflow described below.
 
 ## OpenCode development
 
@@ -213,11 +213,13 @@ While developing, you can run `opencode-drive restart` to restart only the UI (t
 
 View the [skills file](https://github.com/anomalyco/opencode-drive/blob/main/skills/opencode-drive/SKILL.md) for more details about the CLI.
 
-## Promise script API
+## Effect script API
 
-Scripted runs use one fully typed definition:
+Scripted runs use one fully typed, Effect-only definition. `setup` and `run`
+return Effects; Promise callbacks are not part of the API:
 
 ```ts
+import { Effect } from "effect"
 import { defineScript } from "opencode-drive"
 
 export default defineScript({
@@ -233,15 +235,17 @@ export default defineScript({
       "src/example.ts": "export const value = 1\n",
     },
   },
-  setup({ config, tui }) {
-    config.username = "Drive"
-    tui.scroll_speed = 1
-  },
-  async run({ ui, llm }) {
-    await ui.submit("Read src/example.ts")
-    await llm.send(llm.text("The value is 1."))
-    await ui.waitFor("The value is 1.")
-  },
+  setup: ({ config, tui }) =>
+    Effect.sync(() => {
+      config.username = "Drive"
+      tui.scroll_speed = 1
+    }),
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* ui.submit("Read src/example.ts")
+      yield* llm.send(llm.text("The value is 1."))
+      yield* ui.waitFor("The value is 1.")
+    }),
 })
 ```
 
@@ -272,20 +276,25 @@ export default defineScript({
       }),
     )
   },
-  async run({ ui, llm }) {
-    llm.queue(
-      llm.toolCall({
-        index: 0,
-        id: "call_shell",
-        name: "shell",
-        input: { command: "deploy production" },
-      }),
-      llm.finish("tool-calls"),
-    )
-    await ui.submit("Deploy production")
-  },
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.queue(
+        llm.toolCall({
+          index: 0,
+          id: "call_shell",
+          name: "shell",
+          input: { command: "deploy production" },
+        }),
+        llm.finish("tool-calls"),
+      )
+      yield* ui.submit("Deploy production")
+    }),
 })
 ```
+
+Tool handlers also receive the OpenCode transport's `AbortSignal`; their
+Effects are interrupted when it aborts. Script lifecycle cancellation itself
+uses Effect interruption and does not expose a separate signal.
 
 Only registered tools are replaced. Unhandled tools continue to use OpenCode's
 real implementations. Each `progress` value replaces the visible tool output;
@@ -307,37 +316,42 @@ Drive temporarily exposes its script API and `tsgo` beside the script while
 checking, then removes only the links it created. `wait(milliseconds)` is
 available for unconditional delays.
 
-Set `launch: "manual"` to launch the shared OpenCode server and every TUI
-explicitly:
+The `fs`, `ui`, `llm`, `server`, and `clients` capabilities expose
+Effect-returning operations. Compose them with `yield*`, `Effect.flatMap`, or
+other Effect operators. Predicates passed to `ui.waitFor` may return a boolean
+or an Effect. Set `launch: "manual"` to launch the shared OpenCode server and
+every TUI explicitly:
 
 ```ts
+import { Effect } from "effect"
 import { defineScript } from "opencode-drive"
 
 export default defineScript({
   launch: "manual",
-  async run({ ui, server, clients }) {
-    // ui is null in manual mode.
-    await server.launch()
-    const alice = await clients.launch("alice")
-    const bob = await clients.launch("bob")
-    await alice.submit("Hello from Alice")
-    await bob.screenshot("bob-view")
-  },
+  run: ({ ui, server, clients }) =>
+    Effect.gen(function* () {
+      // ui is null in manual mode.
+      yield* server.launch()
+      const alice = yield* clients.launch("alice")
+      const bob = yield* clients.launch("bob")
+      yield* alice.submit("Hello from Alice")
+      yield* bob.screenshot("bob-view")
+    }),
 })
 ```
 
 Only one server may be launched per script. All clients share its LLM backend. Client processes and temporary
 script links are cleaned up when the script ends.
 
-`await server.kill()` stops the server so it can be launched again later.
-Every client handle also has `await ui.kill()` and its name may be reused after
-the TUI exits.
+`yield* server.kill()` stops the server so it can be launched again later.
+Every client handle also has `yield* ui.kill()`, and its name may be reused
+after the TUI exits.
 
 Pass `{ record: true }` to record an individual client:
 
 ```ts
-const ui = await clients.launch("alice", { record: true })
-const video = await ui.kill()
+const ui = yield* clients.launch("alice", { record: true })
+const video = yield* ui.kill()
 ```
 
 `ui.kill()` exports the recording before terminating the TUI. Clients still
@@ -348,16 +362,29 @@ consume `llm.queue`, `llm.send`, or `llm.serve` responses. Manual-launch
 scripts can customize them before starting the server:
 
 ```ts
-llm.title((request) => "Custom title")
-await server.launch()
+yield* llm.title(() => Effect.succeed("Custom title"))
+yield* server.launch()
 ```
 
-Use `await llm.send(...)` to wait for and complete the next request,
-`llm.queue(...)` to declare future responses upfront, or `llm.serve(async
-function* () { ... })` for ongoing streamed responses. The backend connection,
-default `finish("stop")`, cancellation, and cleanup are automatic. All public
-script types are canonically defined in [`src/script/types.ts`](./src/script/types.ts),
-which can be provided directly to an authoring agent.
+Use `yield* llm.send(...)` to wait for and complete the next request or `yield*
+llm.queue(...)` to declare future responses upfront. For ongoing responses,
+the handler passed to `llm.serve` returns an Effect `Stream`:
+
+```ts
+import { Stream } from "effect"
+
+yield* llm.serve((_request, index) =>
+  Stream.make(llm.text(`Response ${index + 1}`)),
+)
+```
+
+The backend connection, default `finish("stop")`, and cleanup are automatic.
+Cancellation is represented by Effect interruption: interrupting the script or
+the fiber running an operation interrupts its in-flight work and runs scoped
+finalizers. There is no Promise compatibility shim or separate cancellation
+API. All public script types are canonically defined in
+[`src/script/types.ts`](./src/script/types.ts), which can be provided directly
+to an authoring agent.
 
 `llm.text()` streams text in randomized chunks. It defaults to a 2 ms delay and
 a target chunk size of 15 characters, varied by plus or minus 5 per chunk:

--- a/docs/driver-consolidation-plan.md
+++ b/docs/driver-consolidation-plan.md
@@ -2,12 +2,14 @@
 
 ## Goal
 
-Make the Effect-native driver the single owner of OpenCode Drive lifecycle behavior while preserving the existing `defineScript` call sites as a Promise adapter. Promote ordinary Effect programs to the primary product, add deterministic OpenCode TUI configuration, return structured run evidence with validated path types, and replace protocol-skew timeouts with explicit compatibility negotiation.
+Make the Effect-native driver the single owner of OpenCode Drive lifecycle behavior. Make `defineScript` Effect-only alongside ordinary Effect programs, add deterministic OpenCode TUI configuration, return structured run evidence with validated path types, and replace protocol-skew timeouts with explicit compatibility negotiation.
 
 ## Invariants
 
 - `OpenCodeDriver.use` is the default safe lifecycle boundary.
-- The Promise script API remains source-compatible.
+- `defineScript` has no Promise API or compatibility shim: `setup` and `run` return Effects.
+- Script `fs`, `ui`, `llm`, `server`, and `clients` operations return Effects; `llm.serve` handlers return Streams.
+- Script cancellation is Effect interruption and runs scoped finalizers.
 - Manual scripts retain server kill/relaunch and named multi-client behavior.
 - CLI `--command.ui.*` names and payloads remain identical to OpenCode's canonical frontend protocol.
 - OpenCode configuration is expressed through normal `opencode.jsonc` and `tui.jsonc` files, not Drive-specific runtime flags.
@@ -31,7 +33,7 @@ Make the Effect-native driver the single owner of OpenCode Drive lifecycle behav
 4. Deep-merge declared configuration over project fixture files, with arrays replacing and setup mutations taking final precedence.
 5. Parse existing JSONC rather than assuming strict JSON.
 6. Write normalized `.opencode/opencode.jsonc` and `.opencode/tui.jsonc` before creating the optional Git baseline.
-7. Verify the same behavior through Promise scripts and the Effect driver.
+7. Verify the same behavior through Effect scripts and the Effect driver.
 
 ## Phase 2: Effect Program Runner
 
@@ -48,9 +50,9 @@ Make the Effect-native driver the single owner of OpenCode Drive lifecycle behav
 1. Make LLM response state independent of one backend connection and attach it per server generation.
 2. Introduce an Effect-native server-generation controller over one prepared `OpenCodeInstance`.
 3. Add Effect-native named client creation, name release, unexpected-exit observation, and relaunch.
-4. Reuse the Effect UI implementation for Promise scripts, including effectful predicates at the adapter boundary.
+4. Reuse the Effect UI implementation directly for `defineScript`, including effectful polling and predicates.
 5. Add an internal driver constructor over an already prepared instance.
-6. Replace Promise-side backend, UI polling, LLM routing, recording finalization, and client ownership with shallow adapters.
+6. Route `defineScript` backend, UI polling, LLM routing, recording finalization, and client ownership through the shared Effect services.
 7. Delete duplicated lifecycle implementations only after all characterization tests pass.
 8. Replace interruption-sensitive cached terminal operations with shared independently owned settlement effects.
 

--- a/docs/open-code-driver-api.md
+++ b/docs/open-code-driver-api.md
@@ -26,9 +26,8 @@ opencode-drive run ./drive.ts
 ```
 
 The command accepts no flags and no arguments after `--`. Use the driver API in
-the module for simulation control. `opencode-drive check` remains the contract
-checker for Promise `defineScript` modules, and `start --script` remains their
-execution path.
+the module for simulation control. `opencode-drive check` validates Effect-only
+`defineScript` modules, and `start --script` executes them.
 
 ## `use` settles one scoped driver
 
@@ -296,63 +295,54 @@ yield* llm.queue(
 
 Responses without an explicit terminal output finish with `"stop"`. Title requests remain separate and do not consume this queue.
 
-## Current and Effect call sites map directly
+## `defineScript` is Effect-only
+
+`defineScript` does not provide a Promise adapter. Its `setup` and `run`
+callbacks return Effects, as do operations on `fs`, `ui`, `llm`, `server`,
+and `clients`. Compose script operations in the same runtime with
+`yield*` or Effect operators.
 
 ### Primary UI
 
-Current:
-
 ```ts
+import { Effect } from "effect"
+import { defineScript } from "opencode-drive"
+
 export default defineScript({
-  async run({ ui, llm }) {
-    llm.queue(llm.text("The value is 1."))
-    await ui.submit("Read src/example.ts")
-    await ui.waitFor("The value is 1.")
-  },
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.queue(llm.text("The value is 1."))
+      yield* ui.submit("Read src/example.ts")
+      yield* ui.waitFor("The value is 1.")
+    }),
 })
 ```
 
-Effect:
+`llm.serve` accepts a handler that returns an Effect `Stream`. The registration
+itself is also an Effect:
 
 ```ts
-const driver = yield* OpenCodeDriver.make()
-const { ui, llm } = driver
+import { Stream } from "effect"
 
-yield* llm.queue(
-  Llm.text("The value is 1."),
+yield* llm.serve((_request, index) =>
+  Stream.make(llm.text(`Response ${index + 1}`)),
 )
-yield* ui.submit("Read src/example.ts")
-yield* ui.waitFor("The value is 1.")
-yield* driver.settle()
 ```
+
+Predicates passed to `ui.waitFor` may return a boolean or an Effect.
 
 ### Additional client
 
-Current:
-
 ```ts
-await server.launch()
-const alice = await clients.launch("alice")
-const bob = await clients.launch("bob")
+yield* server.launch()
+const alice = yield* clients.launch("alice")
+const bob = yield* clients.launch("bob")
 
-await alice.submit("Hello from Alice")
-await bob.screenshot("bob-view")
-```
-
-Effect:
-
-```ts
-const oc = yield* OpenCodeDriver.make()
-const secondary = yield* oc.clients.make()
-
-yield* oc.ui.submit("Hello from the primary client")
-yield* secondary.ui.screenshot("secondary-view")
-yield* oc.settle()
+yield* alice.submit("Hello from Alice")
+yield* bob.screenshot("bob-view")
 ```
 
 ### Client configuration
-
-Current:
 
 ```ts
 export default defineScript({
@@ -360,32 +350,21 @@ export default defineScript({
     cols: 118,
     rows: 34,
   },
-  async run({ ui }) {
-    await ui.screenshot("home")
-  },
+  run: ({ ui }) => ui.screenshot("home").pipe(Effect.asVoid),
 })
 ```
 
-Effect:
-
-```ts
-const driver = yield* OpenCodeDriver.make({
-  client: {
-    viewport: {
-      cols: 118,
-      rows: 34,
-    },
-  },
-})
-const { ui } = driver
-
-yield* ui.screenshot("home")
-yield* driver.settle()
-```
+Script cancellation uses Effect interruption. Interrupting the script or an
+operation's fiber interrupts in-flight work and runs its scoped finalizers;
+there is no `AbortSignal`, Promise cancellation convention, or compatibility
+shim.
 
 ## Settled interface
 
 - The API is Effect-native.
+- `defineScript` accepts only Effect-returning `setup` and `run` callbacks.
+- Script capability methods return Effects; `llm.serve` handlers return Streams.
+- Cancellation uses Effect interruption, without a Promise compatibility shim.
 - `OpenCodeDriver.use(options, run)` is the safe top-level bracket and performs typed settlement.
 - `OpenCodeDriver.make(options)` is the primary scoped constructor.
 - Programs that call `make` directly call terminal `driver.settle()` before leaving the scope.

--- a/examples/multiple-clients.ts
+++ b/examples/multiple-clients.ts
@@ -1,50 +1,70 @@
-import { defineScript, wait } from "opencode-drive"
+import { Effect, Stream } from "effect"
+import { defineScript, Llm, wait } from "opencode-drive"
 
 export default defineScript({
   launch: "manual",
 
-  async run({ server, clients, llm }) {
-    await server.launch()
+  run: ({ server, clients, llm }) =>
+    Effect.gen(function* () {
+      yield* server.launch()
 
-    llm.serve((_request, index) => [
-      llm.text(`Response for request ${index + 1}`),
-    ])
+      yield* llm.serve((_request, index) =>
+        Stream.make(Llm.text(`Response for request ${index + 1}`)),
+      )
 
-    const [alice, bob] = await Promise.all([
-      clients.launch("alice", { record: true }),
-      clients.launch("bob", { record: true }),
-    ])
+      const [alice, bob] = yield* Effect.all(
+        [
+          clients.launch("alice", { record: true }),
+          clients.launch("bob", { record: true }),
+        ],
+        { concurrency: "unbounded" },
+      )
 
-    await Promise.all([
-      alice.submit("Reply to Alice"),
-      bob.submit("Reply to Bob"),
-    ])
-    await Promise.all([
-      alice.screenshot("multiple-clients-alice-submitted"),
-      bob.screenshot("multiple-clients-bob-submitted"),
-    ])
-    await Promise.all([
-      alice.waitFor("Response for request", { timeout: 30_000 }),
-      bob.waitFor("Response for request", { timeout: 30_000 }),
-    ])
+      yield* Effect.all(
+        [alice.submit("Reply to Alice"), bob.submit("Reply to Bob")],
+        { concurrency: "unbounded" },
+      )
+      yield* Effect.all(
+        [
+          alice.screenshot("multiple-clients-alice-submitted"),
+          bob.screenshot("multiple-clients-bob-submitted"),
+        ],
+        { concurrency: "unbounded" },
+      )
+      yield* Effect.all(
+        [
+          alice.waitFor("Response for request", { timeout: 30_000 }),
+          bob.waitFor("Response for request", { timeout: 30_000 }),
+        ],
+        { concurrency: "unbounded" },
+      )
 
-    await Promise.all([
-      alice.screenshot("multiple-clients-alice-complete"),
-      bob.screenshot("multiple-clients-bob-complete"),
-    ])
+      yield* Effect.all(
+        [
+          alice.screenshot("multiple-clients-alice-complete"),
+          bob.screenshot("multiple-clients-bob-complete"),
+        ],
+        { concurrency: "unbounded" },
+      )
 
-    await server.kill()
-    await wait(500)
-    await Promise.all([
-      alice.screenshot("multiple-clients-alice-server-stopped"),
-      bob.screenshot("multiple-clients-bob-server-stopped"),
-    ])
+      yield* server.kill()
+      yield* wait(500)
+      yield* Effect.all(
+        [
+          alice.screenshot("multiple-clients-alice-server-stopped"),
+          bob.screenshot("multiple-clients-bob-server-stopped"),
+        ],
+        { concurrency: "unbounded" },
+      )
 
-    await server.launch()
-    await wait(1000)
-    await Promise.all([
-      alice.screenshot("multiple-clients-alice-server-relaunched"),
-      bob.screenshot("multiple-clients-bob-server-relaunched"),
-    ])
-  },
+      yield* server.launch()
+      yield* wait(1000)
+      yield* Effect.all(
+        [
+          alice.screenshot("multiple-clients-alice-server-relaunched"),
+          bob.screenshot("multiple-clients-bob-server-relaunched"),
+        ],
+        { concurrency: "unbounded" },
+      )
+    }),
 })

--- a/examples/serve.ts
+++ b/examples/serve.ts
@@ -1,57 +1,56 @@
-import { defineScript } from "opencode-drive"
+import { Effect, Stream } from "effect"
+import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
-  async setup({ fs }) {
-    await fs.writeFile(
-      "src/greeting.ts",
-      [
-        "export function greeting(name: string) {",
-        '  return `Welcome, ${name}!`',
-        "}",
-        "",
-      ].join("\n"),
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      yield* fs.writeFile(
+        "src/greeting.ts",
+        [
+          "export function greeting(name: string) {",
+          '  return `Welcome, ${name}!`',
+          "}",
+          "",
+        ].join("\n"),
+      )
+    }),
 
-  async run({ llm, ui }) {
-    let turn = 0
+  run: ({ llm, ui }) =>
+    Effect.gen(function* () {
+      let turn = 0
 
-    llm.serve(async function* (request) {
-      if (isTitleRequest(request.body)) {
-        yield { type: "textDelta", text: "Understanding the greeting" }
-        return
-      }
+      yield* llm.serve((request) => {
+        if (isTitleRequest(request.body))
+          return Stream.make(Llm.text("Understanding the greeting"))
 
-      if (turn++ === 0) {
-        yield {
-          type: "reasoningDelta",
-          text: "I should read the implementation before explaining it.",
-        }
-        yield {
-          type: "toolCall",
-          index: 0,
-          id: "call_read_greeting",
-          name: "read",
-          input: { filePath: "src/greeting.ts" },
-        }
-        yield { type: "finish", reason: "tool-calls" }
-        return
-      }
+        if (turn++ === 0)
+          return Stream.make(
+            Llm.reasoning(
+              "I should read the implementation before explaining it.",
+            ),
+            Llm.toolCall({
+              index: 0,
+              id: "call_read_greeting",
+              name: "read",
+              input: { filePath: "src/greeting.ts" },
+            }),
+            Llm.finish("tool-calls"),
+          )
 
-      for (const text of [
-        "The function accepts a name, ",
-        "places it into a welcome message, ",
-        "and adds an exclamation mark.",
-      ]) {
-        yield { type: "textDelta", text }
-        await Bun.sleep(150)
-      }
-      yield { type: "finish", reason: "stop" }
-    })
+        return Stream.make(
+          Llm.text("The function accepts a name, "),
+          Llm.pause(150),
+          Llm.text("places it into a welcome message, "),
+          Llm.pause(150),
+          Llm.text("and adds an exclamation mark."),
+          Llm.pause(150),
+          Llm.finish("stop"),
+        )
+      })
 
-    await ui.submit("Read src/greeting.ts and explain what it does.")
-    await ui.waitFor("adds an exclamation mark")
-  },
+      yield* ui.submit("Read src/greeting.ts and explain what it does.")
+      yield* ui.waitFor("adds an exclamation mark")
+    }),
 })
 
 function isTitleRequest(body: unknown) {

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,39 +1,42 @@
-import { defineScript } from "opencode-drive"
+import { Effect } from "effect"
+import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
-  async setup({ fs }) {
-    await fs.writeFile(
-      "src/message.ts",
-      'export const message = "Hello from OpenCode Drive"\n',
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      yield* fs.writeFile(
+        "src/message.ts",
+        'export const message = "Hello from OpenCode Drive"\n',
+      )
+    }),
 
-  async run({ llm, ui }) {
-    await ui.waitFor((state) => state.focused.editor)
-    const editor = await ui.getElement({ editor: true, focused: true })
-    await ui.focus(editor)
+  run: ({ llm, ui }) =>
+    Effect.gen(function* () {
+      yield* ui.waitFor((state) => state.focused.editor)
+      const editor = yield* ui.getElement({ editor: true, focused: true })
+      yield* ui.focus(editor)
 
-    await ui.submit("What does src/message.ts export?")
-    await llm.send(
-      llm.reasoning("I should inspect the small source file first.", {
-        delay: 5,
-        chunkSize: 10,
-      }),
-      llm.pause(100),
-      llm.text(
-        'src/message.ts exports `message` with the value "Hello from OpenCode Drive".',
-        {
-          delay: 10,
-          chunkSize: 12,
-        },
-      ),
-    )
-    await llm.send(llm.text("Message export"))
+      yield* ui.submit("What does src/message.ts export?")
+      yield* llm.send(
+        Llm.reasoning("I should inspect the small source file first.", {
+          delay: 5,
+          chunkSize: 10,
+        }),
+        Llm.pause(100),
+        Llm.text(
+          'src/message.ts exports `message` with the value "Hello from OpenCode Drive".',
+          {
+            delay: 10,
+            chunkSize: 12,
+          },
+        ),
+      )
+      yield* llm.send(Llm.text("Message export"))
 
-    await ui.waitFor("Hello from OpenCode Drive")
-    if (!(await ui.matches("OpenCode Drive")))
-      throw new Error("the expected response was not visible")
+      yield* ui.waitFor("Hello from OpenCode Drive")
+      if (!(yield* ui.matches("OpenCode Drive")))
+        throw new Error("the expected response was not visible")
 
-    await ui.screenshot("simple-response")
-  },
+      yield* ui.screenshot("simple-response")
+    }),
 })

--- a/examples/viewport-resize.ts
+++ b/examples/viewport-resize.ts
@@ -1,46 +1,51 @@
-import { defineScript, wait } from "opencode-drive"
+import { Effect } from "effect"
+import { defineScript, Llm, wait } from "opencode-drive"
 
 export default defineScript({
   viewport: { cols: 120, rows: 36 },
 
-  async setup({ fs }) {
-    await fs.writeFile(
-      "src/viewport.ts",
-      `export const viewportSequence = ["120x36", "80x24", "50x18"]\n`,
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      yield* fs.writeFile(
+        "src/viewport.ts",
+        `export const viewportSequence = ["120x36", "80x24", "50x18"]\n`,
+      )
+    }),
 
-  async run({ ui, llm }) {
-    await ui.submit("Show a compact status report for the viewport resize demo.")
-    await llm.send(
-      llm.text(
-        "Viewport demo: starting wide at 120 columns by 36 rows. The file src/viewport.ts lists the planned sequence. This first response should have plenty of horizontal room before the terminal narrows.",
-      ),
-    )
-    await wait(900)
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* ui.submit(
+        "Show a compact status report for the viewport resize demo.",
+      )
+      yield* llm.send(
+        Llm.text(
+          "Viewport demo: starting wide at 120 columns by 36 rows. The file src/viewport.ts lists the planned sequence. This first response should have plenty of horizontal room before the terminal narrows.",
+        ),
+      )
+      yield* wait(900)
 
-    await ui.resize({ cols: 80, rows: 24 })
-    await wait(900)
+      yield* ui.resize({ cols: 80, rows: 24 })
+      yield* wait(900)
 
-    await ui.submit("Now describe the medium viewport.")
-    await llm.send(
-      llm.text(
-        "Medium viewport: resized to 80 columns by 24 rows. Lines should wrap sooner, the composer has less vertical breathing room, and the conversation should reflow without losing focus.",
-      ),
-    )
-    await ui.waitFor("resized to 80 columns")
-    await wait(900)
+      yield* ui.submit("Now describe the medium viewport.")
+      yield* llm.send(
+        Llm.text(
+          "Medium viewport: resized to 80 columns by 24 rows. Lines should wrap sooner, the composer has less vertical breathing room, and the conversation should reflow without losing focus.",
+        ),
+      )
+      yield* ui.waitFor("resized to 80 columns")
+      yield* wait(900)
 
-    await ui.resize({ cols: 50, rows: 18 })
-    await wait(900)
+      yield* ui.resize({ cols: 50, rows: 18 })
+      yield* wait(900)
 
-    await ui.submit("Finish with the narrow viewport summary.")
-    await llm.send(
-      llm.text(
-        "Narrow viewport: now 50 columns by 18 rows. This final state is intentionally cramped so modal, wrapping, and footer behavior are easy to inspect in the recording.",
-      ),
-    )
-    await ui.waitFor("now 50 columns")
-    await wait(1200)
-  },
+      yield* ui.submit("Finish with the narrow viewport summary.")
+      yield* llm.send(
+        Llm.text(
+          "Narrow viewport: now 50 columns by 18 rows. This final state is intentionally cramped so modal, wrapping, and footer behavior are easy to inspect in the recording.",
+        ),
+      )
+      yield* ui.waitFor("now 50 columns")
+      yield* wait(1200)
+    }),
 })

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -7,7 +7,10 @@ description: Use when an agent needs to drive OpenCode with an Effect program or
 
 Use `opencode-drive` to launch an isolated OpenCode instance and control its TUI and simulated LLM.
 
-Default to a one-shot Effect program. Use live commands only for interactive development against a persistent or visible instance. Use the Promise script adapter only for named, visible, restartable, or manual-launch compatibility workflows.
+Default to a one-shot Effect program. Use `defineScript` for named, visible,
+restartable, or manual-launch workflows; it is also Effect-only. Use live
+commands only for interactive development against a persistent or visible
+instance.
 
 ## Effect Programs
 
@@ -65,11 +68,12 @@ export default OpenCodeDriver.use(
       theme: "system",
       scroll_speed: 1,
     },
-    async setup({ fs, config, tui }) {
-      await fs.writeFile("src/setup.ts", "export const ready = true\n")
-      config.username = "Setup wins"
-      tui.scroll_speed = 2
-    },
+    setup: ({ fs, config, tui }) =>
+      Effect.gen(function* () {
+        yield* fs.writeFile("src/setup.ts", "export const ready = true\n")
+        config.username = "Setup wins"
+        tui.scroll_speed = 2
+      }),
   },
   ({ ui }) => ui.screenshot("home"),
 )
@@ -105,7 +109,20 @@ yield* llm.queue(
 )
 ```
 
-`llm.queue(...)` declares the next response without waiting. `llm.send(...)` waits for the next request and completes its response. `llm.serve(handler)` handles an ongoing sequence of requests. Available outputs include `text`, `reasoning`, `pause`, `toolCall`, `raw`, `finish`, and `disconnect`; a normal response gets `finish("stop")` when no terminal output is supplied.
+`llm.queue(...)` declares the next response without waiting. `llm.send(...)`
+waits for the next request and completes its response. For ongoing responses,
+the handler passed to `llm.serve` returns an Effect `Stream`; registering the
+handler is an Effect. Available outputs include `text`, `reasoning`, `pause`,
+`toolCall`, `raw`, `finish`, and `disconnect`; a normal response gets
+`finish("stop")` when no terminal output is supplied.
+
+```ts
+import { Stream } from "effect"
+
+yield* llm.serve((_request, index) =>
+  Stream.make(llm.text(`Response ${index + 1}`)),
+)
+```
 
 Additional clients share the server and LLM controller:
 
@@ -128,8 +145,11 @@ Drive prefers protocol negotiation and reports explicit legacy fallback. Set `op
 ### Simulated Shell Execution
 
 Use `tools` to replace shell execution without changing the model-visible tool
-schema. The handler receives typed input, a zero-based call index, an abort
-signal, and an Effect progress function. Unregistered tools remain real.
+schema. The handler receives typed input, a zero-based call index, and an Effect
+progress function. It also receives an `AbortSignal` from the OpenCode tool
+transport; handler Effects are interrupted when that signal aborts. This
+transport signal is separate from script lifecycle cancellation, which uses
+Effect interruption. Unregistered tools remain real.
 
 ```ts
 import { Effect } from "effect"
@@ -154,11 +174,16 @@ The same `tools` callback is accepted by `defineScript`. Supported adapters are
 Each progress value replaces the visible tool output, so send accumulated text
 when earlier lines should remain visible.
 
-## Promise Compatibility Scripts
+## Effect Scripts
 
-Retain `defineScript` with `start --script` when the workflow must have a stable instance name, be visible, rerun on `restart`, or explicitly launch and kill its server and clients. Do not choose this adapter for an ordinary one-shot automation.
+Use `defineScript` with `start --script` when the workflow must have a stable
+instance name, be visible, rerun on `restart`, or explicitly launch and kill
+its server and clients. `setup` and `run` return Effects. Operations on `fs`,
+`ui`, `llm`, `server`, and `clients` also return Effects; there is no
+Promise API or compatibility shim.
 
 ```ts
+import { Effect } from "effect"
 import { defineScript } from "opencode-drive"
 
 export default defineScript({
@@ -168,40 +193,46 @@ export default defineScript({
     git: true,
     files: { "src/value.ts": "export const value = 1\n" },
   },
-  async run({ ui, llm }) {
-    llm.queue(llm.text("The value is 1."))
-    await ui.submit("Read src/value.ts")
-    await ui.waitFor("The value is 1.")
-  },
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.queue(llm.text("The value is 1."))
+      yield* ui.submit("Read src/value.ts")
+      yield* ui.waitFor("The value is 1.")
+    }),
 })
 ```
 
-Always type-check a Promise script before starting it:
+Always type-check a script before starting it:
 
 ```bash
 opencode-drive check ./drive.ts
 opencode-drive start --name demo --script ./drive.ts
 ```
 
-The Promise DSL applies `project`, `config`, `tui`, and `setup` with the same deterministic ordering described above. Automatic scripts run again after `opencode-drive restart --name demo`.
+The script DSL applies `project`, `config`, `tui`, and `setup` with the same deterministic ordering described above. Automatic scripts run again after `opencode-drive restart --name demo`.
 
-Use `launch: "manual"` only when the compatibility workflow must control server and client restarts itself. In manual mode `ui` is `null`; call `server.launch()` before `clients.launch(name)`. Only one server may run at a time, `server.kill()` permits relaunch, and a killed client name may be reused.
+Use `launch: "manual"` only when the workflow must control server and client restarts itself. In manual mode `ui` is `null`; run `server.launch()` before `clients.launch(name)`. Only one server may run at a time, `server.kill()` permits relaunch, and a killed client name may be reused.
 
 ```ts
 export default defineScript({
   launch: "manual",
-  async run({ server, clients }) {
-    await server.launch()
-    const alice = await clients.launch("alice", { record: true })
-    await alice.screenshot("alice")
-    await alice.kill()
-  },
+  run: ({ server, clients }) =>
+    Effect.gen(function* () {
+      yield* server.launch()
+      const alice = yield* clients.launch("alice", { record: true })
+      yield* alice.screenshot("alice")
+      yield* alice.kill()
+    }),
 })
 ```
 
+Cancellation uses Effect interruption. Interrupting the script or an
+operation's fiber interrupts in-flight work and runs scoped finalizers; do not
+introduce `AbortSignal` or Promise cancellation wrappers.
+
 ## Prepare An Instance
 
-Use `init` only when files must be copied into an isolated home or project before a named live or Promise-script instance starts:
+Use `init` only when files must be copied into an isolated home or project before a named live or scripted instance starts:
 
 ```bash
 artifacts=$(opencode-drive init --name demo)

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Stream from "effect/Stream"
 import * as OpenCodeDriver from "../driver/index.js"
@@ -10,8 +11,6 @@ import * as Llm from "../llm/index.js"
 import { createScriptFileSystem } from "../script/filesystem.js"
 import { hasGitMetadata } from "../script/project.js"
 import type {
-  LlmOutput,
-  LlmResponse,
   ScriptClientOptions,
   ScriptDefinition,
   ScriptLlm,
@@ -22,19 +21,22 @@ import type {
   UiWaitOptions,
 } from "../script/types.js"
 
-export async function loadScript(file: string): Promise<ScriptDefinition> {
-  const module: { readonly default?: unknown } = await import(
-    pathToFileURL(resolve(file)).href
-  )
-  if (!isScriptDefinition(module.default))
-    throw new Error("script must default-export defineScript({ project?, setup?, run })")
-  return module.default
-}
+export const loadScript = Effect.fn("DriveCli.loadScript")((file: string) =>
+  Effect.tryPromise({
+    try: () => import(pathToFileURL(resolve(file)).href) as Promise<{ readonly default?: unknown }>,
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.flatMap((module) =>
+      isScriptDefinition(module.default)
+        ? Effect.succeed(module.default)
+        : Effect.fail(new Error("script must default-export defineScript({ project?, setup?, run })")),
+    ),
+  ),
+)
 
 export const runScript = Effect.fn("DriveCli.runScript")(function* (
   script: ScriptDefinition,
   instance: OpenCodeInstance.Instance,
-  signal: AbortSignal,
   onScreenshot?: (path: string) => void,
   onRecording?: (path: string) => void,
   onReady?: () => void,
@@ -45,97 +47,90 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
     clientName: "default",
     client: { viewport: script.viewport },
   })
-  const localAbort = new AbortController()
-  const scriptSignal = AbortSignal.any([signal, localAbort.signal])
-  yield* Effect.addFinalizer(() =>
-    Effect.sync(() => localAbort.abort(new Error("script finished"))),
-  )
   const protectGit = yield* Effect.promise(() =>
     hasGitMetadata(join(instance.artifacts, "files")),
   )
-  const operationFailure = Promise.withResolvers<never>()
-  void operationFailure.promise.catch(() => undefined)
+  const operationFailure = yield* Deferred.make<never, unknown>()
+  const run = <A, E>(effect: Effect.Effect<A, E>) =>
+    effect.pipe(
+      Effect.tapError((cause) =>
+        isTimeoutError(cause)
+          ? Deferred.fail(operationFailure, cause).pipe(Effect.asVoid)
+          : Effect.void,
+      ),
+    )
   const recordings = new Set<string>()
   const reportRecording = (path: string) => {
     if (recordings.has(path)) return
     recordings.add(path)
     onRecording?.(path)
   }
-  const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
-    const promise = Effect.runPromise(effect, { signal: scriptSignal })
-    void promise.catch((cause) => {
-      if (isTimeoutError(cause)) {
-        if (!localAbort.signal.aborted) localAbort.abort(cause)
-        operationFailure.reject(cause)
-      }
-    })
-    return promise
-  }
-  const runBackground = <A, E>(effect: Effect.Effect<A, E>) => {
-    const promise = run(effect)
-    void promise.catch((cause) => operationFailure.reject(cause))
-    return promise
-  }
   const adaptUi = (client: OpenCodeClient.Client): ScriptUi => {
     const ui = client.ui
-    const call = <A, E>(effect: Effect.Effect<A, E>) => run(effect)
     return {
-      async kill() {
-        const output = client.recording === undefined
-          ? undefined
-          : await call(client.recording.finish())
-        if (output !== undefined) reportRecording(output)
-        await call(client.close())
-        return output
-      },
-      state: () => call(ui.state()),
-      matches: (matcher) => call(ui.matches(matcher)),
-      async screenshot(name) {
-        const path = await call(ui.screenshot(name))
-        onScreenshot?.(path)
-        return path
-      },
-      type: (text) => call(ui.type(text)),
-      press: (key, modifiers) => call(ui.press(key, modifiers)),
-      enter: () => call(ui.enter()),
-      arrow: (direction) => call(ui.arrow(direction)),
-      focus: (target) => call(ui.focus(target)),
-      click: (target, position) => call(ui.click(target, position)),
-      resize: (viewport) => call(ui.resize(viewport)),
-      submit: (text) => call(ui.submit(text)),
+      kill: () =>
+        run(Effect.gen(function* () {
+          const output = client.recording === undefined
+            ? undefined
+            : yield* client.recording.finish()
+          if (output !== undefined) reportRecording(output)
+          yield* client.close()
+          return output
+        })),
+      state: () => run(ui.state()),
+      matches: (matcher) => run(ui.matches(matcher)),
+      screenshot: (name) => run(ui.screenshot(name)).pipe(Effect.tap((path) => Effect.sync(() => onScreenshot?.(path)))),
+      type: (text) => run(ui.type(text)),
+      press: (key, modifiers) => run(ui.press(key, modifiers)),
+      enter: () => run(ui.enter()),
+      arrow: (direction) => run(ui.arrow(direction)),
+      focus: (target) => run(ui.focus(target)),
+      click: (target, position) => run(ui.click(target, position)),
+      resize: (viewport) => run(ui.resize(viewport)),
+      submit: (text) => run(ui.submit(text)),
       waitFor(target: UiMatcher | UiPredicate, options?: UiWaitOptions) {
-        return call(
-          typeof target === "string"
-            ? ui.waitFor(target, options)
-            : ui.waitForEffect(
-                (state) =>
-                  Effect.tryPromise({
-                    try: () => Promise.resolve(target(state)),
-                    catch: (cause) =>
-                      cause instanceof Error ? cause : new Error(String(cause)),
-                  }),
-                options,
+        if (typeof target === "string") return run(ui.waitFor(target, options))
+        return run(
+          ui.waitForEffect(
+            (state) =>
+              Effect.try({
+                try: (): unknown => target(state),
+                catch: toError,
+              }).pipe(
+                Effect.flatMap((result) => {
+                  if (isEffect(result))
+                    return result.pipe(
+                      Effect.mapError(toError),
+                      Effect.flatMap((value) =>
+                        typeof value === "boolean"
+                          ? Effect.succeed(value)
+                          : Effect.fail(new Error("ui.waitFor predicate Effect must produce a boolean")),
+                      ),
+                    )
+                  if (typeof result === "boolean") return Effect.succeed(result)
+                  return Effect.fail(new Error("ui.waitFor predicate must return a boolean or Effect"))
+                }),
               ),
+            options,
+          ),
         )
       },
       getElement: (
         target: number | string | UiElementQuery,
         options?: UiWaitOptions,
-      ) => call(ui.getElement(target, options)),
+      ) => run(ui.getElement(target, options)),
     }
   }
-  const llm = adaptLlm(prepared.llm, run, runBackground)
+  const llm = adaptLlm(prepared.llm, run)
   const clients = {
     launch: (name: string, options?: ScriptClientOptions) =>
-      run(
-        prepared.clients.launch(name, {
+      run(prepared.clients.launch(name, {
           recording: options?.record,
           viewport: options?.viewport ?? script.viewport,
-        }),
-      ).then((client) => {
-        onReady?.()
-        return adaptUi(client)
-      }),
+        })).pipe(
+          Effect.tap(() => Effect.sync(() => onReady?.())),
+          Effect.map(adaptUi),
+        ),
   }
   const context = {
     fs: createScriptFileSystem(join(instance.artifacts, "files"), {
@@ -148,74 +143,45 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
     },
     llm,
     artifacts: instance.artifacts,
-    signal: scriptSignal,
   }
   const primaryClient = prepared.primary
-  const execution = Promise.resolve(
+  const execution =
     "launch" in script
       ? script.run({ ...context, ui: null })
-      : script.run({ ...context, ui: adaptUi(primaryClient!) }),
-  )
+      : script.run({ ...context, ui: adaptUi(primaryClient!) })
+  if (!Effect.isEffect(execution))
+    return yield* Effect.fail(new Error("script run must return an Effect"))
   if (primaryClient !== undefined) onReady?.()
-  yield* Effect.tryPromise({
-    try: async () => {
-      try {
-        await Promise.race([
-          execution,
-          operationFailure.promise,
-          Effect.runPromise(prepared.failure),
-          aborted(scriptSignal),
-        ])
-      } catch (cause) {
-        if (isZeroStatusClientExit(cause)) {
-          localAbort.abort(cause)
-          await execution
-          return
-        }
-        throw cause
-      }
-    },
-    catch: (cause) => cause,
-  })
+  yield* Effect.raceAllFirst([
+    execution,
+    Deferred.await(operationFailure),
+    prepared.failure.pipe(
+      Effect.catchIf(isZeroStatusClientExit, () => Effect.void),
+    ),
+  ])
   const settlement = yield* prepared.settle()
   for (const path of settlement.recordings) reportRecording(path)
 })
 
 function adaptLlm(
   controller: OpenCodeDriver.Llm,
-  run: <A, E>(effect: Effect.Effect<A, E>) => Promise<A>,
-  runBackground: <A, E>(effect: Effect.Effect<A, E>) => Promise<A>,
+  run: <A, E>(effect: Effect.Effect<A, E>) => Effect.Effect<A, E>,
 ): ScriptLlm {
   return {
-    queue(...output) {
-      void runBackground(controller.queue(...output.map(normalizeOutput)))
-    },
-    send: (...output) => run(controller.send(...output.map(normalizeOutput))),
-    serve(handler) {
-      void runBackground(
-        controller.serve((request, index) =>
-          responseStream(() => handler(request, index)),
+    queue: (...output) => run(controller.queue(...output)),
+    send: (...output) => run(controller.send(...output)),
+    serve: (handler) =>
+      run(controller.serve((request, index) =>
+        handler(request, index).pipe(
+          Stream.mapError((cause) => llmError("serve", cause, request.id)),
         ),
-      )
-    },
-    title(handler) {
-      void runBackground(
-        controller.title((request, index) =>
-          Effect.tryPromise({
-            try: () => Promise.resolve(handler(request, index)),
-            catch: (cause) => cause,
-          }).pipe(
-            Effect.mapError((cause) =>
-              new OpenCodeDriver.LlmControllerError({
-                operation: "title",
-                requestId: request.id,
-                message: cause instanceof Error ? cause.message : String(cause),
-              }),
-            ),
-          ),
+      )),
+    title: (handler) =>
+      run(controller.title((request, index) =>
+        handler(request, index).pipe(
+          Effect.mapError((cause) => llmError("title", cause, request.id)),
         ),
-      )
-    },
+      )),
     text: Llm.text,
     reasoning: Llm.reasoning,
     pause: Llm.pause,
@@ -226,35 +192,20 @@ function adaptLlm(
   }
 }
 
-function responseStream(make: () => LlmResponse) {
-  const iterable = {
-    async *[Symbol.asyncIterator]() {
-      for await (const item of make()) yield normalizeOutput(item)
-    },
-  }
-  return Stream.fromAsyncIterable(iterable, (cause) =>
-    new OpenCodeDriver.LlmControllerError({
-      operation: "serve",
-      message: cause instanceof Error ? cause.message : String(cause),
-    }),
-  )
-}
-
-function normalizeOutput(output: LlmOutput): Llm.Output {
-  if (output.type === "textDelta" || output.type === "reasoningDelta")
-    return Llm.raw({ type: output.type, text: output.text })
-  return output
-}
-
-function aborted(signal: AbortSignal) {
-  return new Promise<never>((_resolve, reject) => {
-    if (signal.aborted) return reject(signal.reason ?? new Error("script aborted"))
-    signal.addEventListener(
-      "abort",
-      () => reject(signal.reason ?? new Error("script aborted")),
-      { once: true },
-    )
+function llmError(operation: string, cause: unknown, requestId?: string) {
+  return new OpenCodeDriver.LlmControllerError({
+    operation,
+    requestId,
+    message: cause instanceof Error ? cause.message : String(cause),
   })
+}
+
+function toError(cause: unknown) {
+  return cause instanceof Error ? cause : new Error(String(cause))
+}
+
+function isEffect(value: unknown): value is Effect.Effect<unknown, unknown> {
+  return Effect.isEffect(value)
 }
 
 function isZeroStatusClientExit(cause: unknown) {

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,4 +1,6 @@
 import * as Effect from "effect/Effect"
+import * as Cause from "effect/Cause"
+import * as Exit from "effect/Exit"
 import { toStringUnknown } from "effect/Inspectable"
 import { initializeInstance } from "../instance/instance.js"
 import * as DriveProcess from "../instance/process.js"
@@ -55,15 +57,10 @@ const startScoped = Effect.fn("DriveCli.startScoped")(function* (options: StartO
       )
     : undefined
   const script = scriptTooling
-    ? yield* fromPromise(async () => {
-        try {
-          logSuccess(`loading script ${scriptTooling.file}`)
-          return await loadScript(scriptTooling.file)
-        } catch (error) {
-          await scriptTooling.links.remove()
-          throw error
-        }
-      })
+    ? yield* loadScript(scriptTooling.file).pipe(
+        Effect.tap(() => Effect.sync(() => logSuccess(`loading script ${scriptTooling.file}`))),
+        Effect.onError(() => fromPromise(() => scriptTooling.links.remove()).pipe(Effect.ignore)),
+      )
     : undefined
   if (script && "launch" in script && options.record) {
     return yield* Effect.fail(new Error("--record is not supported when launch is manual"))
@@ -193,9 +190,7 @@ async function runLifecycle(
           const previous = current
           const restartReason = new Error("script restarted")
           previous?.abort.abort(restartReason)
-          await previous?.promise.catch((error) => {
-            if (error !== restartReason) throw error
-          })
+          await previous?.promise
           driveReady = false
           await runEffect(instance.restart)
           recording = undefined
@@ -460,18 +455,22 @@ function run(
     }
     if (driveScript) {
       logSuccess("running script")
-      await runEffect(
+      const exit = await Effect.runPromiseExit(
         Effect.scoped(
           runScript(
             driveScript,
             instance,
-            abort.signal,
             onScreenshot,
             onRecording,
             ready,
           ),
         ),
+        { signal: abort.signal },
       )
+      if (Exit.isFailure(exit)) {
+        if (abort.signal.aborted && Cause.hasInterruptsOnly(exit.cause)) return
+        throw Cause.squash(exit.cause)
+      }
       ready()
       logSuccess("script completed")
       return

--- a/src/driver/project.ts
+++ b/src/driver/project.ts
@@ -41,17 +41,15 @@ export const make = Effect.fn("OpenCodeProject.make")(function* (
             catch: () => undefined,
           }).pipe(Effect.ignore),
   )
-  yield* Effect.tryPromise({
-    try: () =>
-      prepareInstanceProject({
-        artifacts,
-        project: options.project,
-        config: options.config,
-        tui: options.tui,
-        setup: options.setup,
-      }),
-    catch: (cause) => error("project.prepare", cause),
-  })
+  yield* prepareInstanceProject({
+    artifacts,
+    project: options.project,
+    config: options.config,
+    tui: options.tui,
+    setup: options.setup,
+  }).pipe(
+    Effect.mapError((cause) => error("project.prepare", cause)),
+  )
   return { artifacts }
 })
 

--- a/src/experimental/reproduce-stale-exploring-empty.ts
+++ b/src/experimental/reproduce-stale-exploring-empty.ts
@@ -1,92 +1,103 @@
 import { join } from "node:path"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 import { defineScript } from "../index.js"
 import type { ScriptUi } from "../index.js"
 
 export default defineScript({
-  async run({ artifacts, llm, ui }) {
-    const completed = Array.from({ length: 3 }, () => Promise.withResolvers<void>())
-    let turn = 0
-
-    llm.serve(async function* (request) {
-      if (isTitleRequest(request.body)) {
-        yield llm.text("Stale exploring reproduction")
-        return
-      }
-      const current = turn++
-      if (current === 0) {
-        yield llm.toolCall({
-          index: 0,
-          id: "call_read",
-          name: "read",
-          input: { filePath: join(artifacts, "files", "src", "garden.js") },
-        })
-        yield llm.finish("tool-calls")
-        return
-      }
-      if (current === 1) {
-        yield llm.finish("tool-calls")
-        completed[0]?.resolve()
-        return
-      }
-      yield llm.text(
-        current === 2
-          ? "The file exports a small greeting function."
-          : "Confirmed again with no more tools.",
+  run: ({ artifacts, llm, ui }) =>
+    Effect.gen(function* () {
+      const completed = yield* Effect.forEach(
+        Array.from({ length: 3 }),
+        () => Deferred.make<void>(),
       )
-      completed[current - 1]?.resolve()
-    })
+      let turn = 0
 
-    const prompts = [
-      "Read src/garden.js, then tell me what it contains.",
-      "Now inspect that file one more time.",
-      "Finally, verify the same file again.",
-    ]
-    for (const [index, prompt] of prompts.entries()) {
-      if (index === 0) await ui.type(prompt)
-      else await typeSlowly(ui, prompt)
-      await ui.enter()
-      await withTimeout(
-        completed[index]!.promise,
-        30_000,
-        `timed out waiting for empty continuation ${index + 1}`,
-      )
-      await waitForEditor(ui)
-      await Bun.sleep(500)
-      await ui.screenshot(`stale-exploring-${index + 1}`)
-    }
-  }
+      yield* llm.serve((request) => {
+        if (isTitleRequest(request.body)) {
+          return Stream.make(llm.text("Stale exploring reproduction"))
+        }
+        const current = turn++
+        if (current === 0) {
+          return Stream.make(
+            llm.toolCall({
+              index: 0,
+              id: "call_read",
+              name: "read",
+              input: { filePath: join(artifacts, "files", "src", "garden.js") },
+            }),
+            llm.finish("tool-calls"),
+          )
+        }
+        if (current === 1) {
+          return Stream.make(llm.finish("tool-calls")).pipe(
+            Stream.onEnd(Deferred.succeed(completed[0]!, undefined)),
+          )
+        }
+        return Stream.make(
+          llm.text(
+            current === 2
+              ? "The file exports a small greeting function."
+              : "Confirmed again with no more tools.",
+          ),
+        ).pipe(
+          Stream.onEnd(Deferred.succeed(completed[current - 1]!, undefined)),
+        )
+      })
+
+      const prompts = [
+        "Read src/garden.js, then tell me what it contains.",
+        "Now inspect that file one more time.",
+        "Finally, verify the same file again.",
+      ]
+      for (const [index, prompt] of prompts.entries()) {
+        if (index === 0) yield* ui.type(prompt)
+        else yield* typeSlowly(ui, prompt)
+        yield* ui.enter()
+        yield* withTimeout(
+          Deferred.await(completed[index]!),
+          30_000,
+          `timed out waiting for empty continuation ${index + 1}`,
+        )
+        yield* waitForEditor(ui)
+        yield* Effect.sleep(500)
+        yield* ui.screenshot(`stale-exploring-${index + 1}`)
+      }
+    }),
 })
 
-async function withTimeout(promise: Promise<void>, timeout: number, message: string) {
-  const expired = Promise.withResolvers<never>()
-  const timer = setTimeout(() => expired.reject(new Error(message)), timeout)
-  try {
-    await Promise.race([promise, expired.promise])
-  } finally {
-    clearTimeout(timer)
-  }
+function withTimeout(
+  effect: Effect.Effect<void>,
+  timeout: number,
+  message: string,
+) {
+  return Effect.timeoutOrElse(effect, {
+    duration: timeout,
+    orElse: () => Effect.fail(new Error(message)),
+  })
 }
 
-async function typeSlowly(
+const typeSlowly = Effect.fn("typeSlowly")(function* (
   ui: ScriptUi,
   text: string,
 ) {
   for (const char of text) {
-    await ui.type(char)
-    await Bun.sleep(55)
+    yield* ui.type(char)
+    yield* Effect.sleep(55)
   }
-}
+})
 
-async function waitForEditor(
-  ui: ScriptUi,
-) {
+const waitForEditor = Effect.fn("waitForEditor")(function* (ui: ScriptUi) {
   const deadline = Date.now() + 30_000
   while (Date.now() < deadline) {
-    if ((await ui.state()).focused.editor) return
-    await Bun.sleep(50)
+    if ((yield* ui.state()).focused.editor) return
+    yield* Effect.sleep(50)
   }
-  throw new Error("timed out waiting for the session to become idle")
-}
+  return yield* Effect.fail(
+    new Error("timed out waiting for the session to become idle"),
+  )
+})
 
 function isTitleRequest(body: unknown) {
   if (typeof body !== "object" || body === null || !("messages" in body)) return false

--- a/src/instance/instance.ts
+++ b/src/instance/instance.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import * as Effect from "effect/Effect"
 import { createScriptFileSystem } from "../script/filesystem.js"
 import {
   commitScriptProject,
@@ -52,7 +53,7 @@ export async function initializeInstance(name?: string) {
   return artifacts
 }
 
-export async function prepareInstanceProject(options: {
+export const prepareInstanceProject = Effect.fn("OpenCodeInstance.prepareProject")(function* (options: {
   readonly artifacts: string
   readonly project?: ScriptProject
   readonly config?: OpenCodeConfig
@@ -62,28 +63,40 @@ export async function prepareInstanceProject(options: {
   const files = join(resolve(options.artifacts), "files")
   const configPath = join(files, ".opencode", "opencode.jsonc")
   const tuiPath = join(files, ".opencode", "tui.jsonc")
-  if (options.project) await initializeScriptProject(files, options.project)
-  const [config, tui] = await Promise.all([
-    readConfig(configPath, "opencode.jsonc"),
-    readConfig(tuiPath, "tui.jsonc", {}),
-  ])
+  const project = options.project
+  if (project)
+    yield* promise(() => initializeScriptProject(files, project))
+  const [config, tui] = yield* Effect.all([
+    promise(() => readConfig(configPath, "opencode.jsonc")),
+    promise(() => readConfig(tuiPath, "tui.jsonc", {})),
+  ], { concurrency: "unbounded" })
   deepMerge(config, options.config)
   deepMerge(tui, options.tui)
   if (options.setup !== undefined) {
     const protectGit =
-      Boolean(options.project?.git) || (await hasGitMetadata(files))
-    await options.setup({
+      Boolean(options.project?.git) || (yield* promise(() => hasGitMetadata(files)))
+    const setup: unknown = options.setup({
       fs: createScriptFileSystem(files, { git: protectGit }),
       config,
       tui,
     })
+    if (!Effect.isEffect(setup))
+      return yield* Effect.fail(new Error("script setup must return an Effect"))
+    yield* setup
   }
-  await Promise.all([
-    Bun.write(configPath, `${JSON.stringify(config, undefined, 2)}\n`),
-    Bun.write(tuiPath, `${JSON.stringify(tui, undefined, 2)}\n`),
-  ])
-  if (options.project?.git) await commitScriptProject(files)
-}
+  yield* Effect.all([
+    promise(() => Bun.write(configPath, `${JSON.stringify(config, undefined, 2)}\n`)),
+    promise(() => Bun.write(tuiPath, `${JSON.stringify(tui, undefined, 2)}\n`)),
+  ], { concurrency: "unbounded" })
+  if (options.project?.git)
+    yield* promise(() => commitScriptProject(files))
+})
+
+const promise = <A>(evaluate: () => PromiseLike<A>) =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => cause instanceof Error ? cause : new Error(String(cause)),
+  })
 
 async function readConfig(
   path: string,

--- a/src/instance/runtime.ts
+++ b/src/instance/runtime.ts
@@ -125,17 +125,15 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
     options.tui !== undefined ||
     setup !== undefined
   )
-    yield* Effect.tryPromise({
-      try: () =>
-        prepareInstanceProject({
-          artifacts,
-          project: options.project,
-          config: options.config,
-          tui: options.tui,
-          setup,
-        }),
-      catch: (cause) => instanceError("prepare project", cause),
-    })
+    yield* prepareInstanceProject({
+      artifacts,
+      project: options.project,
+      config: options.config,
+      tui: options.tui,
+      setup,
+    }).pipe(
+      Effect.mapError((cause) => instanceError("prepare project", cause)),
+    )
   const environment = stripGitEnvironment({
     ...process.env,
     ...options.env,

--- a/src/script/filesystem.ts
+++ b/src/script/filesystem.ts
@@ -1,5 +1,6 @@
 import { lstat, mkdir, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path"
+import * as Effect from "effect/Effect"
 import type { ScriptFileSystem } from "./types.js"
 
 interface FileSystemOptions {
@@ -12,11 +13,15 @@ export function createScriptFileSystem(
 ): ScriptFileSystem {
   const root = resolve(directory)
   return {
-    async writeFile(path, contents) {
-      const destination = await resolveFile(root, path, options)
-      await mkdir(dirname(destination), { recursive: true })
-      await writeFile(destination, contents)
-    },
+    writeFile: (path, contents) =>
+      Effect.tryPromise({
+        try: async () => {
+          const destination = await resolveFile(root, path, options)
+          await mkdir(dirname(destination), { recursive: true })
+          await writeFile(destination, contents)
+        },
+        catch: (cause) => cause instanceof Error ? cause : new Error(String(cause)),
+      }),
   }
 }
 

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect"
 import type {
   AutomaticScriptDefinition,
   ManualScriptDefinition,
@@ -12,8 +13,6 @@ export function defineScript(script: ScriptDefinition): ScriptDefinition {
   return script
 }
 
-export function wait(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds))
-}
+export const wait = (milliseconds: number) => Effect.sleep(milliseconds)
 
 export type * from "./types.js"

--- a/src/script/types.ts
+++ b/src/script/types.ts
@@ -1,3 +1,5 @@
+import type * as Effect from "effect/Effect"
+import type * as Stream from "effect/Stream"
 import type * as Llm from "../llm/index.js"
 import type * as Tool from "../tool/index.js"
 
@@ -19,7 +21,7 @@ export interface OpenCodeTuiConfig extends JsonObject {}
 
 export interface ScriptFileSystem {
   /** Writes inside the simulated project and creates parent directories. */
-  writeFile(path: string, contents: string | Uint8Array): Promise<void>
+  writeFile(path: string, contents: string | Uint8Array): Effect.Effect<void, Error>
 }
 
 export interface UiKeyModifiers {
@@ -98,46 +100,38 @@ export interface UiViewport {
   readonly rows: number
 }
 
-export type UiPredicate = (state: UiState) => boolean | Promise<boolean>
+export type UiPredicate = (
+  state: UiState,
+) => boolean | Effect.Effect<boolean, Error>
 
 export interface ScriptUi {
   /** Terminates this TUI. The client name may be launched again afterward. */
-  kill(): Promise<string | undefined>
-  state(): Promise<UiState>
-  matches(matcher: UiMatcher): Promise<boolean>
-  screenshot(name?: string): Promise<string>
+  kill(): Effect.Effect<string | undefined, unknown>
+  state(): Effect.Effect<UiState, unknown>
+  matches(matcher: UiMatcher): Effect.Effect<boolean, unknown>
+  screenshot(name?: string): Effect.Effect<string, unknown>
 
-  type(text: string): Promise<UiState>
-  press(key: string, modifiers?: UiKeyModifiers): Promise<UiState>
-  enter(): Promise<UiState>
-  arrow(direction: UiDirection): Promise<UiState>
-  focus(target: number | UiElement): Promise<UiState>
+  type(text: string): Effect.Effect<UiState, unknown>
+  press(key: string, modifiers?: UiKeyModifiers): Effect.Effect<UiState, unknown>
+  enter(): Effect.Effect<UiState, unknown>
+  arrow(direction: UiDirection): Effect.Effect<UiState, unknown>
+  focus(target: number | UiElement): Effect.Effect<UiState, unknown>
   /** Clicks the element center unless a local position is provided. */
-  click(target: number | UiElement, position?: UiPosition): Promise<UiState>
-  resize(viewport: UiViewport): Promise<UiState>
-  submit(text: string): Promise<UiState>
+  click(target: number | UiElement, position?: UiPosition): Effect.Effect<UiState, unknown>
+  resize(viewport: UiViewport): Effect.Effect<UiState, unknown>
+  submit(text: string): Effect.Effect<UiState, unknown>
 
-  waitFor(matcher: UiMatcher, options?: UiWaitOptions): Promise<UiState>
-  waitFor(predicate: UiPredicate, options?: UiWaitOptions): Promise<UiState>
+  waitFor(matcher: UiMatcher, options?: UiWaitOptions): Effect.Effect<UiState, unknown>
+  waitFor(predicate: UiPredicate, options?: UiWaitOptions): Effect.Effect<UiState, unknown>
   /** Waits for exactly one element matching a renderable number, id, or query. */
-  getElement(target: number, options?: UiWaitOptions): Promise<UiElement>
-  getElement(id: string, options?: UiWaitOptions): Promise<UiElement>
-  getElement(query: UiElementQuery, options?: UiWaitOptions): Promise<UiElement>
-}
-
-export interface LlmTextDelta {
-  readonly type: "textDelta"
-  readonly text: string
+  getElement(target: number, options?: UiWaitOptions): Effect.Effect<UiElement, unknown>
+  getElement(id: string, options?: UiWaitOptions): Effect.Effect<UiElement, unknown>
+  getElement(query: UiElementQuery, options?: UiWaitOptions): Effect.Effect<UiElement, unknown>
 }
 
 export type LlmStreamOptions = Llm.StreamOptions
 
 export type LlmText = Llm.Text
-
-export interface LlmReasoningDelta {
-  readonly type: "reasoningDelta"
-  readonly text: string
-}
 
 export type LlmReasoning = Llm.Reasoning
 
@@ -147,22 +141,14 @@ export type LlmToolCall = Llm.ToolCall
 
 export type LlmRawChunk = Llm.Raw
 
-export type LlmItem =
-  | LlmTextDelta
-  | LlmReasoningDelta
-  | LlmToolCall
-  | LlmRawChunk
-
 export type LlmFinishReason = Llm.FinishReason
 
 export type LlmFinish = Llm.Finish
 
 export type LlmDisconnect = Llm.Disconnect
 
-export type LlmOutput =
-  | Llm.Output
-  // Legacy scripts may still send protocol-level deltas directly.
-  | LlmItem
+export type LlmOutput = Llm.Output
+export type LlmItem = Llm.Output
 
 export interface LlmRequest {
   readonly id: string
@@ -170,7 +156,7 @@ export interface LlmRequest {
   readonly body: JsonValue
 }
 
-export type LlmResponse = Iterable<LlmOutput> | AsyncIterable<LlmOutput>
+export type LlmResponse = Stream.Stream<LlmOutput, unknown>
 
 export type LlmServeHandler = (
   request: LlmRequest,
@@ -180,17 +166,17 @@ export type LlmServeHandler = (
 export type LlmTitleHandler = (
   request: LlmRequest,
   index: number,
-) => string | Promise<string>
+) => Effect.Effect<string, unknown>
 
 export interface ScriptLlm {
   /** Queues one response composed of these chunks and terminal events. */
-  queue(...output: ReadonlyArray<LlmOutput>): void
+  queue(...output: ReadonlyArray<LlmOutput>): Effect.Effect<void, unknown>
   /** Waits for the next request and resolves after its response is accepted. */
-  send(...output: ReadonlyArray<LlmOutput>): Promise<void>
+  send(...output: ReadonlyArray<LlmOutput>): Effect.Effect<void, unknown>
   /** Generates a response for every LLM request until the script ends. */
-  serve(handler: LlmServeHandler): void
+  serve(handler: LlmServeHandler): Effect.Effect<void, unknown>
   /** Overrides the default response for background title requests. */
-  title(handler: LlmTitleHandler): void
+  title(handler: LlmTitleHandler): Effect.Effect<void, unknown>
 
   text(text: string, options?: LlmStreamOptions): LlmText
   reasoning(text: string, options?: LlmStreamOptions): LlmReasoning
@@ -225,7 +211,7 @@ export interface ScriptProject {
 
 export interface ScriptClients {
   /** Launches a headless TUI connected to this script's shared service. */
-  launch(name: string, options?: ScriptClientOptions): Promise<ScriptUi>
+  launch(name: string, options?: ScriptClientOptions): Effect.Effect<ScriptUi, unknown>
 }
 
 export interface ScriptClientOptions {
@@ -237,9 +223,9 @@ export interface ScriptClientOptions {
 
 export interface ScriptServer {
   /** Launches the one shared OpenCode server for this script. */
-  launch(): Promise<void>
+  launch(): Effect.Effect<void, unknown>
   /** Stops the shared server. It may be launched again afterward. */
-  kill(): Promise<void>
+  kill(): Effect.Effect<void, unknown>
 }
 
 export interface ScriptContext {
@@ -249,7 +235,6 @@ export interface ScriptContext {
   readonly server: ScriptServer
   readonly llm: ScriptLlm
   readonly artifacts: string
-  readonly signal: AbortSignal
 }
 
 export interface ManualScriptContext extends Omit<ScriptContext, "ui"> {
@@ -258,12 +243,12 @@ export interface ManualScriptContext extends Omit<ScriptContext, "ui"> {
 
 export type ScriptSetup = (
   context: ScriptSetupContext,
-) => void | Promise<void>
+) => Effect.Effect<void, unknown>
 
-export type ScriptRun = (context: ScriptContext) => void | Promise<void>
+export type ScriptRun = (context: ScriptContext) => Effect.Effect<void, unknown>
 export type ManualScriptRun = (
   context: ManualScriptContext,
-) => void | Promise<void>
+) => Effect.Effect<void, unknown>
 
 export interface AutomaticScriptDefinition {
   /** Declares the isolated project OpenCode runs against. */

--- a/src/tool/controller.ts
+++ b/src/tool/controller.ts
@@ -66,10 +66,20 @@ export function composeSetup(
   setup: ScriptSetup | undefined,
 ): ScriptSetup | undefined {
   if (tools === undefined && setup === undefined) return undefined
-  return async (context) => {
-    await setup?.(context)
-    controller.configure(context.config)
-  }
+  return (context) =>
+    Effect.suspend(() => {
+      const configured: unknown = setup?.(context) ?? Effect.void
+      if (!isEffect(configured))
+        return Effect.fail(new Error("script setup must return an Effect"))
+      return configured.pipe(
+        Effect.asVoid,
+        Effect.andThen(Effect.sync(() => controller.configure(context.config))),
+      )
+    })
+}
+
+function isEffect(value: unknown): value is Effect.Effect<unknown, unknown> {
+  return Effect.isEffect(value)
 }
 
 export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {

--- a/test/cli/integration.test.ts
+++ b/test/cli/integration.test.ts
@@ -761,7 +761,7 @@ describe("opencode-drive", () => {
     await mkdir(directory, { recursive: true })
     await Bun.write(
       join(directory, "valid.ts"),
-      'import { defineScript, wait } from "opencode-drive"\nexport default defineScript({ project: { git: true, files: { "src/index.ts": "export {}\\n" } }, async run() { await wait(1) } })\n',
+      'import { defineScript, wait } from "opencode-drive"\nexport default defineScript({ project: { git: true, files: { "src/index.ts": "export {}\\n" } }, run: () => wait(1) })\n',
     )
     const checked = spawn(["check", join(directory, "valid.ts")], root)
     expect(await checked.exited).toBe(0)
@@ -772,9 +772,7 @@ describe("opencode-drive", () => {
     await Bun.write(join(directory, "invalid.ts"), 'import { wait } from "opencode-drive"\nwait("wrong")\n')
     const invalid = spawn(["check", join(directory, "invalid.ts")], root)
     expect(await invalid.exited).toBe(1)
-    expect(await new Response(invalid.stdout).text()).toContain(
-      "Argument of type 'string' is not assignable to parameter of type 'number'",
-    )
+    expect(await new Response(invalid.stdout).text()).toContain("is not assignable to parameter of type")
   }, 60_000)
 
   test("launches all clients explicitly for a manual UI script", async () => {
@@ -868,6 +866,57 @@ describe("opencode-drive", () => {
     expect(await new Response(child.stderr).text()).toContain(
       "script must default-export defineScript({ project?, setup?, run })",
     )
+  })
+
+  test.each(["setup", "run"] as const)("rejects a Promise-returning script %s callback", async (callback) => {
+    const root = await temporary()
+    const script = join(root, `promise-${callback}-script.js`)
+    const drive = JSON.stringify(resolve("src/index.ts"))
+    await Bun.write(
+      script,
+      callback === "setup"
+        ? `import { Effect } from "effect"\nimport { defineScript } from ${drive}\nexport default defineScript({ setup: async () => {}, run: () => Effect.void })\n`
+        : `import { defineScript } from ${drive}\nexport default defineScript({ run: async () => {} })\n`,
+    )
+    const child = spawn(
+      [
+        "start",
+        "--name",
+        `promise-${callback}-script-test`,
+        "--script",
+        script,
+        "--",
+        process.execPath,
+        fixture("fake-opencode.ts"),
+      ],
+      root,
+    )
+    expect(await child.exited).toBe(1)
+    expect(await new Response(child.stderr).text()).toContain(`script ${callback} must return an Effect`)
+  })
+
+  test("rejects a Promise-returning UI predicate", async () => {
+    const root = await temporary()
+    const script = join(root, "promise-predicate-script.js")
+    await Bun.write(
+      script,
+      `import { defineScript } from ${JSON.stringify(resolve("src/index.ts"))}\nexport default defineScript({ run: ({ ui }) => ui.waitFor(() => Promise.resolve(false)) })\n`,
+    )
+    const child = spawn(
+      [
+        "start",
+        "--name",
+        "promise-predicate-script-test",
+        "--script",
+        script,
+        "--",
+        process.execPath,
+        fixture("fake-opencode.ts"),
+      ],
+      root,
+    )
+    expect(await child.exited).toBe(1)
+    expect(await new Response(child.stderr).text()).toContain("ui.waitFor predicate must return a boolean or Effect")
   })
 
   test("stops a visible instance after a script completes", async () => {
@@ -1047,7 +1096,7 @@ describe("opencode-drive", () => {
     const marker = join(root, "script-interrupted")
     await Bun.write(
       script,
-      `import { defineScript } from ${JSON.stringify(resolve("src/index.ts"))}\nexport default defineScript({ async run({ signal, artifacts }) { await new Promise<void>((resolve) => signal.addEventListener("abort", () => { void (async () => { const pid = Number(await Bun.file(artifacts + "/child.pid").text()); let running = true; try { process.kill(pid, 0) } catch { running = false }; await Bun.write(${JSON.stringify(marker)}, running ? "child-running\\n" : "child-stopped\\n"); resolve() })() }, { once: true })) } })\n`,
+      `import { Effect } from "effect"\nimport { defineScript } from ${JSON.stringify(resolve("src/index.ts"))}\nexport default defineScript({ run: ({ artifacts }) => Effect.never.pipe(Effect.ensuring(Effect.promise(async () => { const pid = Number(await Bun.file(artifacts + "/child.pid").text()); let running = true; try { process.kill(pid, 0) } catch { running = false }; await Bun.write(${JSON.stringify(marker)}, running ? "child-running\\n" : "child-stopped\\n") }))) })\n`,
     )
     const child = spawn(
       [

--- a/test/fixtures/caught-timeout-script.ts
+++ b/test/fixtures/caught-timeout-script.ts
@@ -1,11 +1,15 @@
 import { defineScript, wait } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
-  async run({ ui }) {
-    try {
-      await ui.waitFor("this text never appears", { timeout: 50 })
-    } catch {
-      await wait(30_000)
-    }
-  },
+  run: ({ ui }) =>
+    Effect.gen(function* () {
+      yield* Effect.matchEffect(
+        ui.waitFor("this text never appears", { timeout: 50 }),
+        {
+          onFailure: () => wait(30_000),
+          onSuccess: Effect.succeed,
+        },
+      )
+    }),
 })

--- a/test/fixtures/crashing-script.ts
+++ b/test/fixtures/crashing-script.ts
@@ -1,12 +1,14 @@
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
-  async run() {
-    Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch: () => new Response("leaked script server"),
-    })
-    throw new Error("script crashed")
-  },
+  run: () =>
+    Effect.gen(function* () {
+      Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => new Response("leaked script server"),
+      })
+      yield* Effect.fail(new Error("script crashed"))
+    }),
 })

--- a/test/fixtures/hanging-script.ts
+++ b/test/fixtures/hanging-script.ts
@@ -1,9 +1,8 @@
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
-  async run({ signal }) {
-    await new Promise<void>((resolve) => {
-      signal.addEventListener("abort", () => resolve(), { once: true })
-    })
-  },
+  run: () => Effect.gen(function* () {
+    yield* Effect.never
+  }),
 })

--- a/test/fixtures/kill-primary-script.ts
+++ b/test/fixtures/kill-primary-script.ts
@@ -1,14 +1,15 @@
 import { defineScript } from "opencode-drive"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 
 export default defineScript({
-  async run({ ui }) {
-    await ui.kill()
-    let closed = false
-    try {
-      await ui.state()
-    } catch {
-      closed = true
-    }
-    if (!closed) throw new Error("primary client remained connected after ui.kill()")
-  },
+  run: ({ ui }) =>
+    Effect.gen(function* () {
+      yield* Effect.exit(ui.kill())
+      const closed = Exit.isFailure(yield* Effect.exit(ui.state()))
+      if (!closed)
+        yield* Effect.fail(
+          new Error("primary client remained connected after ui.kill()"),
+        )
+    }),
 })

--- a/test/fixtures/kill-server-script.ts
+++ b/test/fixtures/kill-server-script.ts
@@ -1,34 +1,51 @@
 import { defineScript, wait } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
   launch: "manual",
-  async run({ server, clients, artifacts }) {
-    await server.launch()
-    const firstServer = Number(await Bun.file(`${artifacts}/service.pid`).text())
-    const [alice, bob] = await Promise.all([
-      clients.launch("alice", { record: true }),
-      clients.launch("bob", { record: true }),
-    ])
+  run: ({ server, clients, artifacts }) =>
+    Effect.gen(function* () {
+      yield* server.launch()
+      const firstServer = Number(
+        yield* Effect.tryPromise(() =>
+          Bun.file(`${artifacts}/service.pid`).text(),
+        ),
+      )
+      const [alice] = yield* Effect.all(
+        [
+          clients.launch("alice", { record: true }),
+          clients.launch("bob", { record: true }),
+        ],
+        { concurrency: "unbounded" },
+      )
 
-    await server.kill()
-    for (let attempt = 0; attempt < 100 && running(firstServer); attempt++)
-      await wait(10)
-    if (running(firstServer)) throw new Error("the first server is still running")
+      yield* server.kill()
+      for (let attempt = 0; attempt < 100 && running(firstServer); attempt++)
+        yield* wait(10)
+      if (running(firstServer))
+        return yield* Effect.fail(new Error("the first server is still running"))
 
-    await server.launch()
-    const secondServer = Number(await Bun.file(`${artifacts}/service.pid`).text())
-    if (secondServer === firstServer) throw new Error("the server was not relaunched")
+      yield* server.launch()
+      const secondServer = Number(
+        yield* Effect.tryPromise(() =>
+          Bun.file(`${artifacts}/service.pid`).text(),
+        ),
+      )
+      if (secondServer === firstServer)
+        return yield* Effect.fail(new Error("the server was not relaunched"))
 
-    const aliceRecording = await alice.kill()
-    const relaunchedAlice = await clients.launch("alice")
-    await relaunchedAlice.kill()
-    await server.kill()
+      const aliceRecording = yield* alice.kill()
+      const relaunchedAlice = yield* clients.launch("alice")
+      yield* relaunchedAlice.kill()
+      yield* server.kill()
 
-    await Bun.write(
-      `${artifacts}/kill-server-result.json`,
-      JSON.stringify({ firstServer, secondServer, aliceRecording }),
-    )
-  },
+      yield* Effect.tryPromise(() =>
+        Bun.write(
+          `${artifacts}/kill-server-result.json`,
+          JSON.stringify({ firstServer, secondServer, aliceRecording }),
+        ),
+      )
+    }),
 })
 
 function running(pid: number) {

--- a/test/fixtures/manual-clients-script.ts
+++ b/test/fixtures/manual-clients-script.ts
@@ -1,41 +1,55 @@
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
   launch: "manual",
-  async run({ ui, server, clients, artifacts }) {
-    if (ui !== null) throw new Error("manual scripts must not receive a default UI")
-    const clientBeforeServer = await clients
-      .launch("too-early")
-      .then(() => "unexpected success")
-      .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
-    await server.launch()
-    const duplicateServer = await server
-      .launch()
-      .then(() => "unexpected success")
-      .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
-    const [alice, bob] = await Promise.all([
-      clients.launch("alice"),
-      clients.launch("bob"),
-    ])
-    await alice.submit("from alice")
-    await bob.submit("from bob")
-    const [aliceMatches, bobMatches, aliceScreenshot, bobScreenshot] =
-      await Promise.all([
+  run: ({ ui, server, clients, artifacts }) =>
+    Effect.gen(function* () {
+      if (ui !== null)
+        return yield* Effect.fail(
+          new Error("manual scripts must not receive a default UI"),
+        )
+      const clientBeforeServer = yield* Effect.matchEffect(
+        clients.launch("too-early"),
+        {
+          onFailure: (error) => Effect.succeed(errorMessage(error)),
+          onSuccess: () => Effect.succeed("unexpected success"),
+        },
+      )
+      yield* server.launch()
+      const duplicateServer = yield* Effect.matchEffect(server.launch(), {
+        onFailure: (error) => Effect.succeed(errorMessage(error)),
+        onSuccess: () => Effect.succeed("unexpected success"),
+      })
+      const [alice, bob] = yield* Effect.all(
+        [clients.launch("alice"), clients.launch("bob")],
+        { concurrency: "unbounded" },
+      )
+      yield* alice.submit("from alice")
+      yield* bob.submit("from bob")
+      const [aliceMatches, bobMatches, aliceScreenshot, bobScreenshot] =
+        yield* Effect.all([
         alice.matches("client-alice"),
         bob.matches("client-bob"),
         alice.screenshot("alice"),
         bob.screenshot("bob"),
-      ])
-    await Bun.write(
-      `${artifacts}/manual-clients.json`,
-      JSON.stringify({
-        aliceMatches,
-        bobMatches,
-        clientBeforeServer,
-        duplicateServer,
-        aliceScreenshot,
-        bobScreenshot,
-      }),
-    )
-  },
+        ], { concurrency: "unbounded" })
+      yield* Effect.tryPromise(() =>
+        Bun.write(
+          `${artifacts}/manual-clients.json`,
+          JSON.stringify({
+            aliceMatches,
+            bobMatches,
+            clientBeforeServer,
+            duplicateServer,
+            aliceScreenshot,
+            bobScreenshot,
+          }),
+        ),
+      )
+    }),
 })
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/test/fixtures/prepared-git-script.ts
+++ b/test/fixtures/prepared-git-script.ts
@@ -1,24 +1,35 @@
 import { join } from "node:path"
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 let setupGitError: string | undefined
 
 export default defineScript({
   launch: "manual",
-  async setup({ fs }) {
-    setupGitError = await fs
-      .writeFile(".GIT/config", "setup must not replace Git metadata\n")
-      .then(() => undefined)
-      .catch((error: unknown) => String(error))
-  },
-  async run({ artifacts, fs }) {
-    const runGitError = await fs
-      .writeFile(".GIT/config", "run must not replace Git metadata\n")
-      .then(() => undefined)
-      .catch((error: unknown) => String(error))
-    await Bun.write(
-      join(artifacts, "prepared-git-result.json"),
-      `${JSON.stringify({ runGitError, setupGitError }, undefined, 2)}\n`,
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      setupGitError = yield* Effect.matchEffect(
+        fs.writeFile(".GIT/config", "setup must not replace Git metadata\n"),
+        {
+          onFailure: (error) => Effect.succeed(String(error)),
+          onSuccess: () => Effect.succeed(undefined),
+        },
+      )
+    }),
+  run: ({ artifacts, fs }) =>
+    Effect.gen(function* () {
+      const runGitError = yield* Effect.matchEffect(
+        fs.writeFile(".GIT/config", "run must not replace Git metadata\n"),
+        {
+          onFailure: (error) => Effect.succeed(String(error)),
+          onSuccess: () => Effect.succeed(undefined),
+        },
+      )
+      yield* Effect.tryPromise(() =>
+        Bun.write(
+          join(artifacts, "prepared-git-result.json"),
+          `${JSON.stringify({ runGitError, setupGitError }, undefined, 2)}\n`,
+        ),
+      )
+    }),
 })

--- a/test/fixtures/restart-script.ts
+++ b/test/fixtures/restart-script.ts
@@ -1,20 +1,20 @@
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 
 export default defineScript({
-  async run({ artifacts, llm, signal }) {
-    llm.serve(async function* () {
-      await Bun.sleep(500)
-      yield llm.text("late response")
-    })
-    const file = `${artifacts}/script-runs.txt`
-    await Bun.write(
-      file,
-      `${await Bun.file(file)
-        .text()
-        .catch(() => "")}run\n`,
-    )
-    await new Promise<void>((resolve) => {
-      signal.addEventListener("abort", () => resolve(), { once: true })
-    })
-  },
+  run: ({ artifacts, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.serve(() =>
+        Stream.fromEffect(
+          Effect.sleep(500).pipe(Effect.as(llm.text("late response"))),
+        ),
+      )
+      const file = `${artifacts}/script-runs.txt`
+      const previous = yield* Effect.promise(() =>
+        Bun.file(file).text().catch(() => ""),
+      )
+      yield* Effect.tryPromise(() => Bun.write(file, `${previous}run\n`))
+      yield* Effect.never
+    }),
 })

--- a/test/fixtures/script.ts
+++ b/test/fixtures/script.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path"
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
   config: {
@@ -14,30 +15,38 @@ export default defineScript({
       "src/seeded.ts": "export const seeded = true\n",
     },
   },
-  async setup({ fs, config, tui }) {
-    config.autoupdate = false
-    config.test = { ...config.test as Record<string, boolean>, setup: true }
-    tui.test = { ...tui.test as Record<string, boolean>, setup: true }
-    await fs.writeFile("setup-seeded.txt", "included in baseline\n")
-  },
+  setup: ({ fs, config, tui }) =>
+    Effect.gen(function* () {
+      config.autoupdate = false
+      config.test = { ...config.test as Record<string, boolean>, setup: true }
+      tui.test = { ...tui.test as Record<string, boolean>, setup: true }
+      yield* fs.writeFile("setup-seeded.txt", "included in baseline\n")
+    }),
 
-  async run({ artifacts, fs, llm, ui }) {
-    const gitWriteError = await fs
-      .writeFile(".GIT/config", "no")
-      .then(() => undefined)
-      .catch((error: unknown) => String(error))
-    const editor = await ui.getElement(1)
-    await ui.focus(editor)
-    await ui.click(editor)
-    await ui.submit("script-text")
-    await llm.send(llm.text("script response", { delay: 0, chunkSize: 3 }))
-    const matches = await ui.matches("script-text")
-    await ui.waitFor("script-text")
-    await ui.screenshot("script-shot")
-    const state = await ui.state()
-    await Bun.write(
-      join(artifacts, "script-result.json"),
-      `${JSON.stringify({ focused: state.focused, gitWriteError, matches }, undefined, 2)}\n`,
-    )
-  },
+  run: ({ artifacts, fs, llm, ui }) =>
+    Effect.gen(function* () {
+      const gitWriteError = yield* Effect.matchEffect(
+        fs.writeFile(".GIT/config", "no"),
+        {
+          onFailure: (error) => Effect.succeed(String(error)),
+          onSuccess: () => Effect.succeed(undefined),
+        },
+      )
+      yield* ui.waitFor((state) => Effect.succeed(state.focused.editor))
+      const editor = yield* ui.getElement(1)
+      yield* ui.focus(editor)
+      yield* ui.click(editor)
+      yield* ui.submit("script-text")
+      yield* llm.send(llm.text("script response", { delay: 0, chunkSize: 3 }))
+      const matches = yield* ui.matches("script-text")
+      yield* ui.waitFor("script-text")
+      yield* ui.screenshot("script-shot")
+      const state = yield* ui.state()
+      yield* Effect.tryPromise(() =>
+        Bun.write(
+          join(artifacts, "script-result.json"),
+          `${JSON.stringify({ focused: state.focused, gitWriteError, matches }, undefined, 2)}\n`,
+        ),
+      )
+    }),
 })

--- a/test/fixtures/serve-script.ts
+++ b/test/fixtures/serve-script.ts
@@ -1,15 +1,20 @@
 import { defineScript } from "../../src/index.js"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 
 export default defineScript({
-  async run({ llm }) {
-    const completed = Promise.withResolvers<void>()
-    llm.serve(async function* () {
-      yield llm.reasoning("thinking", { delay: 0, chunkSize: 2 })
-      yield llm.pause(1)
-      yield llm.text("served response")
-      yield llm.finish("length")
-      completed.resolve()
-    })
-    await completed.promise
-  },
+  run: ({ llm }) =>
+    Effect.gen(function* () {
+      const completed = yield* Deferred.make<void>()
+      yield* llm.serve(() =>
+        Stream.make(
+          llm.reasoning("thinking", { delay: 0, chunkSize: 2 }),
+          llm.pause(1),
+          llm.text("served response"),
+          llm.finish("length"),
+        ).pipe(Stream.onEnd(Deferred.succeed(completed, undefined))),
+      )
+      yield* Deferred.await(completed)
+    }),
 })

--- a/test/fixtures/title-script.ts
+++ b/test/fixtures/title-script.ts
@@ -1,10 +1,12 @@
 import { defineScript } from "../../src/index.js"
+import * as Effect from "effect/Effect"
 
 export default defineScript({
   launch: "manual",
-  async run({ server, llm }) {
-    llm.title(() => "Custom title")
-    await server.launch()
-    await llm.send(llm.text("Normal response"))
-  },
+  run: ({ server, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.title(() => Effect.succeed("Custom title"))
+      yield* server.launch()
+      yield* llm.send(llm.text("Normal response"))
+    }),
 })

--- a/test/instance/config.test.ts
+++ b/test/instance/config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest"
 import { rm } from "node:fs/promises"
 import { join } from "node:path"
+import * as Effect from "effect/Effect"
 import {
   initializeInstance,
   prepareInstanceProject,
@@ -20,7 +21,7 @@ describe("instance configuration", () => {
   test("merges JSONC fixtures, replaces arrays, applies setup last, and commits normalized files", async () => {
     const root = await initializeInstance()
     artifacts.push(root)
-    await prepareInstanceProject({
+    await Effect.runPromise(prepareInstanceProject({
       artifacts: root,
       project: {
         git: true,
@@ -45,13 +46,15 @@ describe("instance configuration", () => {
         items: ["declared"],
       },
       setup({ config, tui }) {
-        config.nested = {
-          ...(config.nested as Record<string, boolean | string>),
-          winner: "setup",
-        }
-        tui.items = ["setup"]
+        return Effect.sync(() => {
+          config.nested = {
+            ...(config.nested as Record<string, boolean | string>),
+            winner: "setup",
+          }
+          tui.items = ["setup"]
+        })
       },
-    })
+    }))
 
     const files = join(root, "files")
     const configText = await Bun.file(
@@ -77,12 +80,12 @@ describe("instance configuration", () => {
     const root = await initializeInstance()
     artifacts.push(root)
     await expect(
-      prepareInstanceProject({
+      Effect.runPromise(prepareInstanceProject({
         artifacts: root,
         project: {
           files: { ".opencode/tui.jsonc": "{ invalid" },
         },
-      }),
+      })),
     ).rejects.toThrow("invalid .opencode/tui.jsonc")
   })
 
@@ -92,25 +95,53 @@ describe("instance configuration", () => {
     const config = { nested: { value: "declared" }, items: ["declared"] }
     const tui = { keybinds: { app_exit: "ctrl+q" } }
 
-    await prepareInstanceProject({
+    await Effect.runPromise(prepareInstanceProject({
       artifacts: root,
       config,
       tui,
       setup({ config, tui }) {
-        const nested = config.nested as Record<string, string>
-        const items = config.items as Array<string>
-        const keybinds = tui.keybinds as Record<string, string>
-        nested.value = "setup"
-        items.push("setup")
-        keybinds.app_exit = "ctrl+x"
+        return Effect.sync(() => {
+          const nested = config.nested as Record<string, string>
+          const items = config.items as Array<string>
+          const keybinds = tui.keybinds as Record<string, string>
+          nested.value = "setup"
+          items.push("setup")
+          keybinds.app_exit = "ctrl+x"
+        })
       },
-    })
+    }))
 
     expect(config).toEqual({
       nested: { value: "declared" },
       items: ["declared"],
     })
     expect(tui).toEqual({ keybinds: { app_exit: "ctrl+q" } })
+  })
+
+  test("interrupts setup with project preparation", async () => {
+    const root = await initializeInstance()
+    artifacts.push(root)
+    const started = Promise.withResolvers<void>()
+    let finalized = false
+    const controller = new AbortController()
+    const prepared = Effect.runPromise(
+      prepareInstanceProject({
+        artifacts: root,
+        setup: () =>
+          Effect.sync(() => started.resolve()).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Effect.sync(() => {
+              finalized = true
+            })),
+          ),
+      }),
+      { signal: controller.signal },
+    )
+
+    await started.promise
+    controller.abort()
+    await expect(prepared).rejects.toThrow()
+    expect(finalized).toBe(true)
   })
 })
 

--- a/test/manual/session-switching.ts
+++ b/test/manual/session-switching.ts
@@ -1,96 +1,109 @@
 import { defineScript, type ScriptUi } from "../../src/index.js"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 
 export default defineScript({
-  async setup({ fs }) {
-    await fs.writeFile(
-      "src/garden.ts",
-      [
-        "export const flowers = [\"aster\", \"dahlia\", \"iris\"]",
-        "export const count = flowers.length",
-        "",
-      ].join("\n"),
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      yield* fs.writeFile(
+        "src/garden.ts",
+        [
+          "export const flowers = [\"aster\", \"dahlia\", \"iris\"]",
+          "export const count = flowers.length",
+          "",
+        ].join("\n"),
+      )
+    }),
 
-  async run({ llm, ui }) {
-    let phase = 0
-    let title = 0
+  run: ({ llm, ui }) =>
+    Effect.gen(function* () {
+      let phase = 0
+      let title = 0
 
-    llm.serve(async function* (request) {
-      if (isTitleRequest(request.body)) {
-        yield llm.text(title++ === 0 ? "Garden inventory" : "Project follow-up")
-        return
-      }
+      yield* llm.serve((request) => {
+        if (isTitleRequest(request.body)) {
+          return Stream.make(
+            llm.text(title++ === 0 ? "Garden inventory" : "Project follow-up"),
+          )
+        }
 
-      if (phase === 0) {
-        phase++
-        yield llm.reasoning("I should read the source before answering.")
-        yield llm.toolCall({
-          index: 0,
-          id: "call_read_garden",
-          name: "read",
-          input: { filePath: "src/garden.ts" },
-        })
-        yield llm.finish("tool-calls")
-        return
-      }
-      if (phase === 1) {
-        phase++
-        yield llm.text(
-          "Session one complete: the garden contains aster, dahlia, and iris.",
+        if (phase === 0) {
+          phase++
+          return Stream.make(
+            llm.reasoning("I should read the source before answering."),
+            llm.toolCall({
+              index: 0,
+              id: "call_read_garden",
+              name: "read",
+              input: { filePath: "src/garden.ts" },
+            }),
+            llm.finish("tool-calls"),
+          )
+        }
+        if (phase === 1) {
+          phase++
+          return Stream.make(
+            llm.text(
+              "Session one complete: the garden contains aster, dahlia, and iris.",
+            ),
+          )
+        }
+        if (phase === 2) {
+          phase++
+          return Stream.make(
+            llm.reasoning("I will search for the exported count."),
+            llm.toolCall({
+              index: 0,
+              id: "call_grep_count",
+              name: "grep",
+              input: { pattern: "count", path: "src", include: "*.ts" },
+            }),
+            llm.finish("tool-calls"),
+          )
+        }
+        if (phase === 3) {
+          phase++
+          return Stream.make(
+            llm.text(
+              "Session two complete: the project exports count from src/garden.ts.",
+            ),
+          )
+        }
+
+        return Stream.make(
+          llm.text("Back in session one: there are exactly three flowers."),
         )
-        return
-      }
-      if (phase === 2) {
-        phase++
-        yield llm.reasoning("I will search for the exported count.")
-        yield llm.toolCall({
-          index: 0,
-          id: "call_grep_count",
-          name: "grep",
-          input: { pattern: "count", path: "src", include: "*.ts" },
-        })
-        yield llm.finish("tool-calls")
-        return
-      }
-      if (phase === 3) {
-        phase++
-        yield llm.text("Session two complete: the project exports count from src/garden.ts.")
-        return
-      }
+      })
 
-      yield llm.text("Back in session one: there are exactly three flowers.")
-    })
+      yield* ui.submit("Read src/garden.ts and list every flower.")
+      yield* ui.waitFor("Session one complete", { timeout: 20_000 })
+      yield* ui.screenshot("sessions-first")
 
-    await ui.submit("Read src/garden.ts and list every flower.")
-    await ui.waitFor("Session one complete", { timeout: 20_000 })
-    await ui.screenshot("sessions-first")
+      yield* leader(ui, "n")
+      yield* ui.waitFor((state) => state.focused.editor)
+      yield* ui.submit("Find where the project exports count.")
+      yield* ui.waitFor("Session two complete", { timeout: 20_000 })
+      yield* ui.screenshot("sessions-second")
 
-    await leader(ui, "n")
-    await ui.waitFor((state) => state.focused.editor)
-    await ui.submit("Find where the project exports count.")
-    await ui.waitFor("Session two complete", { timeout: 20_000 })
-    await ui.screenshot("sessions-second")
+      yield* leader(ui, "l")
+      yield* ui.waitFor("Sessions")
+      yield* ui.arrow("down")
+      yield* ui.enter()
+      yield* ui.waitFor("Session one complete")
 
-    await leader(ui, "l")
-    await ui.waitFor("Sessions")
-    await ui.arrow("down")
-    await ui.enter()
-    await ui.waitFor("Session one complete")
-
-    await ui.submit("How many flowers were there?")
-    await ui.waitFor("exactly three flowers", { timeout: 20_000 })
-    await ui.screenshot("sessions-returned")
-  },
+      yield* ui.submit("How many flowers were there?")
+      yield* ui.waitFor("exactly three flowers", { timeout: 20_000 })
+      yield* ui.screenshot("sessions-returned")
+    }),
 })
 
-async function leader(
+const leader = Effect.fn("leader")(function* (
   ui: ScriptUi,
   key: string,
 ) {
-  await ui.press("x", { ctrl: true })
-  await ui.press(key)
-}
+  yield* ui.press("x", { ctrl: true })
+  yield* ui.press(key)
+})
 
 function isTitleRequest(body: unknown) {
   return JSON.stringify(body).includes("title generator")

--- a/test/manual/subagents.ts
+++ b/test/manual/subagents.ts
@@ -1,97 +1,110 @@
 import { defineScript, type JsonValue, type ScriptUi } from "../../src/index.js"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 
 export default defineScript({
-  async setup({ fs }) {
-    await fs.writeFile(
-      "src/ledger.ts",
-      [
-        "export const credits = [8, 13, 21]",
-        "export const total = credits.reduce((sum, value) => sum + value, 0)",
-        "",
-      ].join("\n"),
-    )
-  },
+  setup: ({ fs }) =>
+    Effect.gen(function* () {
+      yield* fs.writeFile(
+        "src/ledger.ts",
+        [
+          "export const credits = [8, 13, 21]",
+          "export const total = credits.reduce((sum, value) => sum + value, 0)",
+          "",
+        ].join("\n"),
+      )
+    }),
 
-  async run({ llm, ui }) {
-    let phase = 0
+  run: ({ llm, ui }) =>
+    Effect.gen(function* () {
+      let phase = 0
 
-    llm.serve(async function* (request) {
-      if (isTitleRequest(request.body)) {
-        yield llm.text("Delegating ledger checks")
-        return
-      }
+      yield* llm.serve((request) => {
+        if (isTitleRequest(request.body)) {
+          return Stream.make(llm.text("Delegating ledger checks"))
+        }
 
-      if (phase === 0 || phase === 3) {
-        const tool = subagentTool(request.body)
-        const first = phase === 0
+        if (phase === 0 || phase === 3) {
+          const tool = subagentTool(request.body)
+          const first = phase === 0
+          phase++
+          return Stream.make(
+            llm.reasoning(
+              first
+                ? "I will delegate repository inspection to an explore agent."
+                : "I will ask a general agent to independently verify the result.",
+            ),
+            llm.toolCall({
+              index: 0,
+              id: first ? "call_explore_ledger" : "call_verify_ledger",
+              name: tool,
+              input: subagentInput(
+                tool,
+                first ? "Explore the ledger" : "Verify the total",
+                first
+                  ? "Read src/ledger.ts and report its exports and values."
+                  : "Independently calculate the total exported by src/ledger.ts.",
+                first ? "explore" : "general",
+              ),
+            }),
+            llm.finish("tool-calls"),
+          )
+        }
+
+        if (phase === 1) {
+          phase++
+          return Stream.make(
+            llm.text(
+              "The ledger exports credits containing 8, 13, and 21, plus a computed total.",
+            ),
+          )
+        }
+        if (phase === 2) {
+          phase++
+          return Stream.make(
+            llm.text(
+              "First delegation complete: the explore agent inspected the ledger.",
+            ),
+          )
+        }
+        if (phase === 4) {
+          phase++
+          return Stream.make(
+            llm.text("The independent calculation is 8 + 13 + 21 = 42."),
+          )
+        }
+
         phase++
-        yield llm.reasoning(
-          first
-            ? "I will delegate repository inspection to an explore agent."
-            : "I will ask a general agent to independently verify the result.",
-        )
-        yield llm.toolCall({
-          index: 0,
-          id: first ? "call_explore_ledger" : "call_verify_ledger",
-          name: tool,
-          input: subagentInput(
-            tool,
-            first ? "Explore the ledger" : "Verify the total",
-            first
-              ? "Read src/ledger.ts and report its exports and values."
-              : "Independently calculate the total exported by src/ledger.ts.",
-            first ? "explore" : "general",
+        return Stream.make(
+          llm.text(
+            "Second delegation complete: the general agent confirmed total 42.",
           ),
-        })
-        yield llm.finish("tool-calls")
-        return
-      }
-
-      if (phase === 1) {
-        phase++
-        yield llm.text(
-          "The ledger exports credits containing 8, 13, and 21, plus a computed total.",
         )
-        return
-      }
-      if (phase === 2) {
-        phase++
-        yield llm.text("First delegation complete: the explore agent inspected the ledger.")
-        return
-      }
-      if (phase === 4) {
-        phase++
-        yield llm.text("The independent calculation is 8 + 13 + 21 = 42.")
-        return
-      }
+      })
 
-      phase++
-      yield llm.text("Second delegation complete: the general agent confirmed total 42.")
-    })
+      yield* ui.submit("Use an explore subagent to inspect src/ledger.ts.")
+      yield* ui.waitFor("First delegation complete", { timeout: 30_000 })
+      yield* Effect.sleep(250)
+      yield* ui.screenshot("subagents-first-complete")
 
-    await ui.submit("Use an explore subagent to inspect src/ledger.ts.")
-    await ui.waitFor("First delegation complete", { timeout: 30_000 })
-    await Bun.sleep(250)
-    await ui.screenshot("subagents-first-complete")
+      yield* openSubagents(ui)
+      yield* ui.waitFor("Subagents")
+      yield* ui.enter()
+      yield* ui.screenshot("subagents-child")
+      yield* ui.press("escape")
+      yield* ui.waitFor("First delegation complete")
 
-    await openSubagents(ui)
-    await ui.waitFor("Subagents")
-    await ui.enter()
-    await ui.screenshot("subagents-child")
-    await ui.press("escape")
-    await ui.waitFor("First delegation complete")
-
-    await ui.submit("Now use a general subagent to verify the total independently.")
-    await ui.waitFor("Second delegation complete", { timeout: 30_000 })
-    await Bun.sleep(250)
-    await ui.screenshot("subagents-second-complete")
-  },
+      yield* ui.submit("Now use a general subagent to verify the total independently.")
+      yield* ui.waitFor("Second delegation complete", { timeout: 30_000 })
+      yield* Effect.sleep(250)
+      yield* ui.screenshot("subagents-second-complete")
+    }),
 })
 
-async function openSubagents(ui: ScriptUi) {
-  await ui.press("x", { ctrl: true })
-  await ui.arrow("down")
-}
+const openSubagents = Effect.fn("openSubagents")(function* (ui: ScriptUi) {
+  yield* ui.press("x", { ctrl: true })
+  yield* ui.arrow("down")
+})
 
 function subagentTool(body: JsonValue) {
   const names = offeredTools(body)

--- a/test/script-filesystem.test.ts
+++ b/test/script-filesystem.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "vitest"
 import { mkdtemp, rm, symlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import * as Effect from "effect/Effect"
 import { createScriptFileSystem } from "../src/script/filesystem.js"
 
 const roots: string[] = []
@@ -14,7 +15,7 @@ describe("script filesystem", () => {
   test("writes relative files and creates their parents", async () => {
     const root = await temporary()
     const fs = createScriptFileSystem(root)
-    await fs.writeFile("src/nested/example.ts", "export const value = 1\n")
+    await Effect.runPromise(fs.writeFile("src/nested/example.ts", "export const value = 1\n"))
     expect(await Bun.file(join(root, "src/nested/example.ts")).text()).toBe("export const value = 1\n")
   })
 
@@ -24,15 +25,15 @@ describe("script filesystem", () => {
     const fs = createScriptFileSystem(root)
     await symlink(outside, join(root, "linked"))
 
-    await expect(fs.writeFile("../outside.ts", "no")).rejects.toThrow("stay inside")
-    await expect(fs.writeFile(join(outside, "absolute.ts"), "no")).rejects.toThrow("must be relative")
-    await expect(fs.writeFile("linked/outside.ts", "no")).rejects.toThrow("must not contain symbolic links")
+    await expect(Effect.runPromise(fs.writeFile("../outside.ts", "no"))).rejects.toThrow("stay inside")
+    await expect(Effect.runPromise(fs.writeFile(join(outside, "absolute.ts"), "no"))).rejects.toThrow("must be relative")
+    await expect(Effect.runPromise(fs.writeFile("linked/outside.ts", "no"))).rejects.toThrow("must not contain symbolic links")
   })
 
   test("reserves Git metadata for declared Git projects", async () => {
     const root = await temporary()
     const fs = createScriptFileSystem(root, { git: true })
-    await expect(fs.writeFile(".GIT/config", "no")).rejects.toThrow("must not modify Git metadata")
+    await expect(Effect.runPromise(fs.writeFile(".GIT/config", "no"))).rejects.toThrow("must not modify Git metadata")
   })
 })
 


### PR DESCRIPTION
## What

Make the `defineScript` API Effect-only as a deliberate breaking change.

Script `setup` and `run` callbacks now return Effects. Filesystem, UI, LLM, server, and client operations also return Effects, while `llm.serve` handlers return Streams. Promise callbacks and compatibility adapters are not retained.

This gives scripts one composition, failure, cancellation, and finalization model. Lifecycle cancellation now interrupts the script Effect and waits for its teardown before the owner exits.

## How

- `src/script/types.ts` defines the Effect-only public contracts for setup, execution, UI, LLM, filesystem, server, and client capabilities.
- `src/cli/script.ts` adapts driver capabilities without Promise wrappers, validates dynamically loaded JavaScript callbacks and UI predicates, and preserves owner-fatal UI timeout handling.
- `src/cli/start.ts` runs scripts in the lifecycle scope, interrupts active runs on restart or shutdown, and waits for recording export and finalizers.
- `src/instance/instance.ts` makes project preparation Effect-native so setup interruption reaches finalizers.
- `src/tool/controller.ts` composes Effect setup and tool handlers while preserving the OpenCode transport cancellation signal.
- Examples, fixtures, manual scripts, the README, API documentation, and the bundled skill now show Effect-native usage.
- `.changeset/effect-only-scripts.md` records the major release.

## Scope

- This changes only the `defineScript` scripting surface. Lower-level driver and transport internals may still use Promises at process or protocol boundaries.
- Tool handlers retain the OpenCode transport `AbortSignal`; script lifecycle cancellation does not expose a separate signal and uses Effect interruption.
- This does not consolidate the script UI type aliases with the lower-level driver UI module or refactor the existing repeated built-in tool adapters.

## Testing

- `bun run check`
- `bun run test` (121 Effect/unit tests and 48 CLI integration tests)
- `git diff --check origin/main`
- `bun pm pack --dry-run`
- Packed `opencode-drive-0.5.0.tgz`, installed it in a clean consumer, and ran `bunx tsc -p tsconfig.json`
- Clean consumer verified a valid Effect-only script and compile-time rejection of Promise-returning `setup`, `run`, and `ui.waitFor` predicates
- `bunx opencode-drive check valid.ts` against the packed package
- Repeated `simplify` reviews covering API reuse, lifecycle correctness, interruption, resource cleanup, and runtime validation

## Flow

```mermaid
sequenceDiagram
    participant Script as defineScript program
    participant Owner as Drive lifecycle
    participant Driver as Prepared driver
    participant OpenCode as OpenCode processes

    Owner->>Script: prepare project and run setup Effect
    Owner->>Driver: launch server and clients
    Owner->>Script: run Effect with Effect-native capabilities
    Script->>Driver: yield UI, LLM, filesystem, server, and client Effects
    Driver->>OpenCode: execute protocol and process operations
    alt script completes
        Script-->>Owner: Effect succeeds or fails
    else restart, stop, or child exit
        Owner-->>Script: interrupt Effect
        Script-->>Owner: run finalizers
    end
    Owner->>Driver: settle LLM work, clients, and recordings
    Owner->>OpenCode: stop remaining processes
```
