### PR TITLE
fix(catalog): align flow step ids with titles

### DIFF
--- a/apps/catalog/src/components/ContactSheet.tsx
+++ b/apps/catalog/src/components/ContactSheet.tsx
@@ -98,7 +98,7 @@ export function ContactSheet({
               </button>
               <footer className="capture-caption">
                 <span className="capture-title">{screen.title}</span>
-                <IdChip id={screen.id} />
+                <IdChip id={screen.id} className="id-chip-end" />
               </footer>
             </article>
           )

--- a/apps/catalog/src/components/FlowBrowser.tsx
+++ b/apps/catalog/src/components/FlowBrowser.tsx
@@ -89,10 +89,12 @@ export function FlowBrowser({ catalog, flows, activeFlow, variantId, onFlow, onO
                 </button>
                 <footer className="flow-step-meta">
                   <span className="flow-step-number">{String(index + 1).padStart(2, "0")}</span>
-                  <span>
-                    <strong>{step.title}</strong>
+                  <span className="flow-step-text">
+                    <span className="flow-step-title">
+                      <strong>{step.title}</strong>
+                      <IdChip id={`${activeFlow.id}/${screen.id}`} className="id-chip-end" />
+                    </span>
                     {step.trigger ? <small>{step.trigger}</small> : undefined}
-                    <IdChip id={`${activeFlow.id}/${screen.id}`} />
                   </span>
                 </footer>
               </li>

--- a/apps/catalog/src/styles.css
+++ b/apps/catalog/src/styles.css
@@ -546,10 +546,6 @@ kbd {
   flex: 0 1 auto;
 }
 
-.capture-caption .id-chip-text {
-  justify-items: end;
-}
-
 .capture-title {
   overflow: hidden;
   color: var(--kit-fg-muted);
@@ -609,6 +605,10 @@ kbd {
 
 .id-chip-copied {
   visibility: hidden;
+}
+
+.id-chip-end .id-chip-text {
+  justify-items: end;
 }
 
 .id-chip[data-copied] .id-chip-value {
@@ -834,24 +834,37 @@ kbd {
 .flow-step-meta {
   display: grid;
   grid-template-columns: 1.6rem minmax(0, 1fr);
+  align-items: baseline;
   gap: 0.7rem;
 }
 
 .flow-step-number {
-  padding-top: 0.1rem;
   color: var(--catalog-accent);
   font-family: var(--kit-mono);
   font-size: 0.6rem;
   font-variant-numeric: tabular-nums;
 }
 
-.flow-step-meta > span:last-child {
+.flow-step-text {
   display: grid;
   gap: 0.3rem;
-  justify-items: start;
+  min-width: 0;
+}
+
+.flow-step-title {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.flow-step-title .id-chip {
+  flex: 0 1 auto;
 }
 
 .flow-step-meta strong {
+  min-width: 0;
   overflow: hidden;
   color: var(--kit-fg-strong);
   font-size: 0.83rem;


### PR DESCRIPTION
## What

Clean up the flow-step meta layout: the canonical ID chip now sits right-aligned on the title baseline (matching the screen-card caption pattern) instead of stacking as a third faint line under the trigger.

## How

- `.flow-step-title` flex row: title left, `IdChip` right, baseline-aligned; both truncate gracefully at narrow widths.
- Step number baseline-aligns with the title via `align-items: baseline` on the meta grid.
- Shared `id-chip-end` modifier right-aligns the copied overlay for card and flow chips.

## Testing

- `bun run check` in `apps/catalog`.
- Real Chromium: verified baseline alignment, long-ID rendering (`patch-success-lifecycle/permission-prompt`), and truncation at 1100px.