### PR TITLE
feat(catalog): copy and reproduce state IDs

### DIFF
--- a/apps/catalog/AGENTS.md
+++ b/apps/catalog/AGENTS.md
@@ -33,6 +33,19 @@ The module seams are:
 - `src/components/TerminalFrame.tsx`: derives canvas pixels from normalized frames.
 - `src/App.tsx`: owns active variant and selected screen state.
 
+## State Addresses
+
+Executable states have canonical `<flow-id>/<state-id>` addresses. The catalog viewer's **Copy ID** action copies that address in flow mode. In screen and UI-element modes it copies the standalone capture ID.
+
+Resolve and reproduce an executable state with:
+
+```bash
+bun run catalog:reproduce -- patch-success-lifecycle/permission-prompt \
+  --opencode /path/to/opencode
+```
+
+The command executes the recipe only through the selected state and prints the path to a normalized `opencode-terminal-frame-v1` artifact. `apps/catalog/scenarios/index.ts` is the executable-flow registry used for string resolution. An address is agent-replayable only after its flow is registered there; narrative catalog flows that have not migrated to executable recipes are browse-only.
+
 ## Protocol Convention
 
 Keep Drive `--command.ui.*` names and parameter shapes identical to the frontend portion of the canonical OpenCode simulation protocol. The raw-frame command is `ui.capture` with no parameters.

--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -1,5 +1,7 @@
 # OpenCode Terminal Catalog
 
+Production: <https://catalog.kitlangton.dev>
+
 Capture a reproducible catalog of OpenCode terminal states from local checkouts, browse every state in one web app, and flip between themes or branches without changing the selected screen.
 
 The catalog currently contains 23 scripted states covering the home screen, command and model pickers, integrations, themes, MCPs, permissions, questions, sessions, subagents, shell output, toasts, and the diff viewer.

--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -53,6 +53,16 @@ bun run dev
 In the catalog:
 
 - In the viewer, press left or right to move through flow steps and up or down to switch variants.
+- Use **Copy ID** to copy the active flow state address, or the capture ID when browsing screens directly.
+
+Reproduce a registered executable state against an OpenCode checkout:
+
+```bash
+bun run reproduce -- patch-success-lifecycle/permission-prompt \
+  --opencode /path/to/opencode
+```
+
+The command prints the path to a normalized terminal frame. Only states from flows registered in `scenarios/index.ts` are currently reproducible; other catalog flows remain browse-only until their recipes are migrated.
 - Click a card to open its full-screen viewer.
 - Press up or down in the viewer to move between screens.
 - Press `Escape` to close the viewer.

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate": "bun ./scripts/generate-catalog.ts",
     "capture": "bun ./scripts/capture-opencode-drive.ts",
+    "reproduce": "bun ./scripts/reproduce-state.ts",
     "dev": "bun ./server.ts",
     "lint": "oxlint src catalog scripts scenarios server.ts worker.ts",
     "typecheck": "tsc --noEmit",

--- a/apps/catalog/scenarios/index.ts
+++ b/apps/catalog/scenarios/index.ts
@@ -1,0 +1,3 @@
+import { patchSuccessFlow } from "./tools/patch-success"
+
+export const executableFlows = [patchSuccessFlow] as const

--- a/apps/catalog/scenarios/tools/patch-success.ts
+++ b/apps/catalog/scenarios/tools/patch-success.ts
@@ -83,12 +83,12 @@ export const patchSuccessFlow = defineExecutableFlow(
           ),
           Llm.finish("tool-calls"),
         )
-        yield* driver.llm.queue(Llm.text("The fixture was updated."))
         yield* driver.ui.submit("Change fixture.txt from before to after.")
         yield* Effect.sleep(450)
         yield* checkpoint(inputStreaming)
         yield* driver.ui.waitFor("Permission required", { timeout: 15_000 })
         yield* checkpoint(permissionPrompt)
+        yield* driver.llm.queue(Llm.text("The fixture was updated."))
         yield* driver.ui.enter()
         yield* driver.ui.waitFor("The fixture was updated.", { timeout: 15_000 })
         yield* checkpoint(success)

