### PR TITLE
feat(tools)!: use Effect interruption

### DIFF
--- a/.changeset/effect-tool-cancellation.md
+++ b/.changeset/effect-tool-cancellation.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": major
+---
+
+Remove the tool handler `AbortSignal`. Foreground session interruption, transport disconnects, and Drive shutdown now surface uniformly as Effect interruption, and controller shutdown awaits handler finalizers. Detached background shell handlers remain active after launch and are interrupted during Drive shutdown.

--- a/README.md
+++ b/README.md
@@ -300,9 +300,11 @@ export default defineScript({
 })
 ```
 
-Tool handlers also receive the OpenCode transport's `AbortSignal`; their
-Effects are interrupted when it aborts. Script lifecycle cancellation itself
-uses Effect interruption and does not expose a separate signal.
+Foreground tool handler Effects are interrupted when OpenCode interrupts the
+session, the transport disconnects, or Drive shuts down. Use Effect finalizers
+such as `Effect.onInterrupt` or `Effect.ensuring` for cancellation cleanup.
+Detached background shell handlers continue after their launch response and
+are interrupted when Drive shuts down.
 
 Only registered tools are replaced. Unhandled tools continue to use OpenCode's
 real implementations. Each `progress` value replaces the visible tool output;

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -147,10 +147,11 @@ Drive prefers protocol negotiation and reports explicit legacy fallback. Set `op
 
 Use `tools` to replace shell execution without changing the model-visible tool
 schema. The handler receives typed input, a zero-based call index, and an Effect
