### PR TITLE
ci: restore validation and trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: bun install --frozen-lockfile
       - run: bun run check
       - run: bun run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish npm package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - run: bun install --frozen-lockfile
+
+      - name: Verify tag matches package version
+        run: |
+          version="$(bun -e 'console.log(require("./package.json").version)')"
+          test "$GITHUB_REF_NAME" = "v$version"
+
+      - run: bun run release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: bun install --frozen-lockfile
 
       - name: Verify tag matches package version

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,18 +1,29 @@
 # Releasing
 
-This repository contains one public npm package and uses Changesets for versioning and publishing. Use Bun for installation, validation, and package scripts.
+This repository contains one public npm package and uses Changesets for versioning and publishing. Publishing runs from `.github/workflows/publish.yml` when a version tag is pushed. The workflow authenticates to npm with GitHub Actions OIDC, so it does not use a long-lived npm token. Use Bun for installation, validation, and package scripts.
+
+## Trusted Publisher Setup
+
+Configure the `opencode-drive` package on npm with this GitHub Actions trusted publisher before pushing a release tag:
+
+- Organization: `anomalyco`
+- Repository: `opencode-drive`
+- Workflow filename: `publish.yml`
+- Environment: leave blank
+
+The workflow requires a GitHub-hosted runner, grants only `contents: read` and `id-token: write`, verifies that the tag exactly matches the package version, and publishes through the configured Changesets command.
 
 ## Release 0.5.0
 
-The manifest is already versioned at `0.5.0`, while npm's `latest` version is `0.4.0`. All work currently in the repository belongs to `0.5.0`, so there is intentionally no pending changeset for it. Adding one and running `bun run release:version` would describe work after `0.5.0` and bump the manifest to at least `0.5.1`.
+The manifest is already versioned at `0.5.0`, while npm's `latest` version is `0.4.0`. Pending Changesets describe work after `0.5.0`; do not consume them before publishing this release candidate, or the manifest will advance past `0.5.0`.
 
 To publish the current release candidate:
 
 1. Confirm `bun pm view opencode-drive version` still reports `0.4.0`.
 2. Run `bun install --frozen-lockfile`.
 3. Run `bun run release:validate` and inspect the dry-run package file list and metadata.
-4. Run `bun run release`. This validates again, then `changeset publish` detects that local `0.5.0` is absent from npm, publishes it with public access, and creates the corresponding Git tag.
-5. Push the release commit and tag after verifying npm.
+4. Push tag `v0.5.0` from the exact validated commit.
+5. Watch the publish workflow, then verify npm and install the published artifact in a clean consumer.
 
 Do not run `bun run release:version` for this initial Changesets-managed release.
 


### PR DESCRIPTION
## What

Restore automated validation for pull requests and `main`, and publish tagged releases to npm through GitHub Actions trusted publishing without a long-lived npm token.

## How

- `.github/workflows/ci.yml` installs with the locked Bun version, then runs lint, typecheck, and the complete test suite.
- `.github/workflows/publish.yml` accepts `v*` tags, verifies the tag exactly matches `package.json`, and invokes the configured Changesets release command with npm OIDC authority.
- `docs/releasing.md` records the trusted publisher identity and the special `0.5.0` release sequence without consuming Changesets intended for later work.

## Scope

This PR installs release infrastructure only. It does not push a release tag or consume pending Changesets.

## Testing

- `bun run release:validate`
- 128 Effect/Vitest tests passed
- 49 CLI integration tests passed
- typecheck passed
- lint passed with 3 existing warnings
- packed artifact inspected: 85 files, 1.51 MB unpacked
- `git diff --check`
