### PR TITLE
feat(scripts): add CLI authoring guidance

### DIFF
--- a/.changeset/script-cli-ux.md
+++ b/.changeset/script-cli-ux.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": minor
+---
+
+Add `opencode-drive script init` for generating an Effect-native starter script and show focused migration guidance when `check` finds Promise-style script callbacks.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ View the [skills file](https://github.com/anomalyco/opencode-drive/blob/main/ski
 Scripted runs use one fully typed, Effect-only definition. `setup` and `run`
 return Effects; Promise callbacks are not part of the API:
 
+```sh
+opencode-drive script init ./drive.ts
+```
+
+This creates a canonical starter without overwriting an existing file. The
+generated script is ready for `opencode-drive check ./drive.ts` and
+`start --script ./drive.ts`.
+
 ```ts
 import { Effect } from "effect"
 import { defineScript, Llm } from "opencode-drive"
@@ -313,8 +321,10 @@ opencode-drive check ./drive.ts
 ```
 
 Drive temporarily exposes its script API and `tsgo` beside the script while
-checking, then removes only the links it created. `wait(milliseconds)` is
-available for unconditional delays.
+checking, then removes only the links it created. When it detects an old
+Promise-style `setup`, `run`, or `ui.waitFor` callback, it prints the equivalent
+Effect shape after the TypeScript diagnostics. `wait(milliseconds)` is available
+for unconditional delays.
 
 The `fs`, `ui`, `llm`, `server`, and `clients` capabilities expose
 Effect-returning operations. Compose them with `yield*`, `Effect.flatMap`, or

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -210,6 +210,11 @@ opencode-drive check ./drive.ts
 opencode-drive start --name demo --script ./drive.ts
 ```
 
+For a new script, run `opencode-drive script init ./drive.ts` once. It creates a
+canonical Effect-native starter and refuses to overwrite an existing file.
+`check` adds focused migration guidance when it finds Promise-style script
+callbacks.
+
 The script DSL applies `project`, `config`, `tui`, and `setup` with the same deterministic ordering described above. Automatic scripts run again after `opencode-drive restart --name demo`.
 
 Use `launch: "manual"` only when the workflow must control server and client restarts itself. In manual mode `ui` is `null`; run `server.launch()` before `clients.launch(name)`. Only one server may run at a time, `server.kill()` permits relaunch, and a killed client name may be reused.

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -5,8 +5,69 @@ import { checkScript } from "../script/tooling.js"
 export async function check(file: string) {
   const artifacts = await initializeInstance()
   try {
-    await checkScript(artifacts, file)
+    try {
+      await checkScript(artifacts, file)
+    } catch (error) {
+      const source = await Bun.file(file).slice(0, 256 * 1024).text().catch(() => "")
+      const hint = effectScriptHint(source, message(error))
+      if (hint !== undefined) throw new Error(`${message(error)}\n\n${hint}`, { cause: error })
+      throw error
+    }
   } finally {
     await rm(artifacts, { recursive: true, force: true })
   }
+}
+
+export function effectScriptHint(source: string, diagnostics: string) {
+  if (!/\bPromise(?:Like)?</.test(diagnostics)) return undefined
+  if (!/\bdefineScript\s*\(/.test(source)) return undefined
+  const relevant = diagnosticSource(source, diagnostics)
+  if (/\.waitFor\s*\(/.test(relevant))
+    return `${heading}
+
+Instead of:
+  ui.waitFor(async (state) => state.focused.editor)
+
+Use:
+  ui.waitFor((state) => Effect.succeed(state.focused.editor))`
+  if (/\bsetup\s*:|\basync\s+setup\s*\(/.test(relevant))
+    return `${heading}
+
+Instead of:
+  setup: async ({ fs }) => {
+    await fs.writeFile("src/example.ts", "export {}")
+  }
+
+Use:
+  setup: ({ fs }) => fs.writeFile("src/example.ts", "export {}")`
+  if (/\brun\s*:|\basync\s+run\s*\(/.test(relevant))
+    return `${heading}
+
+Instead of:
+  run: async ({ ui }) => {
+    await ui.submit("Hello")
+  }
+
+Use:
+  run: ({ ui }) =>
+    Effect.gen(function* () {
+      yield* ui.submit("Hello")
+    })`
+  return undefined
+}
+
+const heading = "OpenCode Drive scripts are Effect-only. Promise callbacks are not supported."
+
+function diagnosticSource(source: string, diagnostics: string) {
+  const lines = source.split("\n")
+  const numbers = [...diagnostics.matchAll(/(?::(\d+):\d+|\((\d+),\d+\))/g)]
+    .map((match) => Number(match[1] ?? match[2]))
+    .filter((line) => Number.isInteger(line) && line > 0)
+  return numbers.length === 0
+    ? source
+    : numbers.map((line) => lines[line - 1] ?? "").join("\n")
+}
+
+function message(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { restart } from "./restart.js"
 import { responses } from "./responses.js"
 import { runProgram } from "./run.js"
 import { send } from "./send.js"
+import { initScript } from "./script-init.js"
 import { start } from "./start.js"
 import { stop } from "./stop.js"
 import { logError } from "../log.js"
@@ -59,6 +60,25 @@ const checkCommand = Command.make(
       description: "Type-check a script with the bundled script API",
     },
   ]),
+)
+
+const scriptInitCommand = Command.make(
+  "init",
+  { file: Argument.string("file") },
+  (config) => execute(() => initScript(config.file)),
+).pipe(
+  Command.withDescription("Create an Effect-native OpenCode Drive script"),
+  Command.withExamples([
+    {
+      command: "opencode-drive script init ./drive.ts",
+      description: "Create a type-checkable script without overwriting existing files",
+    },
+  ]),
+)
+
+const scriptCommand = Command.make("script").pipe(
+  Command.withDescription("Create and manage OpenCode Drive scripts"),
+  Command.withSubcommands([scriptInitCommand]),
 )
 
 const runCommand = Command.make(
@@ -210,6 +230,7 @@ const root = Command.make("opencode-drive").pipe(
   Command.withDescription("Drive real and simulated OpenCode instances"),
   Command.withSubcommands([
     initCommand,
+    scriptCommand,
     checkCommand,
     runCommand,
     startCommand,

--- a/src/cli/script-init.ts
+++ b/src/cli/script-init.ts
@@ -1,0 +1,46 @@
+import { mkdir, open, rm } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { logSuccess } from "../log.js"
+
+const template = `import { Effect } from "effect"
+import { defineScript, Llm } from "opencode-drive"
+
+export default defineScript({
+  project: {
+    files: {
+      "src/example.ts": "export const value = 1\\n",
+    },
+  },
+  run: ({ ui, llm }) =>
+    Effect.gen(function* () {
+      yield* llm.queue(Llm.text("The value is 1."))
+      yield* ui.submit("Read src/example.ts")
+      yield* ui.waitFor("The value is 1.")
+      yield* ui.screenshot("result")
+    }),
+})
+`
+
+export async function initScript(path: string) {
+  const file = resolve(path)
+  await mkdir(dirname(file), { recursive: true })
+  const handle = await open(file, "wx").catch((error: unknown) => {
+    if (isAlreadyExists(error))
+      throw new Error(`script already exists: ${file}`, { cause: error })
+    throw error
+  })
+  try {
+    await handle.writeFile(template)
+  } catch (error) {
+    await handle.close().catch(() => undefined)
+    await rm(file, { force: true })
+    throw error
+  }
+  await handle.close()
+  logSuccess("created script")
+  console.log(file)
+}
+
+function isAlreadyExists(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "EEXIST"
+}

--- a/src/script/tooling.ts
+++ b/src/script/tooling.ts
@@ -140,7 +140,7 @@ function isPackageMetadata(
 export async function checkScript(artifacts: string, script: string) {
   const tooling = await prepareScriptTooling(artifacts, script)
   try {
-    await typecheckPreparedTooling(tooling, artifacts, "script")
+    await typecheckPreparedTooling(tooling, artifacts, "script", true)
   } finally {
     await tooling.links.remove()
   }
@@ -150,14 +150,22 @@ export async function typecheckPreparedTooling(
   tooling: Awaited<ReturnType<typeof prepareScriptTooling>>,
   cwd: string,
   label: string,
+  capture: boolean = false,
 ) {
   const output = await runProcess(
     [tooling.tsgo, "-p", tooling.tsconfig],
     cwd,
-    { stdout: "inherit", stderr: "inherit" },
+    capture ? {} : { stdout: "inherit", stderr: "inherit" },
   )
-  if (output.status !== 0)
-    throw new Error(`${label} type check failed with status ${output.status}`)
+  if (output.status !== 0) {
+    const diagnostics = [output.stdout, output.stderr]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join("\n")
+    throw new Error(
+      diagnostics || `${label} type check failed with status ${output.status}`,
+    )
+  }
 }
 
 const runProcess = (

--- a/test/cli/check.test.ts
+++ b/test/cli/check.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest"
+import { effectScriptHint } from "../../src/cli/check.js"
+
+const promiseDiagnostic = (line: number) =>
+  `/tmp/drive.ts:${line}:10 - error TS2322: Type 'Promise<void>' is not assignable to type 'Effect<void>'.`
+
+describe("Effect script check hints", () => {
+  test.each([
+    [
+      'defineScript({ run: async ({ ui }) => { await ui.submit("Hello") } })',
+      "run: ({ ui }) =>",
+    ],
+    [
+      'defineScript({ setup: () => Promise.resolve() })',
+      "setup: ({ fs }) => fs.writeFile",
+    ],
+    [
+      'defineScript({ run: ({ ui }) => ui.waitFor(() => Promise.resolve(false)) })',
+      "ui.waitFor((state) => Effect.succeed",
+    ],
+  ])("describes the failing Promise callback", (callback, expected) => {
+    const source = `import { defineScript } from "opencode-drive"\n${callback}\n`
+    expect(effectScriptHint(source, promiseDiagnostic(2))).toContain(expected)
+  })
+
+  test("ignores Promise diagnostics on unrelated source lines", () => {
+    const source = [
+      'import { defineScript } from "opencode-drive"',
+      "// run: async () => {}",
+      "const value: Effect.Effect<void> = Promise.resolve()",
+      "defineScript({ run: () => Effect.void })",
+    ].join("\n")
+    expect(effectScriptHint(source, promiseDiagnostic(3))).toBeUndefined()
+  })
+})

--- a/test/cli/integration.test.ts
+++ b/test/cli/integration.test.ts
@@ -771,8 +771,42 @@ describe("opencode-drive", () => {
 
     await Bun.write(join(directory, "invalid.ts"), 'import { wait } from "opencode-drive"\nwait("wrong")\n')
     const invalid = spawn(["check", join(directory, "invalid.ts")], root)
+    const invalidError = new Response(invalid.stderr).text()
     expect(await invalid.exited).toBe(1)
-    expect(await new Response(invalid.stdout).text()).toContain("is not assignable to parameter of type")
+    expect(await invalidError).toContain("is not assignable to parameter of type")
+
+    await Bun.write(
+      join(directory, "promise.ts"),
+      'import { defineScript } from "opencode-drive"\nexport default defineScript({ run: async ({ ui }) => { await ui.submit("Hello") } })\n',
+    )
+    const promise = spawn(["check", join(directory, "promise.ts")], root)
+    const promiseError = new Response(promise.stderr).text()
+    expect(await promise.exited).toBe(1)
+    expect(await promiseError).toContain("OpenCode Drive scripts are Effect-only")
+    expect(await promiseError).toContain("Effect.gen(function* ()")
+  }, 60_000)
+
+  test("creates a type-checkable Effect script without overwriting it", async () => {
+    const root = await temporary()
+    const file = join(root, "scripts", "drive.ts")
+    const created = spawn(["script", "init", file], root)
+    const [status, stdout] = await Promise.all([
+      created.exited,
+      new Response(created.stdout).text(),
+    ])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe(file)
+    const source = await Bun.file(file).text()
+    expect(source).toContain('import { defineScript, Llm } from "opencode-drive"')
+    expect(source).toContain('llm.queue(Llm.text("The value is 1."))')
+
+    const checked = spawn(["check", file], root)
+    expect(await checked.exited).toBe(0)
+
+    const repeated = spawn(["script", "init", file], root)
+    expect(await repeated.exited).toBe(1)
+    expect(await new Response(repeated.stderr).text()).toContain("script already exists")
+    expect(await Bun.file(file).text()).toBe(source)
   }, 60_000)
 
   test("launches all clients explicitly for a manual UI script", async () => {


### PR DESCRIPTION
## What

Make the Effect-only script API easier to start and easier to migrate to.

```sh
opencode-drive script init ./drive.ts
opencode-drive check ./drive.ts
```

`script init` creates a canonical, immediately type-checkable script without overwriting existing work. `check` keeps normal TypeScript diagnostics and adds a focused Effect rewrite when the failing diagnostic points to a Promise-style `setup`, `run`, or `ui.waitFor` callback.

## Before / After

**Before:** authors had to find and adapt an example manually. Promise-era callbacks produced technically correct TypeScript errors but no direct migration path.

**After:** one command creates the canonical `Effect.gen` plus `Llm.*` shape, and migration failures include the matching replacement form next to the compiler diagnostic.

## How

- `src/cli/script-init.ts` writes the starter exclusively, preserves existing files, and removes a partial file if writing fails.
- `src/cli/index.ts` adds the nested `script init FILE` command without conflicting with instance `init`.
- `src/script/tooling.ts` captures standalone `check` diagnostics so the CLI can emit one coherent stderr report; startup typechecks retain inherited output.
- `src/cli/check.ts` correlates Promise-related diagnostics with bounded source lines and selects a callback-specific Effect rewrite.
- Unit coverage rejects unrelated source-line false positives; integration coverage checks creation, typechecking, diagnostics, and non-overwrite behavior.

## Scope

- The scaffold has one canonical automatic-script shape rather than flags or templates.
- `check` does not rewrite files and does not hide TypeScript diagnostics.
- Tool-handler cancellation remains unchanged.

## Testing

- `bun run check`
- `bun run test:effect` (126 tests)
- `bun run test:cli` (49 tests)
- `git diff --check`
- Fresh `simplify` review across reuse, command UX, diagnostic accuracy, output channels, and resource cleanup