--- a/apps/catalog/scripts/reproduce-state.ts
+++ b/apps/catalog/scripts/reproduce-state.ts
@@ -1,0 +1,76 @@
+import { mkdir } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { Effect } from "effect"
+import { OpenCodeDriver } from "opencode-drive"
+import { executeFlow } from "../catalog/flow"
+import { executableFlows } from "../scenarios"
+
+const defaultOpenCode = fileURLToPath(new URL("../../../../opencode-v2-latest/", import.meta.url))
+const options = parseArgs(process.argv.slice(2))
+const selected = executableFlows.flatMap((flow) =>
+  flow.states.flatMap((state) => state.address === options.address ? [{ flow, state }] : []),
+)[0]
+
+if (!selected) {
+  const known = executableFlows.flatMap((flow) => flow.states.map((state) => state.address))
+  throw new Error(`Unknown catalog state ${JSON.stringify(options.address)}. Known states:\n${known.join("\n")}`)
+}
+
+await Effect.runPromise(
+  OpenCodeDriver.use(
+    {
+      project: { files: { "fixture.txt": "before\n" } },
+      config: {
+        autoupdate: false,
+        permissions: [{ action: "*", resource: "*", effect: "ask" }],
+      },
+      setup:
+        options.theme === undefined
+          ? undefined
+          : ({ fs }) =>
+              fs.writeFile(
+                ".opencode/tui.json",
+                `${JSON.stringify({ $schema: "https://opencode.ai/tui.json", theme: options.theme }, undefined, 2)}\n`,
+              ),
+      client: { viewport: { cols: 118, rows: 34 } },
+      opencode: { dev: options.opencode },
+    },
+    (driver) => executeFlow(selected.flow, {
+      driver,
+      through: selected.state,
+      capture: () => Effect.gen(function* () {
+        const frame = yield* driver.ui.capture()
+        yield* Effect.promise(() => mkdir(dirname(options.output), { recursive: true }))
+        yield* Effect.promise(() =>
+          Bun.write(
+            options.output,
+            `${JSON.stringify({ format: "opencode-terminal-frame-v1", ...frame })}\n`,
+          ),
+        )
+      }),
+    }),
+  ),
+)
+
+console.log(options.output)
+
+function parseArgs(args: ReadonlyArray<string>) {
+  const address = args[0]
+  if (!address || address.startsWith("--")) {
+    throw new Error("Usage: reproduce-state <flow-id/state-id> [--opencode path] [--output path] [--theme name]")
+  }
+  let opencode = defaultOpenCode
+  let output = resolve(`.tmp/reproductions/${address.replace("/", "--")}.frame.json`)
+  let theme: string | undefined
+  for (let index = 1; index < args.length; index++) {
+    const flag = args[index]
+    const value = args[++index]
+    if (!value) throw new Error(`${flag} requires a value`)
+    if (flag === "--opencode") opencode = resolve(value)
+    else if (flag === "--output") output = resolve(value)
+    else if (flag === "--theme") theme = value
+    else throw new Error(`Unknown argument ${flag}`)
+  }
+  return { address, opencode, output, theme }
+}

