### PR TITLE
fix(cli): preserve canonical UI command parameters

### DIFF
--- a/.changeset/protocol-command-parity.md
+++ b/.changeset/protocol-command-parity.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Preserve the canonical OpenCode UI command shapes for optional named screenshots and key presses.

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -275,6 +275,8 @@ opencode-drive stop --name demo
 - `--command.ui.arrow '{"direction":"down"}'`
 - `--command.ui.focus '{"target":12}'`
 - `--command.ui.click '{"target":12,"x":4,"y":1}'`
+- `--command.ui.resize '{"cols":120,"rows":40}'`
+- `--command.ui.screenshot` or `--command.ui.screenshot '{"name":"home"}'`
 - `--command.ui.state`
 - `--command.ui.capture`
 - `--command.ui.matches '{"text":"OpenCode"}'`

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -19,8 +19,8 @@ export const commandInfo = {
     description: "Resize terminal viewport using JSON params",
   },
   "ui.screenshot": {
-    value: false,
-    description: "Take a screenshot and return its path",
+    value: "optional",
+    description: "Take a screenshot with optional JSON params and return its path",
   },
   "ui.capture": {
     value: false,
@@ -161,8 +161,16 @@ async function execute(
         throw new Error("invalid ui.resize params")
       return ui.resize(request.params)
     }
-    case "ui.screenshot":
-      return ui.screenshot()
+    case "ui.screenshot": {
+      const request = Frontend.decodeRequest({
+        jsonrpc: "2.0",
+        method: "ui.screenshot",
+        ...(command.value === undefined ? {} : { params: json(command.value) }),
+      })
+      if (request.method !== "ui.screenshot")
+        throw new Error("invalid ui.screenshot params")
+      return ui.screenshot(request.params?.name)
+    }
     case "ui.capture":
       return ui.capture()
     case "ui.state":

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -15,9 +15,11 @@ export function extractCommands(args: ReadonlyArray<string>) {
       continue
     }
     const operation = flag.slice("--command.".length)
-    const acceptsValue = commandAcceptsValue(operation)
-    const value = acceptsValue ? cli[++index] : undefined
-    if (acceptsValue && (value === undefined || value.startsWith("--"))) throw new Error(`${flag} requires a value`)
+    const valueMode = commandAcceptsValue(operation)
+    const next = cli[index + 1]
+    const takesValue = valueMode === true || (valueMode === "optional" && next !== undefined && !next.startsWith("--"))
+    const value = takesValue ? cli[++index] : undefined
+    if (valueMode === true && (value === undefined || value.startsWith("--"))) throw new Error(`${flag} requires a value`)
     commands.push({ operation, ...(value === undefined ? {} : { value }) })
   }
   return { args: remaining, app, commands }

--- a/src/simulation/protocol.ts
+++ b/src/simulation/protocol.ts
@@ -233,7 +233,7 @@ export namespace Frontend {
     key: string,
     modifiers?: KeyModifiers,
   ): PressParams => ({
-    key: key === "escape" ? "\u001b" : key,
+    key,
     ...(modifiers === undefined ? {} : { modifiers }),
   })
 

