### PR TITLE
fix(catalog): expose IDs on capture cards

### DIFF
--- a/apps/catalog/src/components/ContactSheet.tsx
+++ b/apps/catalog/src/components/ContactSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useEffectEvent, useRef } from "react"
 import type { BrowseMode, Screen, TaxonomyGroup } from "../catalog"
 import { frameFor, taxonomyLabel } from "../catalog"
+import { CopyIdButton } from "./CopyIdButton"
 import { TerminalFrame } from "./TerminalFrame"
 
 interface ContactSheetProps {
@@ -81,31 +82,36 @@ export function ContactSheet({
           const values = mode === "screens" ? screen.screenLabels : screen.uiElements
           const frame = frameFor(screen, variantId)
           return (
-            <button
+            <article
               key={screen.id}
-              type="button"
-              data-screen={screen.id}
               className={`capture-card${screen.id === selectedId ? " selected" : ""}`}
-              tabIndex={screen.id === selectedId ? 0 : -1}
-              aria-label={`Open ${screen.title}`}
-              onClick={() => onOpen(screen.id)}
-              onFocus={() => {
-                if (screen.id !== selectedId) onSelect(screen.id)
-              }}
             >
-              <span className="capture-frame">
-                <TerminalFrame frame={frame} label={screen.title} lazy />
-              </span>
-              <span className="capture-caption">
-                <span className="capture-title">{screen.title}</span>
-                <span className="capture-labels">
-                  {values.slice(0, 3).map((value) => (
-                    <span key={value}>{taxonomyLabel(taxonomy, value)}</span>
-                  ))}
-                  {values.length > 3 ? <span>+{values.length - 3}</span> : undefined}
+              <button
+                type="button"
+                data-screen={screen.id}
+                className="capture-open"
+                tabIndex={screen.id === selectedId ? 0 : -1}
+                aria-label={`Open ${screen.title}`}
+                onClick={() => onOpen(screen.id)}
+                onFocus={() => {
+                  if (screen.id !== selectedId) onSelect(screen.id)
+                }}
+              >
+                <span className="capture-frame">
+                  <TerminalFrame frame={frame} label={screen.title} lazy />
                 </span>
-              </span>
-            </button>
+                <span className="capture-caption">
+                  <span className="capture-title">{screen.title}</span>
+                  <span className="capture-labels">
+                    {values.slice(0, 3).map((value) => (
+                      <span key={value}>{taxonomyLabel(taxonomy, value)}</span>
+                    ))}
+                    {values.length > 3 ? <span>+{values.length - 3}</span> : undefined}
+                  </span>
+                </span>
+              </button>
+              <CopyIdButton identifier={screen.id} />
+            </article>
           )
         })
       )}

--- a/apps/catalog/src/components/CopyIdButton.tsx
+++ b/apps/catalog/src/components/CopyIdButton.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react"
+
+interface CopyIdButtonProps {
+  readonly identifier: string
+  readonly className?: string
+}
+
+export function CopyIdButton({ identifier, className = "" }: CopyIdButtonProps) {
+  const [status, setStatus] = useState<"idle" | "copied" | "failed">("idle")
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(identifier)
+      setStatus("copied")
+    } catch {
+      setStatus("failed")
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={`copy-id-action ${className}`.trim()}
+      title={identifier}
+      aria-label={`Copy identifier ${identifier}`}
+      onClick={copy}
+    >
+      {status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy ID"}
+    </button>
+  )
+}

--- a/apps/catalog/src/components/FlowBrowser.tsx
+++ b/apps/catalog/src/components/FlowBrowser.tsx
@@ -1,5 +1,6 @@
 import type { Catalog, Flow } from "../catalog"
 import { frameFor } from "../catalog"