--- a/apps/catalog/src/App.tsx
+++ b/apps/catalog/src/App.tsx
@@ -313,6 +313,7 @@ export function App({ catalog }: AppProps) {
         <Viewer
           key={selectedScreen.id}
           screen={selectedScreen}
+          identifier={ui.mode === "flows" && activeFlow ? `${activeFlow.id}/${selectedScreen.id}` : selectedScreen.id}
           variant={activeVariant}
           variantPosition={variantIndex + 1}
           variantTotal={catalog.variants.length}

--- a/apps/catalog/src/components/Viewer.tsx
+++ b/apps/catalog/src/components/Viewer.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useEffectEvent, useRef } from "react"
+import { useEffect, useEffectEvent, useRef, useState } from "react"
 import type { Facet, Filter, Screen, Taxonomy, TaxonomyGroup, Variant } from "../catalog"
 import { facetValues, frameFor, label, taxonomyLabel } from "../catalog"
 import { TerminalFrame } from "./TerminalFrame"
 
 interface ViewerProps {
   readonly screen: Screen
+  readonly identifier: string
   readonly variant: Variant
   readonly variantPosition: number
   readonly variantTotal: number
@@ -24,6 +25,7 @@ const facetOrder: ReadonlyArray<Facet> = ["surface", "pattern", "feature", "stat
 
 export function Viewer({
   screen,
+  identifier,
   variant,
   variantPosition,
   variantTotal,
@@ -39,7 +41,17 @@ export function Viewer({
   onTaxonomy,
 }: ViewerProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle")
   const frame = frameFor(screen, variant.id)
+
+  const copyIdentifier = async () => {
+    try {
+      await navigator.clipboard.writeText(identifier)
+      setCopyStatus("copied")
+    } catch {
+      setCopyStatus("failed")
+    }
+  }
 
   useEffect(() => {
     dialogRef.current?.showModal()
@@ -88,6 +100,15 @@ export function Viewer({
           <button type="button" className="viewer-button" onClick={() => onNavigate(1)} aria-label="Next flow step">→</button>
         </span>
         <div className="viewer-actions">
+          <button
+            type="button"
+            className="viewer-button"
+            title={identifier}
+            aria-label={`Copy identifier ${identifier}`}
+            onClick={copyIdentifier}
+          >
+            {copyStatus === "copied" ? "Copied" : copyStatus === "failed" ? "Copy failed" : "Copy ID"}
+          </button>
           <button type="button" className="viewer-button" onClick={() => onVariant(-1)} aria-label="Previous variant">←</button>
           <span className="viewer-variant"><strong>{variant.label}</strong> {variantPosition}/{variantTotal}</span>
           <button type="button" className="viewer-button" onClick={() => onVariant(1)} aria-label="Next variant">→</button>

--- a/apps/catalog/wrangler.jsonc
+++ b/apps/catalog/wrangler.jsonc
@@ -5,5 +5,11 @@
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS"
-  }
+  },
+  "routes": [
+    {
+      "pattern": "catalog.kitlangton.dev",
+      "custom_domain": true
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "bun run --cwd packages/drive test && bun run --cwd apps/catalog test",
     "catalog": "bun run --cwd apps/catalog dev",
     "catalog:capture": "bun run --cwd apps/catalog capture",
+    "catalog:reproduce": "bun run --cwd apps/catalog reproduce",
     "release:version": "changeset version",
     "release:validate": "bun run --cwd packages/drive release:validate",
     "release": "bun run release:validate && changeset publish"


### PR DESCRIPTION
## What

Make catalog state identifiers discoverable and executable.

The viewer now exposes a **Copy ID** action. Flow mode copies a canonical address such as `patch-success-lifecycle/permission-prompt`; direct screen browsing copies the capture ID.

Agents can resolve a registered state address with:

```sh
bun run catalog:reproduce -- patch-success-lifecycle/permission-prompt \
  --opencode /path/to/opencode
```

## How

- Pass the active flow-owned address into `Viewer` and copy it through the Clipboard API with visible success/failure feedback.
- Add `scenarios/index.ts` as the executable-flow registry.
- Add `scripts/reproduce-state.ts` to resolve an address, run only through its typed checkpoint, and write a normalized terminal frame.
- Queue future LLM responses after their preceding checkpoint so selected prefix runs settle without unused responses.
- Document the human and agent workflows in the catalog guide and README.

## Scope

Only registered executable flows are replayable. The patch lifecycle is currently the only registered recipe; narrative catalog flows remain browse-only until migrated.

## Testing

- `bun run check` in `apps/catalog`: lint, typecheck, 10 tests, and both bundles passed.
- Reproduced `patch-success-lifecycle/permission-prompt` end-to-end against the beta.98 OpenCode checkout and wrote a nonempty normalized frame.
- Deployed Cloudflare Worker version `559c6623-e435-4475-8604-4a35ab698810`.
- Verified the production button copies the exact canonical address and changes to `Copied` with no page errors.

## Demo

![Copy catalog state ID](https://github.com/user-attachments/assets/6c4a32cb-87c3-4a5f-9cbb-4a21f265b517)