-progress function. It also receives an `AbortSignal` from the OpenCode tool
-transport; handler Effects are interrupted when that signal aborts. This
-transport signal is separate from script lifecycle cancellation, which uses
-Effect interruption. Unregistered tools remain real.
+progress function. Foreground handler Effects are interrupted when OpenCode
+interrupts the session, the transport disconnects, or Drive shuts down; use
+Effect finalizers for cancellation cleanup. Detached background shell handlers
+continue after their launch response and are interrupted when Drive shuts down.
+Unregistered tools remain real.
 
 ```ts
 import { Effect } from "effect"

--- a/src/tool/controller.ts
+++ b/src/tool/controller.ts
@@ -42,7 +42,6 @@ type Definition = {
   readonly invoke: (
     input: unknown,
     index: number,
-    signal: AbortSignal,
     progress: (result: Result) => Effect.Effect<void>,
   ) => Effect.Effect<Result, unknown>
 }
@@ -97,13 +96,12 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
           const handler = registration[1]
           add("shell", {
             schema: ShellInput,
-            invoke: (raw, index, signal, progress) =>
+            invoke: (raw, index, progress) =>
               Effect.gen(function* () {
                 const input = yield* Schema.decodeUnknownEffect(ShellInput)(raw)
                 const result = yield* handler({
                   input,
                   index,
-                  signal,
                   progress: (value) => progress(typeof value === "string" ? { output: value } : value),
                 })
                 return yield* Schema.decodeUnknownEffect(ShellResult)(result)
@@ -115,13 +113,12 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
           const handler = registration[1]
           add("webfetch", {
             schema: WebFetchInput,
-            invoke: (raw, index, signal, progress) =>
+            invoke: (raw, index, progress) =>
               Effect.gen(function* () {
                 const input = yield* Schema.decodeUnknownEffect(WebFetchInput)(raw)
                 const result = yield* handler({
                   input,
                   index,
-                  signal,
                   progress: (value) => progress(typeof value === "string" ? { output: value } : value),
                 })
                 return yield* Schema.decodeUnknownEffect(WebFetchResult)(result)
@@ -133,13 +130,12 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
           const handler = registration[1]
           add("websearch", {
             schema: WebSearchInput,
-            invoke: (raw, index, signal, progress) =>
+            invoke: (raw, index, progress) =>
               Effect.gen(function* () {
                 const input = yield* Schema.decodeUnknownEffect(WebSearchInput)(raw)
                 const result = yield* handler({
                   input,
                   index,
-                  signal,
                   progress: (value) => progress(typeof value === "string" ? { output: value } : value),
                 })
                 return yield* Schema.decodeUnknownEffect(WebSearchResult)(result)
@@ -154,7 +150,7 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
 
   const token = crypto.randomUUID()
   const indexes = new Map<string, number>()
-  const active = new Set<AbortController>()
+  const active = new Map<AbortController, Promise<unknown>>()
   const background = new Map<string, BackgroundJob>()
   let closing = false
   const server = yield* Effect.acquireRelease(
@@ -194,10 +190,10 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
       Effect.gen(function* () {
         closing = true
         yield* Effect.sync(() => {
-          for (const controller of active)
+          for (const controller of active.keys())
             controller.abort(new Error("Drive tool controller stopped"))
         })
-        yield* Effect.promise(() => Promise.allSettled([...background.values()].map((job) => job.completion)))
+        yield* Effect.promise(() => Promise.allSettled(active.values()))
         background.clear()
         yield* Effect.promise(() => server.stop(true))
       }),
@@ -232,14 +228,13 @@ function execute(
   name: string,
   definition: Definition,
   indexes: Map<string, number>,
-  active: Set<AbortController>,
+  active: Map<AbortController, Promise<unknown>>,
   background: Map<string, BackgroundJob>,
 ) {
   const transport = new TransformStream<Uint8Array, Uint8Array>()
   const writer = transport.writable.getWriter()
   const controller = new AbortController()
   const signal = AbortSignal.any([request.signal, controller.signal])
-  active.add(controller)
   const send = (event: Event) =>
     Effect.suspend(() => {
       const frame = encodeEvent(event)
@@ -274,12 +269,14 @@ function execute(
       }
     }
     const index = nextIndex(indexes, name)
-    return yield* definition.invoke(input, index, signal, (value) => send({ type: "progress", result: value }))
+    return yield* definition.invoke(input, index, (value) => send({ type: "progress", result: value }))
   })
   void writer.closed.catch((cause) => controller.abort(cause))
-  void (async () => {
+  const completion = (async () => {
     try {
-      const exit = await Effect.runPromise(Effect.exit(result), { signal })
+      const exit = await Effect.runPromiseExit(result, { signal })
+      if (signal.aborted)
+        throw signal.reason ?? new Error("Drive tool execution interrupted")
       if (Exit.isSuccess(exit))
         await Effect.runPromise(send({ type: "success", result: exit.value }), { signal })
       else {
@@ -292,13 +289,14 @@ function execute(
         )
       }
       await writer.close()
-    } catch (cause) {
+    } catch {
       if (launched !== undefined) launched.cancel()
-      await writer.abort(cause).catch(() => undefined)
+      await writer.abort().catch(() => undefined)
     } finally {
       active.delete(controller)
     }
   })()
+  active.set(controller, completion)
   return new Response(transport.readable, {
     headers: { "content-type": "application/x-ndjson" },
   })
@@ -315,17 +313,16 @@ function startBackgroundShell(
   index: number,
   shellID: string,
   inputKey: string,
-  active: Set<AbortController>,
+  active: Map<AbortController, Promise<unknown>>,
 ): BackgroundJob {
   const controller = new AbortController()
-  active.add(controller)
   let output = ""
-  const result = definition.invoke(input, index, controller.signal, (value) =>
+  const result = definition.invoke(input, index, (value) =>
     Effect.sync(() => {
       encodeEvent({ type: "progress", result: value })
       output = value.output
     }))
-  const completion = Effect.runPromise(Effect.exit(result), { signal: controller.signal })
+  const completion = Effect.runPromiseExit(result, { signal: controller.signal })
     .then((exit): BackgroundCompletion => {
       if (Exit.isSuccess(exit)) {
         encodeEvent({ type: "success", result: exit.value })
@@ -348,6 +345,7 @@ function startBackgroundShell(
       output: errorOutput(output, cause instanceof Error ? cause.message : String(cause)),
     }))
     .finally(() => active.delete(controller))
+  active.set(controller, completion)
   return {
     input: inputKey,
     completion,

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -69,7 +69,6 @@ export interface Context<Input, Result> {
   readonly input: Input
   /** Zero-based invocation index for this handler. */
   readonly index: number
-  readonly signal: AbortSignal
   readonly progress: (output: string | Result) => Effect.Effect<void>
 }
 

--- a/test/tool/controller.test.ts
+++ b/test/tool/controller.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
 import * as ToolController from "../../src/tool/controller.js"
 import { Failure } from "../../src/tool/index.js"
@@ -134,15 +135,16 @@ it.effect("settles background shells immediately and retains their completion", 
   Effect.scoped(
     Effect.gen(function* () {
       const release = Promise.withResolvers<void>()
-      let aborted = false
+      let interrupted = false
       const controller = yield* ToolController.make((tools) => {
-        tools.handle("shell", ({ input, signal, progress }) =>
+        tools.handle("shell", ({ input, progress }) =>
           Effect.gen(function* () {
-            signal.addEventListener("abort", () => (aborted = true), { once: true })
             yield* progress("still running\n")
             yield* Effect.promise(() => release.promise)
             return { output: `${input.command} complete\n`, exit: 0 }
-          }),
+          }).pipe(
+            Effect.onInterrupt(() => Effect.sync(() => (interrupted = true))),
+          ),
         )
       })
       const config: OpenCodeConfig = {}
@@ -175,7 +177,7 @@ it.effect("settles background shells immediately and retains their completion", 
           },
         },
       ])
-      expect(aborted).toBe(false)
+      expect(interrupted).toBe(false)
 
       const completion = fetch(`${injected.options.endpoint}/background/call_background`, { headers })
         .then((response) => response.json())
@@ -345,15 +347,14 @@ it.effect("notifies OpenCode when a registered background shell completes", () =
 it.effect("cancels retained background shells when the controller stops", () =>
   Effect.gen(function* () {
     const started = Promise.withResolvers<void>()
-    const aborted = Promise.withResolvers<void>()
+    const interrupted = Promise.withResolvers<void>()
     const scope = yield* Scope.make()
     const controller = yield* ToolController.make((tools) => {
-      tools.handle("shell", ({ signal }) =>
-        Effect.gen(function* () {
-          signal.addEventListener("abort", () => aborted.resolve(), { once: true })
-          started.resolve()
-          return yield* Effect.never
-        }),
+      tools.handle("shell", () =>
+        Effect.sync(() => started.resolve()).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() => Effect.sync(() => interrupted.resolve())),
+        ),
       )
     }).pipe(Scope.provide(scope))
     const config: OpenCodeConfig = {}
@@ -376,22 +377,75 @@ it.effect("cancels retained background shells when the controller stops", () =>
     )
     yield* Effect.promise(() => started.promise)
     yield* Scope.close(scope, Exit.void)
-    yield* Effect.promise(() => aborted.promise)
+    yield* Effect.promise(() => interrupted.promise)
   }),
 )
 
-it.effect("aborts a handler when its transport disconnects", () =>
+it.effect("waits for foreground handler finalizers when the controller stops", () =>
+  Effect.gen(function* () {
+    const started = Promise.withResolvers<void>()
+    const finalizing = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    let finalized = false
+    const scope = yield* Scope.make()
+    const controller = yield* ToolController.make((tools) => {
+      tools.handle("shell", () =>
+        Effect.sync(() => started.resolve()).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() =>
+            Effect.sync(() => finalizing.resolve()).pipe(
+              Effect.andThen(Effect.promise(() => release.promise)),
+              Effect.andThen(Effect.sync(() => {
+                finalized = true
+              })),
+            ),
+          ),
+        ),
+      )
+    }).pipe(Scope.provide(scope))
+    const config: OpenCodeConfig = {}
+    controller.configure(config)
+    const injected = (config.plugins as Array<{
+      options: { endpoint: string; token: string }
+    }>)[0]!
+    const response = fetch(`${injected.options.endpoint}/execute/shell`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        input: { command: "wait" },
+        context: { callID: "call_foreground_shutdown" },
+      }),
+    }).then((response) => response.text()).catch(() => undefined)
+    yield* Effect.promise(() => started.promise)
+    let closed = false
+    const close = Effect.runPromise(Scope.close(scope, Exit.void)).then(() => {
+      closed = true
+    })
+    yield* Effect.promise(() => finalizing.promise)
+    expect(closed).toBe(false)
+    expect(finalized).toBe(false)
+    release.resolve()
+    yield* Effect.promise(() => close)
+    yield* Effect.promise(() => response)
+    expect(closed).toBe(true)
+    expect(finalized).toBe(true)
+  }),
+)
+
+it.effect("interrupts a handler when its transport disconnects", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const started = Promise.withResolvers<void>()
-      const aborted = Promise.withResolvers<void>()
+      const interrupted = Promise.withResolvers<void>()
       const controller = yield* ToolController.make((tools) => {
-        tools.handle("shell", ({ signal }) =>
-          Effect.gen(function* () {
-            signal.addEventListener("abort", () => aborted.resolve(), { once: true })
-            started.resolve()
-            return yield* Effect.never
-          }),
+        tools.handle("shell", () =>
+          Effect.sync(() => started.resolve()).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Effect.sync(() => interrupted.resolve())),
+          ),
         )
       })
       const config: OpenCodeConfig = {}
@@ -414,8 +468,54 @@ it.effect("aborts a handler when its transport disconnects", () =>
       }).catch(() => undefined)
       yield* Effect.promise(() => started.promise)
       request.abort()
-      yield* Effect.promise(() => aborted.promise)
+      yield* Effect.promise(() => interrupted.promise)
       yield* Effect.promise(() => response)
+    }),
+  ),
+)
+
+it.effect("interrupts a handler with its plugin execution", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const started = Promise.withResolvers<void>()
+      const interrupted = Promise.withResolvers<void>()
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", () =>
+          Effect.sync(() => started.resolve()).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Effect.sync(() => interrupted.resolve())),
+          ),
+        )
+      })
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const options = (config.plugins as Array<{ options: unknown }>)[0]!.options
+      let shell: RegisteredTool | undefined
+      yield* plugin.effect({
+        options,
+        tool: {
+          transform: (register: (tools: { add: (name: string, tool: RegisteredTool) => void }) => void) =>
+            Effect.sync(() =>
+              register({
+                add: (name, tool) => {
+                  if (name === "shell") shell = tool
+                },
+              }),
+            ),
+        },
+        session: {
+          synthetic: () => Effect.void,
+        },
+      })
+      if (shell === undefined) return yield* Effect.die(new Error("shell tool was not registered"))
+
+      const execution = yield* shell.execute(
+        { command: "wait" },
+        { sessionID: "ses_interrupt", callID: "call_interrupt" },
+      ).pipe(Effect.forkScoped)
+      yield* Effect.promise(() => started.promise)
+      yield* Fiber.interrupt(execution)
+      yield* Effect.promise(() => interrupted.promise)
     }),
   ),
 )


### PR DESCRIPTION
## What

Remove the public tool-handler `AbortSignal` and make Effect interruption the single cancellation model.

```ts
tools.handle("shell", ({ input, progress }) =>
  Effect.gen(function* () {
    yield* progress(`Running ${input.command}\n`)
    return yield* work.pipe(
      Effect.onInterrupt(() => cleanup),
    )
  }),
)
```

Foreground handlers are interrupted by authenticated OpenCode session interruption, transport disconnects, and Drive shutdown. Detached background shell handlers continue after their launch response and are interrupted during Drive shutdown.

## Before / After

**Before:** tool handlers received both an `AbortSignal` and an Effect, forcing callers to choose or coordinate two cancellation models. Drive shutdown signaled foreground interruption but could finish before asynchronous handler finalizers completed.

**After:** handlers use standard Effect finalizers. The controller owns every active execution, interrupts it at the appropriate lifecycle boundary, and joins its finalizers before shutdown completes.

## How

- `src/tool/types.ts` removes `signal` from the public handler context.
- `src/tool/controller.ts` keeps transport signals internal to `Effect.runPromiseExit`, tracks foreground and background execution promises, and awaits all active handlers during release.
- Interrupted response streams close without surfacing handled cancellation stacks.
- Controller tests cover plugin execution interruption, transport disconnect, foreground shutdown finalizer joining, and retained background shutdown.
- Documentation and the bundled skill describe foreground and detached-background ownership separately.
- A major changeset records the breaking API removal.

## Scope

- Background shells intentionally outlive the foreground launch request and are not cancelled by later session interruption.
- The internal HTTP and process boundaries may continue to use `AbortSignal`; it is no longer part of the handler API.

## Testing

- `bun run check`
- `bun run test:effect` (128 tests)
- `bun run test:cli` (49 tests)
- `git diff --check`
- Real OpenCode v2 proof at `f76e18201a`: queued a never-ending simulated shell tool, waited for the visible interrupt affordance, sent the confirmed Escape gesture, and observed the handler's `Effect.onInterrupt` finalizer before Drive completed
- Repeated `simplify` review across Effect API reuse, cancellation correctness, detached background semantics, and shutdown resource ownership

## Flow

```mermaid
sequenceDiagram
    participant Session as OpenCode session
    participant Plugin as Drive plugin Effect
    participant Controller as Tool controller
    participant Handler as Handler Effect

    Session->>Plugin: execute tool
    Plugin->>Controller: authenticated streaming request
    Controller->>Handler: run Effect
    alt foreground session interrupt
        Session-->>Plugin: interrupt execution fiber
        Plugin-->>Controller: abort request transport
        Controller-->>Handler: interrupt Effect
    else Drive shutdown
        Controller-->>Handler: interrupt Effect
    end
    Handler-->>Controller: run finalizers
    Controller-->>Controller: await execution completion
```
