### PR TITLE
refactor(scripts): simplify Effect adapters

### DIFF
--- a/docs/open-code-driver-api.md
+++ b/docs/open-code-driver-api.md
@@ -361,10 +361,6 @@ shim.
 
 ## Settled interface
 
-- The API is Effect-native.
-- `defineScript` accepts only Effect-returning `setup` and `run` callbacks.
-- Script capability methods return Effects; `llm.serve` handlers return Streams.
-- Cancellation uses Effect interruption, without a Promise compatibility shim.
 - `OpenCodeDriver.use(options, run)` is the safe top-level bracket and performs typed settlement.
 - `OpenCodeDriver.make(options)` is the primary scoped constructor.
 - Programs that call `make` directly call terminal `driver.settle()` before leaving the scope.

--- a/examples/serve.ts
+++ b/examples/serve.ts
@@ -2,18 +2,15 @@ import { Effect, Stream } from "effect"
 import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
-  setup: ({ fs }) =>
-    Effect.gen(function* () {
-      yield* fs.writeFile(
-        "src/greeting.ts",
-        [
-          "export function greeting(name: string) {",
-          '  return `Welcome, ${name}!`',
-          "}",
-          "",
-        ].join("\n"),
-      )
-    }),
+  setup: ({ fs }) => fs.writeFile(
+    "src/greeting.ts",
+    [
+      "export function greeting(name: string) {",
+      '  return `Welcome, ${name}!`',
+      "}",
+      "",
+    ].join("\n"),
+  ),
 
   run: ({ llm, ui }) =>
     Effect.gen(function* () {

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -2,13 +2,10 @@ import { Effect } from "effect"
 import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
-  setup: ({ fs }) =>
-    Effect.gen(function* () {
-      yield* fs.writeFile(
-        "src/message.ts",
-        'export const message = "Hello from OpenCode Drive"\n',
-      )
-    }),
+  setup: ({ fs }) => fs.writeFile(
+    "src/message.ts",
+    'export const message = "Hello from OpenCode Drive"\n',
+  ),
 
   run: ({ llm, ui }) =>
     Effect.gen(function* () {

--- a/examples/viewport-resize.ts
+++ b/examples/viewport-resize.ts
@@ -4,13 +4,10 @@ import { defineScript, Llm, wait } from "opencode-drive"
 export default defineScript({
   viewport: { cols: 120, rows: 36 },
 
-  setup: ({ fs }) =>
-    Effect.gen(function* () {
-      yield* fs.writeFile(
-        "src/viewport.ts",
-        `export const viewportSequence = ["120x36", "80x24", "50x18"]\n`,
-      )
-    }),
+  setup: ({ fs }) => fs.writeFile(
+    "src/viewport.ts",
+    `export const viewportSequence = ["120x36", "80x24", "50x18"]\n`,
+  ),
 
   run: ({ ui, llm }) =>
     Effect.gen(function* () {

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -51,10 +51,10 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
     hasGitMetadata(join(instance.artifacts, "files")),
   )
   const operationFailure = yield* Deferred.make<never, unknown>()
-  const run = <A, E>(effect: Effect.Effect<A, E>) =>
+  const runUi = <A, E>(effect: Effect.Effect<A, E>) =>
     effect.pipe(
       Effect.tapError((cause) =>
-        isTimeoutError(cause)
+        cause instanceof OpenCodeDriver.UiTimeoutError
           ? Deferred.fail(operationFailure, cause).pipe(Effect.asVoid)
           : Effect.void,
       ),
@@ -69,7 +69,7 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
     const ui = client.ui
     return {
       kill: () =>
-        run(Effect.gen(function* () {
+        runUi(Effect.gen(function* () {
           const output = client.recording === undefined
             ? undefined
             : yield* client.recording.finish()
@@ -77,20 +77,20 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
           yield* client.close()
           return output
         })),
-      state: () => run(ui.state()),
-      matches: (matcher) => run(ui.matches(matcher)),
-      screenshot: (name) => run(ui.screenshot(name)).pipe(Effect.tap((path) => Effect.sync(() => onScreenshot?.(path)))),
-      type: (text) => run(ui.type(text)),
-      press: (key, modifiers) => run(ui.press(key, modifiers)),
-      enter: () => run(ui.enter()),
-      arrow: (direction) => run(ui.arrow(direction)),
-      focus: (target) => run(ui.focus(target)),
-      click: (target, position) => run(ui.click(target, position)),
-      resize: (viewport) => run(ui.resize(viewport)),
-      submit: (text) => run(ui.submit(text)),
+      state: () => runUi(ui.state()),
+      matches: (matcher) => runUi(ui.matches(matcher)),
+      screenshot: (name) => runUi(ui.screenshot(name)).pipe(Effect.tap((path) => Effect.sync(() => onScreenshot?.(path)))),
+      type: (text) => runUi(ui.type(text)),
+      press: (key, modifiers) => runUi(ui.press(key, modifiers)),
+      enter: () => runUi(ui.enter()),
+      arrow: (direction) => runUi(ui.arrow(direction)),
+      focus: (target) => runUi(ui.focus(target)),
+      click: (target, position) => runUi(ui.click(target, position)),
+      resize: (viewport) => runUi(ui.resize(viewport)),
+      submit: (text) => runUi(ui.submit(text)),
       waitFor(target: UiMatcher | UiPredicate, options?: UiWaitOptions) {
-        if (typeof target === "string") return run(ui.waitFor(target, options))
-        return run(
+        if (typeof target === "string") return runUi(ui.waitFor(target, options))
+        return runUi(
           ui.waitForEffect(
             (state) =>
               Effect.try({
@@ -118,19 +118,19 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
       getElement: (
         target: number | string | UiElementQuery,
         options?: UiWaitOptions,
-      ) => run(ui.getElement(target, options)),
+      ) => runUi(ui.getElement(target, options)),
     }
   }
-  const llm = adaptLlm(prepared.llm, run)
+  const llm = adaptLlm(prepared.llm)
   const clients = {
     launch: (name: string, options?: ScriptClientOptions) =>
-      run(prepared.clients.launch(name, {
-          recording: options?.record,
-          viewport: options?.viewport ?? script.viewport,
-        })).pipe(
-          Effect.tap(() => Effect.sync(() => onReady?.())),
-          Effect.map(adaptUi),
-        ),
+      prepared.clients.launch(name, {
+        recording: options?.record,
+        viewport: options?.viewport ?? script.viewport,
+      }).pipe(
+        Effect.tap(() => Effect.sync(() => onReady?.())),
+        Effect.map(adaptUi),
+      ),
   }
   const context = {
     fs: createScriptFileSystem(join(instance.artifacts, "files"), {
@@ -138,8 +138,8 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
     }),
     clients,
     server: {
-      launch: () => run(prepared.server.launch()),
-      kill: () => run(prepared.server.kill()),
+      launch: prepared.server.launch,
+      kill: prepared.server.kill,
     },
     llm,
     artifacts: instance.artifacts,
@@ -165,23 +165,22 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
 
 function adaptLlm(
   controller: OpenCodeDriver.Llm,
-  run: <A, E>(effect: Effect.Effect<A, E>) => Effect.Effect<A, E>,
 ): ScriptLlm {
   return {
-    queue: (...output) => run(controller.queue(...output)),
-    send: (...output) => run(controller.send(...output)),
+    queue: controller.queue,
+    send: controller.send,
     serve: (handler) =>
-      run(controller.serve((request, index) =>
+      controller.serve((request, index) =>
         handler(request, index).pipe(
           Stream.mapError((cause) => llmError("serve", cause, request.id)),
         ),
-      )),
+      ),
     title: (handler) =>
-      run(controller.title((request, index) =>
+      controller.title((request, index) =>
         handler(request, index).pipe(
           Effect.mapError((cause) => llmError("title", cause, request.id)),
         ),
-      )),
+      ),
     text: Llm.text,
     reasoning: Llm.reasoning,
     pause: Llm.pause,
@@ -214,11 +213,6 @@ function isZeroStatusClientExit(cause: unknown) {
     cause.operation === "client.exit" &&
     cause.message.endsWith("status 0")
   )
-}
-
-function isTimeoutError(cause: unknown) {
-  const message = cause instanceof Error ? cause.message : String(cause)
-  return /\btimeout\b|\btimed out\b/i.test(message)
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,5 @@
+import type { Backend } from "../simulation/protocol.js"
+
 export { SimulationClient, SimulationError, connectSimulation } from "./client.js"
 export { BackendSimulationClient, BackendSimulationError, connectBackendSimulation } from "./backend.js"
 export type { BackendSimulationClientOptions } from "./backend.js"
@@ -5,10 +7,10 @@ export type { SimulationClientOptions } from "./client.js"
 export const defaultPort = 40900
 export const defaultBackendPort = 40950
 export { Backend, Frontend, JsonRpc, SimulationProtocol } from "./protocol.js"
+export type BackendFinishReason = Backend.FinishReason
+export type BackendItem = Backend.Item
+export type OpenedExchange = Backend.OpenedExchange
 export type {
-  LlmFinishReason as BackendFinishReason,
-  LlmItem as BackendItem,
-  LlmRequest as OpenedExchange,
   UiAction,
   UiElement,
   UiKeyModifiers as KeyModifiers,

--- a/src/experimental/reproduce-stale-exploring-empty.ts
+++ b/src/experimental/reproduce-stale-exploring-empty.ts
@@ -60,7 +60,7 @@ export default defineScript({
           30_000,
           `timed out waiting for empty continuation ${index + 1}`,
         )
-        yield* waitForEditor(ui)
+        yield* ui.waitFor((state) => state.focused.editor, { timeout: 30_000 })
         yield* Effect.sleep(500)
         yield* ui.screenshot(`stale-exploring-${index + 1}`)
       }
@@ -86,17 +86,6 @@ const typeSlowly = Effect.fn("typeSlowly")(function* (
     yield* ui.type(char)
     yield* Effect.sleep(55)
   }
-})
-
-const waitForEditor = Effect.fn("waitForEditor")(function* (ui: ScriptUi) {
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if ((yield* ui.state()).focused.editor) return
-    yield* Effect.sleep(50)
-  }
-  return yield* Effect.fail(
-    new Error("timed out waiting for the session to become idle"),
-  )
 })
 
 function isTitleRequest(body: unknown) {

--- a/src/script/types.ts
+++ b/src/script/types.ts
@@ -148,7 +148,6 @@ export type LlmFinish = Llm.Finish
 export type LlmDisconnect = Llm.Disconnect
 
 export type LlmOutput = Llm.Output
-export type LlmItem = Llm.Output
 
 export interface LlmRequest {
   readonly id: string

--- a/test/manual/session-switching.ts
+++ b/test/manual/session-switching.ts
@@ -3,17 +3,14 @@ import * as Effect from "effect/Effect"
 import * as Stream from "effect/Stream"
 
 export default defineScript({
-  setup: ({ fs }) =>
-    Effect.gen(function* () {
-      yield* fs.writeFile(
-        "src/garden.ts",
-        [
-          "export const flowers = [\"aster\", \"dahlia\", \"iris\"]",
-          "export const count = flowers.length",
-          "",
-        ].join("\n"),
-      )
-    }),
+  setup: ({ fs }) => fs.writeFile(
+    "src/garden.ts",
+    [
+      "export const flowers = [\"aster\", \"dahlia\", \"iris\"]",
+      "export const count = flowers.length",
+      "",
+    ].join("\n"),
+  ),
 
   run: ({ llm, ui }) =>
     Effect.gen(function* () {

--- a/test/manual/subagents.ts
+++ b/test/manual/subagents.ts
@@ -3,17 +3,14 @@ import * as Effect from "effect/Effect"
 import * as Stream from "effect/Stream"
 
 export default defineScript({
-  setup: ({ fs }) =>
-    Effect.gen(function* () {
-      yield* fs.writeFile(
-        "src/ledger.ts",
-        [
-          "export const credits = [8, 13, 21]",
-          "export const total = credits.reduce((sum, value) => sum + value, 0)",
-          "",
-        ].join("\n"),
-      )
-    }),
+  setup: ({ fs }) => fs.writeFile(
+    "src/ledger.ts",
+    [
+      "export const credits = [8, 13, 21]",
+      "export const total = credits.reduce((sum, value) => sum + value, 0)",
+      "",
+    ].join("\n"),
+  ),
 
   run: ({ llm, ui }) =>
     Effect.gen(function* () {


### PR DESCRIPTION
## What

Simplify the Effect-only script migration after #13 and correct the public backend protocol type aliases.

`BackendItem`, `BackendFinishReason`, and `OpenedExchange` now come from the canonical backend wire protocol rather than the script-level LLM output model.

## How

- Track owner-fatal timeouts only for typed `UiTimeoutError` failures from adapted UI operations.
- Remove no-op wrappers around LLM, server, and client-launch Effects.
- Reuse `ui.waitFor` instead of maintaining an experimental polling loop.
- Return one-step filesystem setup Effects directly in examples and manual scripts.
- Remove duplicated migration bullets from the API document.

## Scope

This does not change lifecycle behavior from #13. Caught UI timeouts remain owner-fatal, clean child exits interrupt hanging scripts, restarts wait for teardown, and setup interruption runs finalizers.

## Testing

- `bun run check`
- `bun run test:effect` (121 tests)
- `bun run test:cli` (48 tests)
- `git diff --check`
- Fresh three-agent `simplify` review covering reuse, code quality, and resource lifecycle