--- a/test/cli/parse.test.ts
+++ b/test/cli/parse.test.ts
@@ -9,6 +9,8 @@ describe("drive CLI parser", () => {
         "--command.ui.type",
         '{"text":"hello"}',
         "--command.ui.screenshot",
+        '{"name":"home"}',
+        "--command.ui.screenshot",
         "--command.ui.matches",
         '{"text":"hello"}',
         "--command.ui.state",
@@ -18,6 +20,7 @@ describe("drive CLI parser", () => {
       app: [],
       commands: [
         { operation: "ui.type", value: '{"text":"hello"}' },
+        { operation: "ui.screenshot", value: '{"name":"home"}' },
         { operation: "ui.screenshot" },
         { operation: "ui.matches", value: '{"text":"hello"}' },
         { operation: "ui.state" },

--- a/test/driver/ui.test.ts
+++ b/test/driver/ui.test.ts
@@ -81,7 +81,7 @@ describe("OpenCodeUi", () => {
           jsonrpc: "2.0",
           id: 3,
           method: "ui.press",
-          params: { key: "\u001b", modifiers: { ctrl: true } },
+          params: { key: "escape", modifiers: { ctrl: true } },
         },
         { jsonrpc: "2.0", id: 4, method: "ui.state" },
         {

--- a/test/simulation/direct-cli.test.ts
+++ b/test/simulation/direct-cli.test.ts
@@ -37,7 +37,13 @@ test.sequential("CLI drives an externally owned OpenCode endpoint on the default
           return
         }
         requests.push(request)
-        socket.send(JSON.stringify({ jsonrpc: "2.0", id: request.id, result: state }))
+        socket.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: request.method === "ui.screenshot" ? "/tmp/home.png" : state,
+          }),
+        )
       },
     },
   })
@@ -51,9 +57,14 @@ test.sequential("CLI drives an externally owned OpenCode endpoint on the default
     expect(second.status).toBe(0)
     expect(JSON.parse(second.stdout)).toEqual(state)
 
+    const screenshot = await send(root, ["--command.ui.screenshot", '{"name":"home"}'])
+    expect(screenshot.status).toBe(0)
+    expect(screenshot.stdout.trim()).toBe("/tmp/home.png")
+
     expect(requests).toEqual([
       { jsonrpc: "2.0", id: 1, method: "ui.state" },
       { jsonrpc: "2.0", id: 1, method: "ui.state" },
+      { jsonrpc: "2.0", id: 1, method: "ui.screenshot", params: { name: "home" } },
     ])
   } finally {
     await server.stop(true)
@@ -62,7 +73,11 @@ test.sequential("CLI drives an externally owned OpenCode endpoint on the default
 })
 
 async function sendState(root: string) {
-  const child = Bun.spawn([process.execPath, resolve("src/cli/index.ts"), "send", "--command.ui.state"], {
+  return send(root, ["--command.ui.state"])
+}
+
+async function send(root: string, args: string[]) {
+  const child = Bun.spawn([process.execPath, resolve("src/cli/index.ts"), "send", ...args], {
     cwd: resolve("."),
     env: {
       ...process.env,

--- a/test/simulation/ui.test.ts
+++ b/test/simulation/ui.test.ts
@@ -99,7 +99,7 @@ describe("OpenCode UI simulation transport", () => {
           jsonrpc: "2.0",
           id: 9,
           method: "ui.press",
-          params: { key: "\x1b" },
+          params: { key: "escape" },
         },
         { jsonrpc: "2.0", id: 10, method: "ui.enter" },
         {


### PR DESCRIPTION
## What

Keep Drive's `--command.ui.*` forwarding aligned with the canonical OpenCode frontend simulation protocol.

## Before / After

**Before:** `--command.ui.screenshot` could only omit the protocol's optional `{ name?: string }` parameters, and `ui.press` rewrote the caller's `"escape"` key to an ESC byte.

**After:** Screenshots accept either no value or the canonical optional JSON object, and key strings are forwarded unchanged. The checked-in skill documents the complete resize and screenshot forms.

## How

- `src/cli/parse.ts` recognizes screenshot parameters as optional without changing required command arguments.
- `src/cli/commands.ts` validates screenshot JSON through the copied frontend protocol and forwards its optional name.
- `src/simulation/protocol.ts` removes the non-canonical `"escape"` convenience rewrite.
- Transport tests assert exact JSON-RPC frames.
- A patch Changeset records the user-facing CLI correction.

## Scope

This does not add new UI commands. `ui.resize`, `ui.capture`, and handshake capability negotiation already match current OpenCode.

## Testing

- `bun run test:effect` (128 passed)
- focused protocol/CLI tests (12 passed)
- `bun run typecheck`
- `git diff --check`
