### PR TITLE
feat(recording): export smooth 60 FPS captures

### DIFF
--- a/.changeset/clean-visible-drive.md
+++ b/.changeset/clean-visible-drive.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Keep service and progress output out of visible TUI sessions and avoid reinstalling the OpenTUI preload package for development checkouts.

--- a/.changeset/smooth-recordings.md
+++ b/.changeset/smooth-recordings.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Export recordings at 60 FPS by default and preserve the requested frame rate in generated MP4 files.

--- a/packages/drive/src/cli/start.ts
+++ b/packages/drive/src/cli/start.ts
@@ -67,6 +67,7 @@ const startScoped = Effect.fn("DriveCli.startScoped")(function* (options: StartO
   }
   const responses = createResponseSettings()
   logSuccess("launching instance")
+  const log = options.visible ? (message: string) => logSuccess(message, { terminal: false }) : logSuccess
   const instance = yield* OpenCodeInstance.make({
     artifacts: initialized.artifacts,
     name: options.name,
@@ -81,7 +82,7 @@ const startScoped = Effect.fn("DriveCli.startScoped")(function* (options: StartO
     tui: script?.tuiConfig,
     setup: script?.setup,
     tools: script?.tools,
-    log: logSuccess,
+    log,
   })
   yield* Effect.acquireRelease(
     fromPromise(() =>
@@ -100,7 +101,7 @@ const startScoped = Effect.fn("DriveCli.startScoped")(function* (options: StartO
     ),
     () => fromPromise(() => unregister(options.name, process.pid)).pipe(Effect.ignore),
   )
-  return yield* lifecycle(options, instance, responses, script, scriptTooling)
+  return yield* lifecycle(options, instance, responses, script, scriptTooling, log)
 })
 
 function lifecycle(
@@ -109,10 +110,11 @@ function lifecycle(
   responses: ReturnType<typeof createResponseSettings>,
   script: ScriptDefinition | undefined,
   scriptTooling: Awaited<ReturnType<typeof prepareScriptTooling>> | undefined,
+  log: (message: string) => void,
 ) {
   return Effect.callback<void, unknown>((resume) => {
     const abort = new AbortController()
-    const promise = runLifecycle(options, instance, responses, script, scriptTooling, abort.signal)
+    const promise = runLifecycle(options, instance, responses, script, scriptTooling, log, abort.signal)
     void promise.then(
       () => resume(Effect.void),
       (error) => resume(Effect.fail(error)),
@@ -130,6 +132,7 @@ async function runLifecycle(
   responses: ReturnType<typeof createResponseSettings>,
   script: ScriptDefinition | undefined,
   scriptTooling: Awaited<ReturnType<typeof prepareScriptTooling>> | undefined,
+  log: (message: string) => void,
   signal: AbortSignal,
 ) {
   let completed = false
@@ -201,11 +204,14 @@ async function runLifecycle(
             script,
             (path) => screenshots.push(path),
             (path) => recordings.push(path),
+            log,
           )
           await current.ready
           driveReady = true
           await markReady(options.name, process.pid)
-          await logReadyPaths(instance.artifacts)
+          await logReadyPaths(instance.artifacts, {
+            terminal: !options.visible,
+          })
           return output
         })().finally(() => {
           restarting = undefined
@@ -227,12 +233,13 @@ async function runLifecycle(
       script,
       (path) => screenshots.push(path),
       (path) => recordings.push(path),
+      log,
     )
     await current.ready
     driveReady = true
-    logSuccess(`ready ${options.name}`)
+    log(`ready ${options.name}`)
     await markReady(options.name, process.pid)
-    await logReadyPaths(instance.artifacts)
+    await logReadyPaths(instance.artifacts, { terminal: !options.visible })
     if (options.visible) {
       while (true) {
         const active: NonNullable<typeof current> = current
@@ -445,6 +452,7 @@ function run(
   driveScript: ScriptDefinition | undefined,
   onScreenshot: (path: string) => void,
   onRecording: (path: string) => void,
+  log: (message: string) => void,
 ) {
   const abort = new AbortController()
   const readiness = Promise.withResolvers<void>()
@@ -456,12 +464,12 @@ function run(
   }
   const promise = (async () => {
     if (!driveScript) {
-      logSuccess("waiting for OpenCode")
+      log("waiting for OpenCode")
       await runEffect(instance.waitForDrive("both"))
-      logSuccess("OpenCode ready")
+      log("OpenCode ready")
     }
     if (driveScript) {
-      logSuccess("running script")
+      log("running script")
       const exit = await Effect.runPromiseExit(
         Effect.scoped(
           runScript(
@@ -479,7 +487,7 @@ function run(
         throw Cause.squash(exit.cause)
       }
       ready()
-      logSuccess("script completed")
+      log("script completed")
       return
     }
     const child = await runEffect(instance.primary)

--- a/packages/drive/src/instance/dev.ts
+++ b/packages/drive/src/instance/dev.ts
@@ -1,13 +1,11 @@
+import { mkdir, rm, symlink } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import * as Effect from "effect/Effect"
 import { instanceError } from "./error.js"
-import * as Process from "./process.js"
 
 /**
  * Prepares an OpenCode development checkout for launch: verifies the CLI
- * entrypoint and `@opentui/solid` dependency, links a matching version into
- * the instance's artifact manifest, installs it, and returns the launch
- * command.
+ * entrypoint and reuses its installed `@opentui/solid` preload.
  */
 export const prepareDev = Effect.fn("OpenCodeInstance.prepareDev")(function* (
   artifacts: string,
@@ -15,59 +13,22 @@ export const prepareDev = Effect.fn("OpenCodeInstance.prepareDev")(function* (
 ) {
   const root = resolve(directory)
   const entrypoint = join(root, "packages", "cli", "src", "index.ts")
-  const solidPackage = join(
-    root,
-    "packages",
-    "tui",
-    "node_modules",
-    "@opentui",
-    "solid",
-    "package.json",
-  )
+  const solid = join(root, "packages", "tui", "node_modules", "@opentui", "solid")
   yield* Effect.tryPromise({
     try: async () => {
       if (!(await Bun.file(entrypoint).exists()))
         throw new Error(`OpenCode development entrypoint not found: ${entrypoint}`)
-      if (!(await Bun.file(solidPackage).exists()))
-        throw new Error(
-          `OpenCode development dependency not found: ${solidPackage}; run bun install in ${root}`,
-        )
-      const value: unknown = await Bun.file(solidPackage).json()
-      if (!isPackageInfo(value))
-        throw new Error(`Invalid @opentui/solid package metadata: ${solidPackage}`)
-      const manifestPath = join(artifacts, "package.json")
-      const manifest: unknown = await Bun.file(manifestPath)
-        .json()
-        .catch(() => ({}))
-      const existing = isDependencyManifest(manifest) ? manifest : {}
-      await Bun.write(
-        manifestPath,
-        `${JSON.stringify(
-          {
-            ...existing,
-            private: true,
-            dependencies: {
-              ...existing.dependencies,
-              "@opentui/solid": value.version,
-            },
-          },
-          undefined,
-          2,
-        )}\n`,
-      )
-      return value
+      if (!(await Bun.file(join(solid, "package.json")).exists()))
+        throw new Error(`OpenCode development dependency not found: ${solid}; run bun install in ${root}`)
+      const preload = join(artifacts, "node_modules", "@opentui", "solid")
+      await mkdir(join(artifacts, "node_modules", "@opentui"), {
+        recursive: true,
+      })
+      await rm(preload, { recursive: true, force: true })
+      await symlink(solid, preload, "dir")
     },
     catch: (cause) => instanceError("prepare development checkout", cause),
   })
-  const installed = yield* Process.run([process.execPath, "install"], {
-    cwd: artifacts,
-    stdout: "ignore",
-    stderr: "ignore",
-  }).pipe(Effect.mapError((cause) => instanceError("install development dependencies", cause)))
-  if (installed.status !== 0)
-    return yield* Effect.fail(
-      instanceError("install development dependencies", `bun install failed with status ${installed.status}`),
-    )
   return [
     process.execPath,
     "--conditions=browser",
@@ -75,20 +36,3 @@ export const prepareDev = Effect.fn("OpenCodeInstance.prepareDev")(function* (
     entrypoint,
   ]
 })
-
-function isPackageInfo(value: unknown): value is { readonly version: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "version" in value &&
-    typeof value.version === "string"
-  )
-}
-
-function isDependencyManifest(
-  value: unknown,
-): value is { readonly dependencies?: Readonly<Record<string, string>> } {
-  if (typeof value !== "object" || value === null) return false
-  if (!("dependencies" in value) || value.dependencies === undefined) return true
-  return typeof value.dependencies === "object" && value.dependencies !== null
-}

--- a/packages/drive/src/instance/runtime.ts
+++ b/packages/drive/src/instance/runtime.ts
@@ -200,14 +200,15 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
     driveName: string,
     appCommand: ReadonlyArray<string>,
     logName: string,
+    visible: boolean,
   ) {
     options.log?.(`launching ${logName}`)
     return yield* Process.spawn(appCommand, {
       cwd: files,
       env: { ...environment, OPENCODE_DRIVE: driveName },
-      stdin: options.visible ? "inherit" : "ignore",
-      stdout: options.visible ? "inherit" : { path: join(logs, `${logName}.stdout.log`) },
-      stderr: options.visible ? "inherit" : { path: join(logs, `${logName}.stderr.log`) },
+      stdin: visible ? "inherit" : "ignore",
+      stdout: visible ? "inherit" : { path: join(logs, `${logName}.stdout.log`) },
+      stderr: visible ? "inherit" : { path: join(logs, `${logName}.stderr.log`) },
     }).pipe(
       Effect.provideService(
         ChildProcessSpawner.ChildProcessSpawner,
@@ -224,7 +225,7 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
   ) {
     yield* writeManifest(options.name, endpoints, recording, options.viewport)
     options.log?.("launching OpenCode")
-    return yield* spawn(options.name, command, "opencode")
+    return yield* spawn(options.name, command, "opencode", options.visible ?? false)
   })
 
   if (!options.scripted) {
@@ -248,7 +249,7 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
           backend: endpoints.backend,
         })
         options.log?.("launching script server")
-        const server = yield* spawn(name, [...command, "serve", "--service"], "service")
+        const server = yield* spawn(name, [...command, "serve", "--service"], "service", false)
         yield* Ref.update(state, (value) => ({ ...value, pendingServer: server }))
         return server
       }),
@@ -357,7 +358,7 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
           tuiOptions.viewport ?? options.viewport,
         )
         options.log?.(`launching TUI ${name}`)
-        const tui = yield* spawn(driveName, command, `tui-${name}`)
+        const tui = yield* spawn(driveName, command, `tui-${name}`, options.visible ?? false)
         yield* Ref.update(state, (value) => ({
           ...value,
           pendingTuis: new Map(value.pendingTuis).set(name, tui),

--- a/packages/drive/src/log.ts
+++ b/packages/drive/src/log.ts
@@ -23,9 +23,9 @@ export async function opencodeLogFile(artifacts: string) {
   }
 }
 
-export async function logReadyPaths(artifacts: string) {
-  logSuccess(`opencode instance logs: ${await opencodeLogFile(artifacts)}`)
-  logSuccess(`current run script logs: ${driveLogFile(artifacts)}`)
+export async function logReadyPaths(artifacts: string, options?: { readonly terminal?: boolean }) {
+  logSuccess(`opencode instance logs: ${await opencodeLogFile(artifacts)}`, options)
+  logSuccess(`current run script logs: ${driveLogFile(artifacts)}`, options)
 }
 
 export function configureLogFile(artifacts: string) {
@@ -34,9 +34,9 @@ export function configureLogFile(artifacts: string) {
   return currentLogFile
 }
 
-export function logSuccess(message: string) {
+export function logSuccess(message: string, options: { readonly terminal?: boolean } = {}) {
   const line = `${prefix}: ${message}`
-  console.error(process.stderr.isTTY ? `\x1b[32m${line}\x1b[0m` : line)
+  if (options.terminal !== false) console.error(process.stderr.isTTY ? `\x1b[32m${line}\x1b[0m` : line)
   append("INFO", message)
 }
 

--- a/packages/drive/src/recording/encode.ts
+++ b/packages/drive/src/recording/encode.ts
@@ -24,6 +24,7 @@ export async function encodeFrames(
 ) {
   const final = frames.at(-1)
   if (!final) throw new Error("recording has no frames")
+  const fps = options.fps ?? 60
   await mkdir(dirname(output), { recursive: true })
   const directory = await mkdtemp(join(tmpdir(), "opencode-drive-recording-"))
   const progress = progressReporter(options.onProgress)
@@ -41,7 +42,7 @@ export async function encodeFrames(
       await linkOrCopy(rendered, join(directory, `frame-${String(index).padStart(8, "0")}.png`))
       progress(((index + 1) / frames.length) * 90)
     }
-    const frameDurationMs = 1000 / (options.fps ?? 20)
+    const frameDurationMs = 1000 / fps
     const concat = join(directory, "frames.ffconcat")
     const entries = frames.flatMap((frame, index) => {
       const next = frames[index + 1]
@@ -58,6 +59,8 @@ export async function encodeFrames(
       options.ffmpegPath ?? "ffmpeg",
       [
         "-y",
+        "-r",
+        String(fps),
         "-safe",
         "0",
         "-f",

--- a/packages/drive/src/recording/encode.ts
+++ b/packages/drive/src/recording/encode.ts
@@ -42,16 +42,12 @@ export async function encodeFrames(
       await linkOrCopy(rendered, join(directory, `frame-${String(index).padStart(8, "0")}.png`))
       progress(((index + 1) / frames.length) * 90)
     }
-    const frameDurationMs = 1000 / fps
     const concat = join(directory, "frames.ffconcat")
     const entries = frames.flatMap((frame, index) => {
       const next = frames[index + 1]
-      return [
-        `file frame-${String(index).padStart(8, "0")}.png`,
-        `duration ${(next ? next.atMs - frame.atMs : frameDurationMs) / 1000}`,
-      ]
+      const file = `file frame-${String(index).padStart(8, "0")}.png`
+      return next ? [file, `duration ${(next.atMs - frame.atMs) / 1000}`] : [file]
     })
-    entries.push(`file frame-${String(frames.length - 1).padStart(8, "0")}.png`)
     await writeFile(concat, `ffconcat version 1.0\n${entries.join("\n")}\n`, {
       signal: options.signal,
     })

--- a/packages/drive/src/recording/export.ts
+++ b/packages/drive/src/recording/export.ts
@@ -47,12 +47,19 @@ export async function exportRecording(
     )
     progress(100)
   } else if (extension === ".mp4") {
+    const frameKeys = new WeakMap<object, number>()
+    let nextFrameKey = 0
     await encodeFrames(
       frames.map((sample) => {
         const label = header(sample.atMs)
+        let frameKey = frameKeys.get(sample.frame)
+        if (frameKey === undefined) {
+          frameKey = nextFrameKey++
+          frameKeys.set(sample.frame, frameKey)
+        }
         return {
           atMs: sample.atMs,
-          key: JSON.stringify([sample.frame, label]),
+          key: JSON.stringify([frameKey, label]),
           render: () => renderFrame(sample.frame, { cols, rows, header: label }),
         }
       }),

--- a/packages/drive/src/recording/replay.ts
+++ b/packages/drive/src/recording/replay.ts
@@ -24,7 +24,7 @@ export async function replayRecording(path: string, options: ReplayOptions = {})
 
 export async function replay(path: string, options: InternalReplayOptions = {}): Promise<SampledFrame[]> {
   options.signal?.throwIfAborted()
-  const interval = sampleInterval(options.fps ?? 20)
+  const interval = sampleInterval(options.fps ?? 60)
   if (options.startAtMs !== undefined && (!Number.isFinite(options.startAtMs) || options.startAtMs < 0))
     throw new Error("startAtMs must be a non-negative finite number")
   if (options.durationMs !== undefined && (!Number.isFinite(options.durationMs) || options.durationMs < 0))
@@ -67,7 +67,10 @@ export async function replay(path: string, options: InternalReplayOptions = {}):
     frames.push({ atMs: nextSample, frame: terminal.snapshot() })
     nextSample += interval
   }
-  if (frames.length === 0 || frames.at(-1)!.atMs !== targetFinal) {
+  const final = frames.at(-1)
+  if (final && Math.abs(final.atMs - targetFinal) < 0.000_001) {
+    frames[frames.length - 1] = { ...final, atMs: targetFinal }
+  } else {
     frames.push({ atMs: targetFinal, frame: terminal.snapshot() })
   }
   if (options.startAtMs !== undefined) {

--- a/packages/drive/src/recording/replay.ts
+++ b/packages/drive/src/recording/replay.ts
@@ -41,6 +41,7 @@ export async function replay(path: string, options: InternalReplayOptions = {}):
   const endAt = options.durationMs === undefined ? Number.POSITIVE_INFINITY : startAt + options.durationMs
   let nextSample = startAt
   let finalAt = 0
+  let snapshot = terminal.snapshot()
 
   for (;;) {
     const next = await records.next()
@@ -53,25 +54,27 @@ export async function replay(path: string, options: InternalReplayOptions = {}):
       break
     }
     while (nextSample < event.at_ms && nextSample <= endAt) {
-      frames.push({ atMs: nextSample, frame: terminal.snapshot() })
+      frames.push({ atMs: nextSample, frame: snapshot })
       nextSample += interval
     }
     if (event.type === "output") terminal.write(Buffer.from(event.data, "base64"))
     else terminal.resize(event.cols, event.rows)
+    snapshot = terminal.snapshot()
     finalAt = event.at_ms
   }
   terminal.finish()
+  snapshot = terminal.snapshot()
 
   const targetFinal = options.durationMs === undefined ? Math.max(startAt, finalAt) : endAt
   while (nextSample <= targetFinal) {
-    frames.push({ atMs: nextSample, frame: terminal.snapshot() })
+    frames.push({ atMs: nextSample, frame: snapshot })
     nextSample += interval
   }
   const final = frames.at(-1)
   if (final && Math.abs(final.atMs - targetFinal) < 0.000_001) {
     frames[frames.length - 1] = { ...final, atMs: targetFinal }
   } else {
-    frames.push({ atMs: targetFinal, frame: terminal.snapshot() })
+    frames.push({ atMs: targetFinal, frame: snapshot })
   }
   if (options.startAtMs !== undefined) {
     return frames.map((sample) => ({ ...sample, atMs: sample.atMs - startAt }))

--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -996,6 +996,41 @@ describe("opencode-drive", () => {
     expect(await Bun.file(join(root, "registry", `${name}.json`)).exists()).toBe(false)
   })
 
+  test("keeps service and progress output out of a visible client terminal", async () => {
+    const root = await temporary()
+    const child = spawn(
+      [
+        "start",
+        "--visible",
+        "--name",
+        "visible-output-test",
+        "--script",
+        fixture("script.ts"),
+        "--",
+        process.execPath,
+        fixture("fake-opencode.ts"),
+        "stdio-markers",
+      ],
+      root,
+    )
+    const [status, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+    expect(status).toBe(0)
+    expect(stdout).toContain("fake-client-stdout")
+    expect(stdout).not.toContain("fake-service-stdout")
+    expect(stderr).toContain("fake-client-stderr")
+    expect(stderr).not.toContain("fake-service-stderr")
+    expect(stderr).not.toContain("script completed")
+
+    const artifacts = artifactPath(stderr)
+    expect(await Bun.file(join(artifacts, "logs", "service.stdout.log")).text()).toContain("fake-service-stdout")
+    expect(await Bun.file(join(artifacts, "logs", "service.stderr.log")).text()).toContain("fake-service-stderr")
+    expect(await Bun.file(join(artifacts, "logs", "opencode-drive.log")).text()).toContain("script completed")
+  })
+
   test.each(["title-requests", "latest-title-requests"])(
     "routes %s outside the normal LLM response sequence",
     async (mode) => {

--- a/packages/drive/test/fixtures/fake-opencode.ts
+++ b/packages/drive/test/fixtures/fake-opencode.ts
@@ -7,6 +7,10 @@ const role = serviceMode
     ? "service"
     : "client"
   : "legacy"
+if (process.argv.includes("stdio-markers")) {
+  console.log(`fake-${role}-stdout`)
+  console.error(`fake-${role}-stderr`)
+}
 if (role === "service" && process.env.OPENCODE_TEST_HOME)
   await Promise.all([
     Bun.write(`${process.env.OPENCODE_TEST_HOME}/service.pid`, String(process.pid)),

--- a/packages/drive/test/recording/export.test.ts
+++ b/packages/drive/test/recording/export.test.ts
@@ -77,7 +77,7 @@ test("exports resized recordings on a stable maximum-size canvas", async () => {
   const result = await exportRecording(timeline, output)
   const data = await readFile(output)
 
-  expect(result).toEqual({ frames: 3, durationMs: 100, width: 80, height: 80 })
+  expect(result).toEqual({ frames: 7, durationMs: 100, width: 80, height: 80 })
   expect(data.readUInt32BE(16)).toBe(80)
   expect(data.readUInt32BE(20)).toBe(80)
 })
@@ -219,8 +219,8 @@ test("rejects invalid capture font overrides", async () => {
   expect(await stderr).toContain("Failed to register capture font: /missing/capture-font.woff2")
 })
 
-if (Bun.which("ffmpeg")) {
-  test("exports the off-grid final frame in an H.264 MP4 when ffmpeg is available", async () => {
+if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
+  test("exports a 60 FPS H.264 MP4 with the off-grid final frame", async () => {
     const directory = await mkdtemp(join(tmpdir(), "drive-export-ffmpeg-test-"))
     directories.push(directory)
     const timeline = join(directory, "timeline.jsonl")
@@ -249,16 +249,28 @@ if (Bun.which("ffmpeg")) {
     )
     const output = join(directory, "video.mp4")
     const progress: number[] = []
-    const result = await exportRecording(timeline, output, {
-      fps: 5,
-      onProgress: (percent) => progress.push(percent),
-    })
+    const result = await exportRecording(timeline, output, { onProgress: (percent) => progress.push(percent) })
     const data = await readFile(output)
-    expect(result.frames).toBe(4)
+    expect(result.frames).toBe(28)
     expect(result.durationMs).toBe(450)
     expect(data.subarray(4, 8).toString()).toBe("ftyp")
     expect(data.length).toBeGreaterThan(500)
     expect(progress).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+
+    const probe = Bun.spawnSync([
+      "ffprobe",
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=avg_frame_rate",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      output,
+    ])
+    expect(probe.exitCode).toBe(0)
+    expect(probe.stdout.toString().trim()).toBe("60/1")
 
     const finalFrame = join(directory, "final.png")
     const decoded = Bun.spawnSync([

--- a/packages/drive/test/recording/export.test.ts
+++ b/packages/drive/test/recording/export.test.ts
@@ -264,13 +264,13 @@ if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
       "-select_streams",
       "v:0",
       "-show_entries",
-      "stream=avg_frame_rate",
+      "stream=avg_frame_rate,duration,nb_frames",
       "-of",
       "default=noprint_wrappers=1:nokey=1",
       output,
     ])
     expect(probe.exitCode).toBe(0)
-    expect(probe.stdout.toString().trim()).toBe("60/1")
+    expect(probe.stdout.toString().trim().split("\n")).toEqual(["60/1", "0.466667", "28"])
 
     const finalFrame = join(directory, "final.png")
     const decoded = Bun.spawnSync([

--- a/packages/drive/test/recording/replay.test.ts
+++ b/packages/drive/test/recording/replay.test.ts
@@ -94,6 +94,7 @@ describe("replayRecording", () => {
     expect(frames[1]!.atMs).toBeCloseTo(1_000 / 60)
     expect(frames.at(-1)!.atMs).toBe(1_000)
     expect(frames.every((frame) => lineText(frame.frame) === "ready")).toBe(true)
+    expect(new Set(frames.map((frame) => frame.frame)).size).toBe(1)
   })
 
   test("trims blank startup time and rebases the first visible frame", async () => {

--- a/packages/drive/test/recording/replay.test.ts
+++ b/packages/drive/test/recording/replay.test.ts
@@ -90,8 +90,9 @@ describe("replayRecording", () => {
         [1_000, ""],
       ]),
     )
-    expect(frames).toHaveLength(21)
-    expect(frames.map((frame) => frame.atMs)).toEqual(Array.from({ length: 21 }, (_, index) => index * 50))
+    expect(frames).toHaveLength(61)
+    expect(frames[1]!.atMs).toBeCloseTo(1_000 / 60)
+    expect(frames.at(-1)!.atMs).toBe(1_000)
     expect(frames.every((frame) => lineText(frame.frame) === "ready")).toBe(true)
   })
 


### PR DESCRIPTION
## What

Export MP4 recordings at 60 FPS by default while keeping visible OpenCode TUI sessions free of Drive service and progress output. Development checkouts now reuse the installed OpenTUI preload through a local symlink instead of reinstalling it into every artifact directory.

## How

- `packages/drive/src/recording`: defaults replay and encoding to 60 FPS, reuses unchanged terminal snapshots, avoids repeatedly serializing full frames for deduplication, and emits an exact one-frame tail for off-grid final states.
- `packages/drive/src/instance/runtime.ts`: keeps service stdio in artifact logs and links the checkout's existing `@opentui/solid` preload into development artifacts.
- `packages/drive/src/cli/start.ts` and `src/log.ts`: continue writing lifecycle progress to `opencode-drive.log` without painting over a visible TUI.
- Two patch changesets cover the recording and visible-launch behavior.

## Scope

This does not replace the in-memory replay API with a streaming API. It bounds the expensive part of quiet 60 FPS recordings by sharing immutable snapshots and deduplication keys while preserving the existing public result shape.

## Testing

- `bun run --bun vitest run test/recording/replay.test.ts test/recording/export.test.ts` (19 passed)
- `bun run test:effect` (127 passed)
- `bun test test/cli/integration.test.ts -t "creates a type-checkable Effect script without overwriting it|keeps service and progress output out of a visible client terminal"` (2 passed)
- MP4 regression test verifies `60/1`, `0.466667s`, 28 frames, and the off-grid final frame pixels.
- `bun run typecheck` passed.
- `bun run lint` completed with three pre-existing warnings outside this diff.

## Flow

```mermaid
flowchart LR
  Timeline[Recorded timeline] --> Replay[60 FPS replay]
  Replay --> Shared[Shared unchanged snapshots]
  Shared --> Encode[Deduplicated PNG frames]
  Encode --> MP4[60 FPS H.264 MP4]
```