+import { CopyIdButton } from "./CopyIdButton"
 import { TerminalFrame } from "./TerminalFrame"
 
 interface FlowBrowserProps {
@@ -76,7 +77,7 @@ export function FlowBrowser({ catalog, flows, activeFlow, variantId, onFlow, onO
             const frame = frameFor(screen, variantId)
             return (
               <li key={`${activeFlow.id}:${index}:${step.screenId}`} className="flow-step">
-                <button type="button" onClick={() => onOpen(screen.id)}>
+                <button type="button" className="flow-open" onClick={() => onOpen(screen.id)}>
                   <span className="flow-frame">
                     <TerminalFrame frame={frame} label={screen.title} lazy />
                   </span>
@@ -88,6 +89,7 @@ export function FlowBrowser({ catalog, flows, activeFlow, variantId, onFlow, onO
                     </span>
                   </span>
                 </button>
+                <CopyIdButton identifier={`${activeFlow.id}/${screen.id}`} />
               </li>
             )
           })}

--- a/apps/catalog/src/components/Viewer.tsx
+++ b/apps/catalog/src/components/Viewer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useEffectEvent, useRef, useState } from "react"
+import { useEffect, useEffectEvent, useRef } from "react"
 import type { Facet, Filter, Screen, Taxonomy, TaxonomyGroup, Variant } from "../catalog"
 import { facetValues, frameFor, label, taxonomyLabel } from "../catalog"
+import { CopyIdButton } from "./CopyIdButton"
 import { TerminalFrame } from "./TerminalFrame"
 
 interface ViewerProps {
@@ -41,17 +42,7 @@ export function Viewer({
   onTaxonomy,
 }: ViewerProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
-  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle")
   const frame = frameFor(screen, variant.id)
-
-  const copyIdentifier = async () => {
-    try {
-      await navigator.clipboard.writeText(identifier)
-      setCopyStatus("copied")
-    } catch {
-      setCopyStatus("failed")
-    }
-  }
 
   useEffect(() => {
     dialogRef.current?.showModal()
@@ -100,15 +91,7 @@ export function Viewer({
           <button type="button" className="viewer-button" onClick={() => onNavigate(1)} aria-label="Next flow step">→</button>
         </span>
         <div className="viewer-actions">
-          <button
-            type="button"
-            className="viewer-button"
-            title={identifier}
-            aria-label={`Copy identifier ${identifier}`}
-            onClick={copyIdentifier}
-          >
-            {copyStatus === "copied" ? "Copied" : copyStatus === "failed" ? "Copy failed" : "Copy ID"}
-          </button>
+          <CopyIdButton identifier={identifier} className="viewer-button" />
           <button type="button" className="viewer-button" onClick={() => onVariant(-1)} aria-label="Previous variant">←</button>
           <span className="viewer-variant"><strong>{variant.label}</strong> {variantPosition}/{variantTotal}</span>
           <button type="button" className="viewer-button" onClick={() => onVariant(1)} aria-label="Next variant">→</button>

--- a/apps/catalog/src/styles.css
+++ b/apps/catalog/src/styles.css
@@ -464,6 +464,13 @@ kbd {
   gap: 0.65rem;
   min-width: 0;
   width: 100%;
+}
+
+.capture-open {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+  width: 100%;
   background: transparent;
   text-align: left;
 }
@@ -515,7 +522,7 @@ kbd {
   font-size: 0.52rem;
 }
 
-.capture-card:focus-visible {
+.capture-open:focus-visible {
   outline: 0;
 }
 
@@ -559,9 +566,24 @@ kbd {
   white-space: nowrap;
 }
 
-.capture-card:hover .capture-title,
+.capture-open:hover .capture-title,
 .capture-card.selected .capture-title,
-.capture-card:focus-visible .capture-title {
+.capture-open:focus-visible .capture-title {
+  color: var(--kit-fg-strong);
+}
+
+.copy-id-action {
+  width: fit-content;
+  padding: 0.3rem 0.45rem;
+  border: 1px solid var(--kit-line);
+  color: var(--kit-fg-faint);
+  font-family: var(--kit-mono);
+  font-size: 0.56rem;
+}
+
+.copy-id-action:hover,
+.copy-id-action:focus-visible {
+  border-color: var(--catalog-frame-line-strong);
   color: var(--kit-fg-strong);
 }
 
@@ -739,11 +761,13 @@ kbd {
 }
 
 .flow-step {
+  display: grid;
   min-width: 0;
+  gap: 0.75rem;
   scroll-snap-align: start;
 }
 
-.flow-step button {
+.flow-open {
   display: grid;
   width: 100%;
   gap: 0.85rem;
@@ -756,16 +780,16 @@ kbd {
   outline-offset: -1px;
 }
 
-.flow-step button:hover .flow-frame,
-.flow-step button:focus-visible .flow-frame {
+.flow-open:hover .flow-frame,
+.flow-open:focus-visible .flow-frame {
   outline-color: var(--catalog-frame-line-strong);
 }
 
-.flow-step button:focus-visible {
+.flow-open:focus-visible {
   outline: 0;
 }
 
-.flow-step button:focus-visible .flow-frame {
+.flow-open:focus-visible .flow-frame {
   outline: 1px solid var(--catalog-accent);
   outline-offset: 0.3rem;
 }


### PR DESCRIPTION
## What

Expose **Copy ID** directly on every screen and flow-state card instead of hiding it inside the full-screen viewer.

## Before / After

**Before:** the default catalog grid had no visible identifier action. Users had to open a frame before the viewer header exposed **Copy ID**.

**After:** every preview card has a persistent, separate **Copy ID** action with copied/failed feedback. Screen cards copy capture IDs; flow cards copy canonical `<flow-id>/<state-id>` addresses. The viewer action remains available.

## Testing

- `bun run check` in `apps/catalog`
- Verified 23 visible copy actions on the default screen grid.
- Verified the patch permission flow card exposes `patch-success-lifecycle/permission-prompt` without opening the viewer.
