### PR TITLE
feat(catalog): compare immutable revision sets

### DIFF
--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -188,7 +188,7 @@ The application deploys as a Cloudflare Worker with static assets:
 bun run deploy
 ```
 
-Current deployment: https://opencode-terminal-catalog.kit-langton.workers.dev
+Current deployment: https://catalog.kitlangton.dev
 
 ## Troubleshooting
 

--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -21,11 +21,13 @@ bun install
 
 The OpenCode checkout can live anywhere. Capture commands receive its path explicitly; no sibling-directory layout is required.
 
-## Capture One Checkout
+## Capture Revision Sets
 
 ```bash
 bun run capture -- \
-  --variant baseline=$HOME/code/opencode
+  --opencode $HOME/code/opencode \
+  --revision v2~1 \
+  --revision v2
 
 bun run generate
 bun run dev
@@ -33,7 +35,7 @@ bun run dev
 
 Open the URL printed by `bun run dev`.
 
-`baseline` is the variant ID shown in the catalog. Variant IDs must be lowercase slugs such as `baseline`, `rosepine`, or `theme-redesign`.
+Each revision is resolved to an immutable commit and captured from an isolated detached worktree. Set IDs are derived from the commit SHA, prior sets remain in the manifest, and rerunning the same commit/theme replaces only that set. Sets are ordered by commit time, so the newest commit is selected when the catalog opens.
 
 ## Compare Themes
 
@@ -41,20 +43,21 @@ Variants can use the same OpenCode checkout with different configured themes:
 
 ```bash
 bun run capture -- \
-  --variant opencode=$HOME/code/opencode \
-  --theme opencode=opencode \
-  --variant rosepine=$HOME/code/opencode \
-  --theme rosepine=rosepine
+  --opencode $HOME/code/opencode \
+  --revision v2 \
+  --theme opencode \
+  --theme rosepine
 
 bun run generate
 bun run dev
 ```
 
-`--theme` uses `variant-id=theme-name`, so each theme is attached to one declared variant. Built-in names include `opencode`, `nord`, `one-dark`, `gruvbox`, `rosepine`, `solarized`, `monokai`, and `palenight`.
+Repeated revisions and themes form a cross-product. Use `--theme default` to include OpenCode's configured default alongside named themes. Built-in names include `opencode`, `nord`, `one-dark`, `gruvbox`, `rosepine`, `solarized`, `monokai`, and `palenight`.
 
 In the catalog:
 
-- In the viewer, press left or right to move through flow steps and up or down to switch variants.
+- Use the capture-set picker or press up/down to compare revisions and themes without losing the current screen.
+- In the viewer, press left/right to move through flow steps and up/down to switch capture sets.
 - Use **Copy ID** to copy the active flow state address, or the capture ID when browsing screens directly.
 
 Reproduce a registered executable state against an OpenCode checkout:
@@ -72,12 +75,13 @@ The command prints the path to a normalized terminal frame. Only states from flo
 
 ## Compare Branches
 
-Create two OpenCode worktrees or clones, then capture both:
+Capture any refs available in one OpenCode checkout:
 
 ```bash
 bun run capture -- \
-  --variant before=$HOME/code/opencode-main \
-  --variant after=$HOME/code/opencode-redesign
+  --opencode $HOME/code/opencode \
+  --revision main \
+  --revision v2
 
 bun run generate
 bun run dev
@@ -87,13 +91,14 @@ Themes and checkout comparisons can be combined:
 
 ```bash
 bun run capture -- \
-  --variant main-nord=$HOME/code/opencode-main \
-  --theme main-nord=nord \
-  --variant redesign-nord=$HOME/code/opencode-redesign \
-  --theme redesign-nord=nord
+  --opencode $HOME/code/opencode \
+  --revision main \
+  --revision v2 \
+  --theme nord \
+  --theme rosepine
 ```
 
-Each variant runs in an isolated OpenCode Drive instance. Independent variants capture concurrently, while the states inside one variant remain sequential so session-dependent states stay deterministic.
+Each capture set runs in an isolated OpenCode Drive instance. Independent sets capture concurrently, while states inside one set remain sequential so session-dependent states stay deterministic.
 
 ## Agent Workflow
 
@@ -117,10 +122,11 @@ The equivalent commands are:
 ```bash
 bun install
 bun run capture -- \
-  --variant baseline=$HOME/code/opencode-main \
-  --theme baseline=opencode \
-  --variant redesign=$HOME/code/opencode-redesign \
-  --theme redesign=rosepine
+  --opencode $HOME/code/opencode \
+  --revision v2~1 \
+  --revision v2 \
+  --theme opencode \
+  --theme rosepine
 bun run generate
 bun run typecheck
 bun run test

--- a/apps/catalog/catalog/authored/flows.ts
+++ b/apps/catalog/catalog/authored/flows.ts
@@ -62,6 +62,7 @@ export const flowGroups = defineFlows(screens, {
       "patch-success-lifecycle": {
         title: patchSuccessFlow.title,
         description: patchSuccessFlow.description,
+        replayable: true,
         steps: stepsFromFlow(patchSuccessFlow),
       },
       "approving-a-tool-call": {

--- a/apps/catalog/catalog/authoring.test.ts
+++ b/apps/catalog/catalog/authoring.test.ts
@@ -8,7 +8,15 @@ import type { DriveManifest } from "./schema"
 const manifest: DriveManifest = {
   format: "opencode-terminal-frame-captures-v1",
   generatedBy: "scripts/capture-opencode-drive.ts",
-  variants: [{ id: "baseline", label: "Baseline", source: "/tmp/opencode", revision: "abc123", theme: "opencode" }],
+  variants: [{
+    id: "baseline",
+    label: "Baseline",
+    source: "/tmp/opencode",
+    revision: "abc123",
+    ref: "v2",
+    committedAt: "2026-07-17T10:17:51Z",
+    theme: "opencode",
+  }],
   captures: [
     {
       id: "home",

--- a/apps/catalog/catalog/authoring.ts
+++ b/apps/catalog/catalog/authoring.ts
@@ -70,6 +70,7 @@ export const compileCatalog = Effect.fn("Catalog.compile")(function*(
         title: flow.title,
         group: group.label,
         description: flow.description,
+        replayable: flow.replayable ?? false,
         steps,
       }
     }),

--- a/apps/catalog/catalog/capture-sets.test.ts
+++ b/apps/catalog/catalog/capture-sets.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import type { DriveManifest, Variant } from "./schema"
+import {
+  captureSetId,
+  captureSetLabel,
+  mergeCaptureHistory,
+  parseCaptureOptions,
+  sortCaptureSets,
+} from "../scripts/capture-sets"
+
+const set = (id: string, committedAt: string): Variant => ({
+  id,
+  label: id,
+  source: "opencode",
+  revision: id.repeat(40).slice(0, 40),
+  ref: id,
+  committedAt,
+})
+
+describe("capture revision sets", () => {
+  test("parses repeated revisions and themes", () => {
+    expect(parseCaptureOptions([
+      "--opencode", "./opencode",
+      "--revision", "v2~1",
+      "--revision", "v2",
+      "--theme", "opencode",
+      "--theme", "rosepine",
+    ], "/default")).toEqual({
+      opencode: `${process.cwd()}/opencode`,
+      revisions: ["v2~1", "v2"],
+      themes: ["opencode", "rosepine"],
+    })
+  })
+
+  test("derives immutable commit and theme IDs", () => {
+    expect(captureSetId("ABCDEF1234567890", undefined)).toBe("abcdef123456")
+    expect(captureSetId("ABCDEF1234567890", "One Dark")).toBe("abcdef123456-one-dark")
+    expect(captureSetLabel("abcdef1234567890", "rosepine")).toBe("abcdef1 / rosepine")
+  })
+
+  test("sorts newest commits first", () => {
+    const older = set("a", "2026-07-16T12:00:00Z")
+    const newer = set("b", "2026-07-17T12:00:00Z")
+    expect(sortCaptureSets([older, newer]).map((variant) => variant.id)).toEqual(["b", "a"])
+  })
+
+  test("retains history and replaces a recaptured set", () => {
+    const old = set("old", "2026-07-16T12:00:00Z")
+    const current = set("current", "2026-07-17T12:00:00Z")
+    const manifest: DriveManifest = {
+      format: "opencode-terminal-frame-captures-v1",
+      generatedBy: "test",
+      variants: [current, old],
+      captures: [{
+        id: "home",
+        title: "Home",
+        category: "system",
+        frames: [
+          { variantId: "current", src: "captures/current/home.frame.json", cols: 1, rows: 1 },
+          { variantId: "old", src: "captures/old/home.frame.json", cols: 1, rows: 1 },
+        ],
+      }],
+    }
+    const recaptured = { ...current, label: "current / rosepine", theme: "rosepine" }
+    const merged = mergeCaptureHistory(manifest, [recaptured], [{
+      id: "home",
+      title: "Home",
+      category: "system",
+      frames: [{ variantId: "current", src: "captures/current/home.frame.json", cols: 2, rows: 2 }],
+    }])
+
+    expect(merged.variants.map((variant) => variant.id)).toEqual(["current", "old"])
+    expect(merged.variants[0]?.theme).toBe("rosepine")
+    expect(merged.captures[0]?.frames).toEqual([
+      { variantId: "current", src: "captures/current/home.frame.json", cols: 2, rows: 2 },
+      { variantId: "old", src: "captures/old/home.frame.json", cols: 1, rows: 1 },
+    ])
+  })
+})

--- a/apps/catalog/catalog/dsl.ts
+++ b/apps/catalog/catalog/dsl.ts
@@ -23,7 +23,17 @@ export const Patterns = [
 ] as const
 export type Pattern = (typeof Patterns)[number]
 
-export const States = ["default", "empty", "populated", "streaming", "confirmation", "success", "error"] as const
+export const States = [
+  "default",
+  "empty",
+  "populated",
+  "pending",
+  "running",
+  "streaming",
+  "confirmation",
+  "success",
+  "error",
+] as const
 export type ScreenState = (typeof States)[number]
 
 export type TaxonomyDefinition = Readonly<
@@ -78,6 +88,7 @@ export interface FlowStepDefinition<CaptureId extends string> {
 export interface FlowDefinition<CaptureId extends string> {
   readonly title: string
   readonly description: string
+  readonly replayable?: boolean
   readonly steps: NonEmpty<FlowStepDefinition<CaptureId>>
 }
 

--- a/apps/catalog/catalog/schema.ts
+++ b/apps/catalog/catalog/schema.ts
@@ -16,6 +16,8 @@ export const Variant = Schema.Struct({
   label: Schema.NonEmptyString,
   source: Schema.NonEmptyString,
   revision: Schema.NonEmptyString,
+  ref: Schema.NonEmptyString,
+  committedAt: Schema.NonEmptyString,
   theme: Schema.optionalKey(Schema.NonEmptyString),
 })
 
@@ -77,6 +79,7 @@ export const Flow = Schema.Struct({
   title: Schema.NonEmptyString,
   group: Schema.NonEmptyString,
   description: Schema.NonEmptyString,
+  replayable: Schema.Boolean,
   steps: Schema.NonEmptyArray(FlowStep),
 })
 

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -22,6 +22,7 @@
     "@fontsource/noto-sans-math": "5.2.8",
     "@fontsource/noto-sans-symbols": "5.2.8",
     "@fontsource/noto-sans-symbols-2": "5.2.8",
+    "motion": "^12.42.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/catalog/public/catalog.json
+++ b/apps/catalog/public/catalog.json
@@ -6,13 +6,17 @@
       "id": "baseline",
       "label": "baseline",
       "source": "opencode-effect-beta-98",
-      "revision": "801f019fef49"
+      "revision": "801f019fef495aabf6c82c8f6e34d41482724ff4",
+      "ref": "801f019fef49",
+      "committedAt": "2026-07-17T10:17:51-04:00"
     },
     {
       "id": "rosepine",
       "label": "rosepine",
       "source": "opencode-effect-beta-98",
-      "revision": "801f019fef49",
+      "revision": "801f019fef495aabf6c82c8f6e34d41482724ff4",
+      "ref": "801f019fef49",
+      "committedAt": "2026-07-17T10:17:51-04:00",
       "theme": "rosepine"
     }
   ],
@@ -1752,6 +1756,7 @@
       "title": "Starting a session",
       "group": "Getting started",
       "description": "Begin from the OpenCode start screen and prepare a new conversation.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "home",
@@ -1775,6 +1780,7 @@
       "title": "Switching sessions",
       "group": "Session management",
       "description": "Find an existing conversation and resume it from the session picker.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "command-palette",
@@ -1798,6 +1804,7 @@
       "title": "Renaming a session",
       "group": "Session management",
       "description": "Give the current conversation a recognizable name.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "session-picker-populated",
@@ -1815,6 +1822,7 @@
       "title": "Forking a session",
       "group": "Session management",
       "description": "Branch an existing conversation from a selected message.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "session-picker-populated",
@@ -1832,6 +1840,7 @@
       "title": "Exporting a session",
       "group": "Session management",
       "description": "Choose an export format and confirm the transcript was copied.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "session-export",
@@ -1850,6 +1859,7 @@
       "title": "Patch succeeds",
       "group": "Tool use",
       "description": "Watch a patch stream its input, request permission, and complete successfully.",
+      "replayable": true,
       "steps": [
         {
           "screenId": "patch-input-streaming",
@@ -1870,6 +1880,7 @@
       "title": "Approving a tool call",
       "group": "Tool use",
       "description": "Review a requested operation and choose its permission scope.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "permission-prompt",
@@ -1883,6 +1894,7 @@
       "title": "Answering an agent question",
       "group": "Tool use",
       "description": "Respond to a structured question without leaving the conversation.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "question-prompt",
@@ -1896,6 +1908,7 @@
       "title": "Connecting an integration",
       "group": "Configuration",
       "description": "Choose an integration and verify its connection state.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "integration-picker",
@@ -1912,6 +1925,7 @@
       "title": "Managing MCP servers",
       "group": "Configuration",
       "description": "Inspect configured MCP servers and their runtime status.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "mcp-list",
@@ -1928,6 +1942,7 @@
       "title": "Pairing a device",
       "group": "Configuration",
       "description": "Open the pairing code used to connect another device.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "pair",
@@ -1940,6 +1955,7 @@
       "title": "Reviewing a diff",
       "group": "Review",
       "description": "Inspect the working tree and verify whether files have changed.",
+      "replayable": false,
       "steps": [
         {
           "screenId": "diff-viewer",

--- a/apps/catalog/public/drive-captures.json
+++ b/apps/catalog/public/drive-captures.json
@@ -6,13 +6,17 @@
       "id": "baseline",
       "label": "baseline",
       "source": "opencode-effect-beta-98",
-      "revision": "801f019fef49"
+      "revision": "801f019fef495aabf6c82c8f6e34d41482724ff4",
+      "ref": "801f019fef49",
+      "committedAt": "2026-07-17T10:17:51-04:00"
     },
     {
       "id": "rosepine",
       "label": "rosepine",
       "source": "opencode-effect-beta-98",
-      "revision": "801f019fef49",
+      "revision": "801f019fef495aabf6c82c8f6e34d41482724ff4",
+      "ref": "801f019fef49",
+      "committedAt": "2026-07-17T10:17:51-04:00",
       "theme": "rosepine"
     }
   ],

--- a/apps/catalog/scripts/capture-opencode-drive.ts
+++ b/apps/catalog/scripts/capture-opencode-drive.ts
@@ -1,5 +1,6 @@
-import { mkdir } from "node:fs/promises"
-import { basename, resolve } from "node:path"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Effect } from "effect"
 import { Llm, OpenCodeDriver } from "opencode-drive"
@@ -7,6 +8,14 @@ import { screens, type CaptureId } from "../catalog/authored/screens"
 import type { ScreenCategory } from "../catalog/dsl"
 import { executeFlow } from "../catalog/flow"
 import { patchSuccessFlow } from "../scenarios/tools/patch-success"
+import type { DriveManifest, Variant as CaptureSet } from "../catalog/schema"
+import {
+  captureSetId,
+  captureSetLabel,
+  captureSource,
+  mergeCaptureHistory,
+  parseCaptureOptions,
+} from "./capture-sets"
 
 type Capture = {
   readonly id: CaptureId
@@ -25,13 +34,17 @@ type Variant = {
   readonly label: string
   readonly source: string
   readonly revision: string
+  readonly ref: string
+  readonly committedAt: string
   readonly path: string
   readonly theme?: string
 }
 
 const viewport = { cols: 118, rows: 34 } as const
 const defaultOpenCode = fileURLToPath(new URL("../../../../opencode-v2-latest/", import.meta.url))
-const variants = await Effect.runPromise(parseVariants(process.argv.slice(2)))
+const options = parseCaptureOptions(process.argv.slice(2), defaultOpenCode)
+const prepared = await prepareCaptureSets(options)
+const variants = prepared.variants
 
 const captureVariant = (variant: Variant) => OpenCodeDriver.use(
   {
@@ -198,89 +211,84 @@ const captureVariant = (variant: Variant) => OpenCodeDriver.use(
     }),
 )
 
-const captured = await Effect.runPromise(
-  Effect.forEach(variants, captureVariant, { concurrency: Math.min(variants.length, 2) }),
-)
-const captures = captured[0]?.map((first) => ({
-  id: first.id,
-  title: first.title,
-  category: first.category,
-  frames: captured.flatMap((variantCaptures) =>
-    variantCaptures.filter((capture) => capture.id === first.id).map((capture) => capture.frame),
-  ),
-})) ?? []
-await Bun.write(
-  new URL("../public/drive-captures.json", import.meta.url),
-  `${JSON.stringify(
-    {
-      format: "opencode-terminal-frame-captures-v1",
-      generatedBy: "scripts/capture-opencode-drive.ts",
-      variants: variants.map(({ id, label, source, revision, theme }) => ({
-        id,
-        label,
-        source,
-        revision,
-        ...(theme === undefined ? {} : { theme }),
-      })),
-      captures,
-    },
-    undefined,
-    2,
-  )}\n`,
-)
+try {
+  const captured = await Effect.runPromise(
+    Effect.forEach(variants, captureVariant, { concurrency: Math.min(variants.length, 2) }),
+  )
+  const captures = captured[0]?.map((first) => ({
+    id: first.id,
+    title: first.title,
+    category: first.category,
+    frames: captured.flatMap((variantCaptures) =>
+      variantCaptures.filter((capture) => capture.id === first.id).map((capture) => capture.frame),
+    ) as [Capture["frame"], ...Array<Capture["frame"]>],
+  })) ?? []
+  const manifestFile = new URL("../public/drive-captures.json", import.meta.url)
+  const previous = await readPreviousManifest(manifestFile)
+  const captureSets = variants.map(({ path: _, ...variant }) => variant satisfies CaptureSet)
+  const manifest = mergeCaptureHistory(previous, captureSets, captures)
+  await Bun.write(manifestFile, `${JSON.stringify(manifest, undefined, 2)}\n`)
+} finally {
+  await prepared.cleanup()
+}
 
-function parseVariants(args: ReadonlyArray<string>) {
-  return Effect.gen(function* () {
-    const values: Array<string> = []
-    const themes = new Map<string, string>()
-    for (let index = 0; index < args.length; index++) {
-      if (args[index] === "--theme") {
-        const value = args[++index]
-        if (!value) return yield* Effect.fail(new Error("--theme requires variant=theme"))
-        const separator = value.indexOf("=")
-        if (separator <= 0 || separator === value.length - 1) {
-          return yield* Effect.fail(new Error(`Invalid theme ${JSON.stringify(value)}; expected variant=theme`))
-        }
-        themes.set(value.slice(0, separator), value.slice(separator + 1))
-        continue
-      }
-      if (args[index] !== "--variant") {
-        return yield* Effect.fail(new Error(`Unknown capture argument: ${args[index]}`))
-      }
-      const value = args[++index]
-      if (!value) return yield* Effect.fail(new Error("--variant requires name=path"))
-      values.push(value)
+async function prepareCaptureSets(options: ReturnType<typeof parseCaptureOptions>) {
+  const worktrees: Array<string> = []
+  const variants: Array<Variant> = []
+  const revisions = new Map<string, { ref: string; committedAt: string; path: string }>()
+
+  try {
+    for (const ref of options.revisions) {
+      const revision = await git(options.opencode, "rev-parse", `${ref}^{commit}`)
+      if (revisions.has(revision)) continue
+      const committedAt = await git(options.opencode, "show", "-s", "--format=%cI", revision)
+      const path = await mkdtemp(join(tmpdir(), "opencode-catalog-"))
+      await command(["git", "worktree", "add", "--detach", path, revision], options.opencode)
+      worktrees.push(path)
+      await command(["bun", "install", "--frozen-lockfile"], path)
+      revisions.set(revision, { ref, committedAt, path })
     }
-    if (values.length === 0) values.push(`v2=${defaultOpenCode}`)
-    return yield* Effect.forEach(values, (value) =>
-      Effect.gen(function* () {
-        const separator = value.indexOf("=")
-        const id = separator === -1 ? "" : value.slice(0, separator)
-        const source = resolve(separator === -1 ? "" : value.slice(separator + 1))
-        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id) || separator === value.length - 1) {
-          return yield* Effect.fail(new Error(`Invalid variant ${JSON.stringify(value)}; expected slug=path`))
-        }
-        const revision = yield* Effect.tryPromise({
-          try: async () => {
-            const process = Bun.spawn(["git", "rev-parse", "--short=12", "HEAD"], {
-              cwd: source,
-              stdout: "pipe",
-              stderr: "ignore",
-            })
-            const output = await new Response(process.stdout).text()
-            return (await process.exited) === 0 ? output.trim() : "working-tree"
-          },
-          catch: () => "working-tree",
-        }).pipe(Effect.catch(() => Effect.succeed("working-tree")))
-        return {
-          id,
-          label: id,
-          source: basename(source),
+
+    for (const [revision, preparedRevision] of revisions) {
+      for (const theme of options.themes) {
+        variants.push({
+          id: captureSetId(revision, theme),
+          label: captureSetLabel(revision, theme),
+          source: captureSource(options.opencode),
           revision,
-          path: source,
-          ...(themes.get(id) === undefined ? {} : { theme: themes.get(id) }),
-        } satisfies Variant
-      }),
-    )
-  })
+          ref: preparedRevision.ref,
+          committedAt: preparedRevision.committedAt,
+          path: preparedRevision.path,
+          ...(theme === undefined ? {} : { theme }),
+        })
+      }
+    }
+  } catch (error) {
+    await cleanup()
+    throw error
+  }
+
+  return { variants, cleanup }
+
+  async function cleanup() {
+    for (const path of worktrees.reverse()) {
+      await command(["git", "worktree", "remove", "--force", path], options.opencode).catch(() => rm(path, { recursive: true, force: true }))
+    }
+  }
+}
+
+async function readPreviousManifest(file: URL): Promise<DriveManifest | undefined> {
+  const source = Bun.file(file)
+  return (await source.exists()) ? source.json() as Promise<DriveManifest> : undefined
+}
+
+async function git(cwd: string, ...args: ReadonlyArray<string>): Promise<string> {
+  return (await command(["git", ...args], cwd)).trim()
+}
+
+async function command(argv: ReadonlyArray<string>, cwd: string): Promise<string> {
+  const process = Bun.spawn([...argv], { cwd, stdout: "pipe", stderr: "inherit" })
+  const output = await new Response(process.stdout).text()
+  if (await process.exited !== 0) throw new Error(`${argv.join(" ")} failed`)
+  return output
 }

--- a/apps/catalog/scripts/capture-sets.ts
+++ b/apps/catalog/scripts/capture-sets.ts
@@ -1,0 +1,81 @@
+import { basename, resolve } from "node:path"
+import type { DriveCapture, DriveManifest, Variant } from "../catalog/schema"
+
+export interface CaptureOptions {
+  readonly opencode: string
+  readonly revisions: ReadonlyArray<string>
+  readonly themes: ReadonlyArray<string | undefined>
+}
+
+export function parseCaptureOptions(args: ReadonlyArray<string>, defaultOpenCode: string): CaptureOptions {
+  let opencode = defaultOpenCode
+  const revisions: Array<string> = []
+  const themes: Array<string | undefined> = []
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    const value = args[++index]
+    if (!value) throw new Error(`${argument} requires a value`)
+    if (argument === "--opencode") opencode = value
+    else if (argument === "--revision") revisions.push(value)
+    else if (argument === "--theme") themes.push(value === "default" ? undefined : value)
+    else throw new Error(`Unknown capture argument: ${argument}`)
+  }
+
+  return {
+    opencode: resolve(opencode),
+    revisions: revisions.length === 0 ? ["HEAD"] : revisions,
+    themes: themes.length === 0 ? [undefined] : themes,
+  }
+}
+
+export function captureSetId(revision: string, theme: string | undefined): string {
+  const suffix = theme === undefined ? "" : `-${slug(theme)}`
+  return `${revision.slice(0, 12).toLowerCase()}${suffix}`
+}
+
+export function captureSetLabel(revision: string, theme: string | undefined): string {
+  return `${revision.slice(0, 7)}${theme === undefined ? "" : ` / ${theme}`}`
+}
+
+export function sortCaptureSets(sets: ReadonlyArray<Variant>): Array<Variant> {
+  return [...sets].sort((left, right) => {
+    const byCommit = Date.parse(right.committedAt) - Date.parse(left.committedAt)
+    return byCommit || left.label.localeCompare(right.label)
+  })
+}
+
+export function mergeCaptureHistory(
+  current: DriveManifest | undefined,
+  variants: ReadonlyArray<Variant>,
+  captures: ReadonlyArray<DriveCapture>,
+): DriveManifest {
+  const replaced = new Set(variants.map((variant) => variant.id))
+  const previousVariants = current?.variants.filter((variant) => !replaced.has(variant.id)) ?? []
+  const previousFrames = new Map(
+    current?.captures.map((capture) => [capture.id, capture.frames.filter((frame) => !replaced.has(frame.variantId))]) ?? [],
+  )
+
+  return {
+    format: "opencode-terminal-frame-captures-v1",
+    generatedBy: "scripts/capture-opencode-drive.ts",
+    variants: sortCaptureSets([...previousVariants, ...variants]) as [Variant, ...Array<Variant>],
+    captures: captures.map((capture) => {
+      const [first, ...rest] = capture.frames
+      return {
+        ...capture,
+        frames: [first, ...rest, ...(previousFrames.get(capture.id) ?? [])] as const,
+      }
+    }),
+  }
+}
+
+export function captureSource(path: string): string {
+  return basename(resolve(path))
+}
+
+function slug(value: string): string {
+  const result = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
+  if (result === "") throw new Error(`Theme ${JSON.stringify(value)} cannot form a set ID`)
+  return result
+}

--- a/apps/catalog/src/App.tsx
+++ b/apps/catalog/src/App.tsx
@@ -226,9 +226,9 @@ export function App({ catalog }: AppProps) {
       target instanceof HTMLTextAreaElement ||
       (target instanceof HTMLElement && target.isContentEditable)
     if (editing) return
-    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+    if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       event.preventDefault()
-      navigateVariant(event.key === "ArrowLeft" ? -1 : 1)
+      navigateVariant(event.key === "ArrowUp" ? -1 : 1)
       return
     }
     if (event.key === "/") {
@@ -275,6 +275,7 @@ export function App({ catalog }: AppProps) {
           onClearSearch={() => dispatch({ type: "clear-search" })}
           onOpenPalette={() => dispatch({ type: "open-palette" })}
           onVariant={navigateVariant}
+          onVariantSelect={(id) => setVariantIndex(Math.max(0, catalog.variants.findIndex((variant) => variant.id === id)))}
         />
         {ui.mode !== "flows" ? (
           <SelectionBar
@@ -311,10 +312,12 @@ export function App({ catalog }: AppProps) {
         <Viewer
           key={selectedScreen.id}
           screen={selectedScreen}
-          identifier={ui.mode === "flows" && activeFlow ? `${activeFlow.id}/${selectedScreen.id}` : selectedScreen.id}
+          identifier={ui.mode === "flows" && activeFlow?.replayable
+            ? `${activeFlow.id}/${selectedScreen.id}`
+            : selectedScreen.id}
           variant={activeVariant}
+          variants={catalog.variants}
           variantPosition={variantIndex + 1}
-          variantTotal={catalog.variants.length}
           screenTaxonomy={catalog.screenTaxonomy}
           uiElementTaxonomy={catalog.uiElementTaxonomy}
           position={viewerScreens.findIndex((screen) => screen.id === selectedScreen.id) + 1}
@@ -323,6 +326,7 @@ export function App({ catalog }: AppProps) {
           onClose={() => dispatch({ type: "close-viewer" })}
           onNavigate={navigateViewer}
           onVariant={navigateVariant}
+          onVariantSelect={(id) => setVariantIndex(Math.max(0, catalog.variants.findIndex((variant) => variant.id === id)))}
           onFacet={(filter) => dispatch({ type: "toggle-facet", ...filter })}
           onTaxonomy={(taxonomy, value) => dispatch({ type: "toggle-taxonomy", taxonomy, value })}
         />

--- a/apps/catalog/src/components/CaptureSetSwitcher.tsx
+++ b/apps/catalog/src/components/CaptureSetSwitcher.tsx
@@ -1,0 +1,27 @@
+import type { Variant } from "../catalog"
+
+interface CaptureSetSwitcherProps {
+  readonly sets: ReadonlyArray<Variant>
+  readonly active: Variant
+  readonly position: number
+  readonly onNavigate: (direction: 1 | -1) => void
+  readonly onSelect: (id: string) => void
+}
+
+export function CaptureSetSwitcher({ sets, active, position, onNavigate, onSelect }: CaptureSetSwitcherProps) {
+  return (
+    <div className="variant-switcher" aria-label="Capture set">
+      <button type="button" onClick={() => onNavigate(-1)} aria-label="Newer capture set">↑</button>
+      <label title={`${active.revision}${active.theme ? ` / ${active.theme}` : ""}`}>
+        <span className="sr-only">Capture set</span>
+        <select aria-label="Select capture set" value={active.id} onChange={(event) => onSelect(event.target.value)}>
+          {sets.map((set) => (
+            <option key={set.id} value={set.id}>{set.label}</option>
+          ))}
+        </select>
+        <small>{position}/{sets.length}</small>
+      </label>
+      <button type="button" onClick={() => onNavigate(1)} aria-label="Older capture set">↓</button>
+    </div>
+  )
+}

--- a/apps/catalog/src/components/ContactSheet.tsx
+++ b/apps/catalog/src/components/ContactSheet.tsx
@@ -34,10 +34,9 @@ export function ContactSheet({
       target instanceof HTMLTextAreaElement ||
       (target instanceof HTMLElement && target.isContentEditable)
     if (editing) return
-    const columns = gridColumns(gridRef.current)
     const steps: Record<string, number> = {
-      ArrowUp: -columns,
-      ArrowDown: columns,
+      ArrowLeft: -1,
+      ArrowRight: 1,
     }
     const current = Math.max(
       0,
@@ -106,9 +105,4 @@ export function ContactSheet({
       )}
     </section>
   )
-}
-
-function gridColumns(grid: HTMLElement | null): number {
-  if (!grid) return 1
-  return getComputedStyle(grid).gridTemplateColumns.split(" ").length
 }

--- a/apps/catalog/src/components/FlowBrowser.tsx
+++ b/apps/catalog/src/components/FlowBrowser.tsx
@@ -69,6 +69,7 @@ export function FlowBrowser({ catalog, flows, activeFlow, variantId, onFlow, onO
           </div>
           <span>{activeFlow.steps.length} {activeFlow.steps.length === 1 ? "step" : "steps"}</span>
           <p>{activeFlow.description}</p>
+          {!activeFlow.replayable ? <small className="flow-browse-only">Browse only · IDs identify captures, not recipes</small> : undefined}
         </header>
         <ol className="flow-rail" role="list">
           {activeFlow.steps.map((step, index) => {
@@ -92,7 +93,10 @@ export function FlowBrowser({ catalog, flows, activeFlow, variantId, onFlow, onO
                   <span className="flow-step-text">
                     <span className="flow-step-title">
                       <strong>{step.title}</strong>
-                      <IdChip id={`${activeFlow.id}/${screen.id}`} className="id-chip-end" />
+                    <IdChip
+                      id={activeFlow.replayable ? `${activeFlow.id}/${screen.id}` : screen.id}
+                      className="id-chip-end"
+                    />
                     </span>
                     {step.trigger ? <small>{step.trigger}</small> : undefined}
                   </span>

--- a/apps/catalog/src/components/Header.tsx
+++ b/apps/catalog/src/components/Header.tsx
@@ -2,6 +2,7 @@ import type { Ref } from "react"
 import type { BrowseMode, Catalog, Facet, FacetSelections, TaxonomyGroup, Variant } from "../catalog"
 import { label } from "../catalog"
 import { FilterMenu } from "./FilterMenu"
+import { CaptureSetSwitcher } from "./CaptureSetSwitcher"
 
 interface HeaderProps {
   readonly catalog: Catalog
@@ -23,6 +24,7 @@ interface HeaderProps {
   readonly onClearSearch: () => void
   readonly onOpenPalette: () => void
   readonly onVariant: (direction: 1 | -1) => void
+  readonly onVariantSelect: (id: string) => void
 }
 
 const modes: ReadonlyArray<readonly [BrowseMode, string]> = [
@@ -51,6 +53,7 @@ export function Header({
   onClearSearch,
   onOpenPalette,
   onVariant,
+  onVariantSelect,
 }: HeaderProps) {
   const taxonomy = mode === "screens" ? catalog.screenTaxonomy : catalog.uiElementTaxonomy
   const facetGroups: ReadonlyArray<TaxonomyGroup> = [
@@ -84,11 +87,13 @@ export function Header({
         ))}
       </nav>
       <div className="catalog-tools">
-        <div className="variant-switcher" aria-label="Capture variant">
-          <button type="button" onClick={() => onVariant(-1)} aria-label="Previous variant">←</button>
-          <span><strong>{variant.label}</strong><small>{variantPosition}/{catalog.variants.length}</small></span>
-          <button type="button" onClick={() => onVariant(1)} aria-label="Next variant">→</button>
-        </div>
+        <CaptureSetSwitcher
+          sets={catalog.variants}
+          active={variant}
+          position={variantPosition}
+          onNavigate={onVariant}
+          onSelect={onVariantSelect}
+        />
         {mode !== "flows" ? (
           <FilterMenu
             label={mode === "screens" ? "Screens" : "UI Elements"}

--- a/apps/catalog/src/components/IdChip.tsx
+++ b/apps/catalog/src/components/IdChip.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 
 interface IdChipProps {
   readonly id: string
@@ -8,6 +9,8 @@ interface IdChipProps {
 export function IdChip({ id, className = "" }: IdChipProps) {
   const [copied, setCopied] = useState(false)
   const timer = useRef<number | undefined>(undefined)
+  const reducedMotion = useReducedMotion()
+  const transition = { duration: reducedMotion ? 0 : 0.16, ease: [0.22, 1, 0.36, 1] as const }
 
   useEffect(() => () => window.clearTimeout(timer.current), [])
 
@@ -23,24 +26,67 @@ export function IdChip({ id, className = "" }: IdChipProps) {
   }
 
   return (
-    <button
+    <motion.button
       type="button"
       className={`id-chip ${className}`.trim()}
       data-copied={copied ? "" : undefined}
       title={`Copy ${id}`}
       aria-label={`Copy identifier ${id}`}
       onClick={copy}
+      whileTap={reducedMotion ? undefined : { scale: 0.97 }}
     >
-      <svg className="id-chip-glyph" viewBox="0 0 12 12" aria-hidden="true">
-        <path d="M4.5 3.5v-2h6v6h-2" fill="none" stroke="currentColor" />
-        <rect x="1.5" y="4.5" width="6" height="6" fill="none" stroke="currentColor" />
-      </svg>
+      <AnimatePresence initial={false} mode="popLayout">
+        {copied ? (
+          <motion.svg
+            key="check"
+            className="id-chip-glyph"
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+            initial={{ opacity: 0, scale: 0.65, rotate: -20 }}
+            animate={{ opacity: 1, scale: 1, rotate: 0 }}
+            exit={{ opacity: 0, scale: 0.65, rotate: 20 }}
+            transition={transition}
+          >
+            <motion.path
+              d="m2 6.2 2.4 2.3L10 3"
+              fill="none"
+              stroke="currentColor"
+              initial={{ pathLength: 0 }}
+              animate={{ pathLength: 1 }}
+              transition={transition}
+            />
+          </motion.svg>
+        ) : (
+          <motion.svg
+            key="copy"
+            className="id-chip-glyph"
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+            initial={{ opacity: 0, scale: 0.65 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.65 }}
+            transition={transition}
+          >
+            <path d="M4.5 3.5v-2h6v6h-2" fill="none" stroke="currentColor" />
+            <rect x="1.5" y="4.5" width="6" height="6" fill="none" stroke="currentColor" />
+          </motion.svg>
+        )}
+      </AnimatePresence>
       <span className="id-chip-text">
-        <span className="id-chip-value">{id}</span>
-        <span className="id-chip-copied" aria-hidden="true">
-          copied
-        </span>
+        <span className="id-chip-measure" aria-hidden="true">{id}</span>
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            key={copied ? "copied" : "value"}
+            className="id-chip-value"
+            initial={{ opacity: 0, y: reducedMotion ? 0 : 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: reducedMotion ? 0 : -5 }}
+            transition={transition}
+          >
+            {copied ? "copied" : id}
+          </motion.span>
+        </AnimatePresence>
       </span>
-    </button>
+    </motion.button>
   )
 }

--- a/apps/catalog/src/components/Viewer.tsx
+++ b/apps/catalog/src/components/Viewer.tsx
@@ -3,13 +3,14 @@ import type { Facet, Filter, Screen, Taxonomy, TaxonomyGroup, Variant } from "..
 import { facetValues, frameFor, label, taxonomyLabel } from "../catalog"
 import { IdChip } from "./IdChip"
 import { TerminalFrame } from "./TerminalFrame"
+import { CaptureSetSwitcher } from "./CaptureSetSwitcher"
 
 interface ViewerProps {
   readonly screen: Screen
   readonly identifier: string
   readonly variant: Variant
+  readonly variants: ReadonlyArray<Variant>
   readonly variantPosition: number
-  readonly variantTotal: number
   readonly screenTaxonomy: ReadonlyArray<TaxonomyGroup>
   readonly uiElementTaxonomy: ReadonlyArray<TaxonomyGroup>
   readonly position: number
@@ -18,6 +19,7 @@ interface ViewerProps {
   readonly onClose: () => void
   readonly onNavigate: (direction: 1 | -1) => void
   readonly onVariant: (direction: 1 | -1) => void
+  readonly onVariantSelect: (id: string) => void
   readonly onFacet: (filter: Filter) => void
   readonly onTaxonomy: (taxonomy: Taxonomy, value: string) => void
 }
@@ -28,8 +30,8 @@ export function Viewer({
   screen,
   identifier,
   variant,
+  variants,
   variantPosition,
-  variantTotal,
   screenTaxonomy,
   uiElementTaxonomy,
   position,
@@ -38,6 +40,7 @@ export function Viewer({
   onClose,
   onNavigate,
   onVariant,
+  onVariantSelect,
   onFacet,
   onTaxonomy,
 }: ViewerProps) {
@@ -92,9 +95,13 @@ export function Viewer({
         </span>
         <div className="viewer-actions">
           <IdChip id={identifier} className="viewer-button" />
-          <button type="button" className="viewer-button" onClick={() => onVariant(-1)} aria-label="Previous variant">←</button>
-          <span className="viewer-variant"><strong>{variant.label}</strong> {variantPosition}/{variantTotal}</span>
-          <button type="button" className="viewer-button" onClick={() => onVariant(1)} aria-label="Next variant">→</button>
+          <CaptureSetSwitcher
+            sets={variants}
+            active={variant}
+            position={variantPosition}
+            onNavigate={onVariant}
+            onSelect={onVariantSelect}
+          />
         </div>
       </header>
       <div className="viewer-body">

--- a/apps/catalog/src/styles.css
+++ b/apps/catalog/src/styles.css
@@ -81,6 +81,17 @@ a {
   outline-offset: -1px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 kbd {
   padding: 0.1rem 0.35rem;
   border: 1px solid var(--kit-line-strong);
@@ -505,7 +516,7 @@ kbd {
   color: var(--kit-fg-strong);
 }
 
-.variant-switcher > span {
+.variant-switcher > label {
   display: flex;
   min-width: 5.5rem;
   flex-direction: column;
@@ -513,6 +524,24 @@ kbd {
   align-items: center;
   gap: 0.15rem;
   font-size: 0.62rem;
+}
+
+.variant-switcher select {
+  width: 100%;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--kit-fg-muted);
+  font-family: inherit;
+  font-size: inherit;
+  text-align: center;
+  outline: 0;
+  cursor: pointer;
+}
+
+.variant-switcher select:hover,
+.variant-switcher select:focus-visible {
+  color: var(--kit-fg-strong);
 }
 
 .variant-switcher small {
@@ -580,10 +609,6 @@ kbd {
   color: var(--kit-fg-strong);
 }
 
-.id-chip[data-copied] {
-  color: var(--catalog-accent);
-}
-
 .id-chip-glyph {
   width: 0.7rem;
   height: 0.7rem;
@@ -592,6 +617,7 @@ kbd {
 }
 
 .id-chip-text {
+  position: relative;
   display: grid;
   min-width: 0;
 }
@@ -603,20 +629,17 @@ kbd {
   white-space: nowrap;
 }
 
-.id-chip-copied {
-  visibility: hidden;
-}
-
 .id-chip-end .id-chip-text {
   justify-items: end;
 }
 
-.id-chip[data-copied] .id-chip-value {
+.id-chip-measure {
   visibility: hidden;
 }
 
-.id-chip[data-copied] .id-chip-copied {
-  visibility: visible;
+.id-chip-value {
+  position: absolute;
+  inset: 0;
 }
 
 .empty-state {
@@ -742,6 +765,15 @@ kbd {
 .flow-heading > div p,
 .flow-heading > p {
   margin: 0;
+}
+
+.flow-browse-only {
+  width: fit-content;
+  grid-column: 1 / -1;
+  padding-top: 0.25rem;
+  color: var(--kit-fg-faint);
+  font-family: var(--kit-mono);
+  font-size: 0.58rem;
 }
 
 .flow-heading > div p {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@fontsource/noto-sans-math": "5.2.8",
         "@fontsource/noto-sans-symbols": "5.2.8",
         "@fontsource/noto-sans-symbols-2": "5.2.8",
+        "motion": "^12.42.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
       },
@@ -420,6 +421,8 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -493,6 +496,12 @@
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
+
+    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
+
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
+
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -12,6 +12,30 @@ restartable, or manual-launch workflows; it is also Effect-only. Use live
 commands only for interactive development against a persistent or visible
 instance.
 
+## Catalog State IDs
+
+Browse and copy OpenCode terminal state IDs from:
+
+```text
+https://catalog.kitlangton.dev
+```
+
+Replayable flow states expose canonical `<flow-id>/<state-id>` addresses, for example:
+
+```text
+patch-success-lifecycle/permission-prompt
+```
+
+Reproduce one from an `opencode-drive` source checkout:
+
+```bash
+bun run catalog:reproduce -- patch-success-lifecycle/permission-prompt \
+  --opencode /path/to/opencode \
+  --output /tmp/permission-prompt.frame.json
+```
+
+The command executes the registered recipe only through that checkpoint and writes an `opencode-terminal-frame-v1` artifact. Only flows in `apps/catalog/scenarios/index.ts` are replayable. Browse-only flows and screen cards copy standalone capture IDs instead; do not invent a flow prefix. Use a protocol-compatible OpenCode checkout, ideally the source revision shown by the selected capture set.
+
 ## Effect Programs
 
 Write `drive.ts` as a default-exported, fully provided Effect, then run it directly:


### PR DESCRIPTION
## What

Capture and compare immutable OpenCode revision sets over time.

- Capture repeated v2 refs from one checkout, optionally crossed with multiple themes.
- Preserve prior commit/theme sets instead of overwriting the manifest.
- Select the newest commit by default, choose any set from the header, and use up/down to compare without losing the current screen or flow step.
- Replace generic Copy ID feedback with a neutral Motion interaction that preserves geometry.
- Distinguish replayable flow addresses from browse-only capture IDs.
- Publish catalog replay guidance in the repository's installable Drive skill.

## How

- `scripts/capture-opencode-drive.ts` resolves refs to immutable SHAs, captures each from a detached worktree, and merges results into retained history.
- `scripts/capture-sets.ts` owns argument parsing, commit/theme IDs, newest-first ordering, and history replacement semantics.
- `CaptureSetSwitcher.tsx` provides direct set selection plus up/down navigation in the catalog and viewer.
- `IdChip.tsx` uses Motion v12 for a neutral copy-to-check/text-roll interaction with reduced-motion support.
- Catalog flows persist `replayable`; browse-only flows copy standalone screen IDs instead of fabricated `<flow>/<state>` addresses.

## Scope

This PR provides revision/theme history and fixes the identifier contract. Additional executable thinking, shell, tool, and subagent lifecycle recipes are being implemented separately so their real frame captures do not block this comparison slice.

## Testing

- `bun run check` from the workspace root: Drive lint/typecheck plus catalog generation, lint, typecheck, 14 tests, and both builds.
- Real Chromium at 1600×900:
  - Up/down changed `baseline` to `rosepine` while preserving the selected card.
  - Direct picker selection rendered the chosen set.
  - Copy feedback animated to a neutral check/`copied` state and reset.
  - Browse-only `starting-a-session` copied `home` and displayed its warning.
  - Replayable patch flow copied `patch-success-lifecycle/permission-prompt`.

## Demo

The real local catalog after switching to the rosepine capture set:

![revision-sets-grid.png](https://github.com/user-attachments/assets/eca56399-7c4d-4dad-b5c2-c1df3a641a33)

## Flow

```mermaid
flowchart LR
  A[OpenCode checkout] --> B[Resolve requested refs]
  B --> C[Detached worktree per commit]
  C --> D[Capture commit × theme sets]
  D --> E[Merge with retained manifest]
  E --> F[Sort newest commit first]
  F --> G[Catalog set picker]
  G --> H[Same screen, different frame]
```
