### PR TITLE
feat(drive): control tool calls at runtime

### DIFF
--- a/.changeset/runtime-tool-controls.md
+++ b/.changeset/runtime-tool-controls.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": minor
+---
+
+Allow scripts and library drivers to intercept declared tools and control concurrent invocations by call ID at runtime.

--- a/packages/drive/README.md
+++ b/packages/drive/README.md
@@ -286,27 +286,19 @@ Declared `config` and `tuiConfig` values are deeply merged over fixture
 `.opencode/opencode.jsonc` and `.opencode/tui.jsonc` files. Arrays replace
 instead of merging, and mutations made in `setup` take final precedence.
 
-Declare deterministic replacements for supported built-in tools with `tools`.
-Drive owns the OpenCode schema and plugin adapter; the script only handles typed
-input and emits progress or a terminal result:
+Declare which built-in tools Drive should intercept with `tools`, then control
+their invocations inside `run`. Each tool controller accepts calls in arrival
+order or by the stable call ID chosen in `Llm.toolCall`:
 
 ```ts
 import { Effect } from "effect"
-import { defineScript, Llm, Tool } from "opencode-drive"
+import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
-  tools(tools) {
-    tools.handle("shell", ({ input, index, progress }) =>
-      Effect.gen(function* () {
-        yield* progress(`Running call ${index}: ${input.command}...\n`)
-        if (index === 0)
-          return yield* new Tool.Failure({ message: "Controlled failure" })
-        return { output: "Controlled output\n", exit: 0 }
-      }),
-    )
-  },
-  run: ({ ui, llm }) =>
+  tools: ["shell"],
+  run: ({ ui, llm, tools }) =>
     Effect.gen(function* () {
+      const shells = yield* tools.control("shell")
       yield* llm.queue(
         Llm.toolCall({
           index: 0,
@@ -317,19 +309,29 @@ export default defineScript({
         Llm.finish("tool-calls"),
       )
       yield* ui.submit("Deploy production")
+      const shell = yield* shells.take("call_shell")
+      yield* shell.progress(`Running: ${shell.input.command}...\n`)
+      yield* shell.succeed({ output: "Controlled output\n", exit: 0 })
     }),
 })
 ```
 
-Foreground tool handler Effects are interrupted when OpenCode interrupts the
-session, the transport disconnects, or Drive shuts down. Use Effect finalizers
-such as `Effect.onInterrupt` or `Effect.ensuring` for cancellation cleanup.
-Detached background shell handlers continue after their launch response and
-are interrupted when Drive shuts down.
+Use `calls.take(id)` to coordinate known parallel calls independently, or
+`calls.take()` to accept the next unclaimed invocation. A controlled call can
+emit progress and then succeed or fail exactly once. `awaitInterrupted()`
+observes OpenCode interruption or transport disconnection. Drive interrupts
+all unresolved calls when it shuts down.
 
-Only registered tools are replaced. Unhandled tools continue to use OpenCode's
-real implementations. Each `progress` value replaces the visible tool output;
-send accumulated output when earlier lines should remain visible.
+The original `tools(registry)` callback remains available for fixed handlers
+that do not need orchestration from `run`. Foreground handler Effects are
+interrupted when OpenCode interrupts the session, the transport disconnects,
+or Drive shuts down. Detached background shell handlers continue after their
+launch response and are interrupted when Drive shuts down.
+
+Only declared or registered tools are replaced. Unhandled tools continue to
+use OpenCode's real implementations. Each `progress` value replaces the
+visible tool output; send accumulated output when earlier lines should remain
+visible.
 Supported adapters are `shell`, `webfetch`, and `websearch`; each handler
 receives its canonical typed V2 input and maintains an independent call index.
 When a shell call sets `background: true`, Drive returns immediately with the
@@ -349,7 +351,7 @@ Promise-style `setup`, `run`, or `ui.waitFor` callback, it prints the equivalent
 Effect shape after the TypeScript diagnostics. Use `Effect.sleep(milliseconds)`
 for unconditional delays.
 
-The `fs`, `ui`, `llm`, `server`, and `tuis` capabilities expose
+The `fs`, `ui`, `llm`, `tools`, `server`, and `tuis` capabilities expose
 Effect-returning operations. Compose them with `yield*`, `Effect.flatMap`, or
 other Effect operators. Scripts receive the same `Ui`, `Tui`, `Tuis`, and TUI
 options as `OpenCodeDriver`; `defineScript` does not define a second

--- a/packages/drive/compile/public-api.ts
+++ b/packages/drive/compile/public-api.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect"
-import { OpenCodeDriver } from "../src/index.js"
+import { OpenCodeDriver, Tool } from "../src/index.js"
 import type {
   Frontend,
   Project,
@@ -24,6 +24,12 @@ export type ScriptTuiIsCanonical = Assert<
 export type ScriptTuisAreCanonical = Assert<
   Equal<ScriptContext["tuis"], Tuis>
 >
+export type ScriptToolsAreCanonical = Assert<
+  Equal<ScriptContext["tools"], Tool.Controls>
+>
+export type DriverToolsAreCanonical = Assert<
+  Equal<OpenCodeDriver.Driver["tools"], Tool.Controls>
+>
 export type LaunchedTuiIsCanonical = Assert<
   Equal<Effect.Success<ReturnType<Tuis["launch"]>>, Tui>
 >
@@ -44,4 +50,22 @@ export type DriverProjectIsCanonical = Assert<
 const zeroConfig = OpenCodeDriver.use(() => Effect.void)
 export type ZeroConfigUseIsRunnable = Assert<
   Equal<Effect.Services<typeof zeroConfig>, never>
+>
+
+const controlledOptions: OpenCodeDriver.Options = { tools: ["shell"] }
+declare const controls: Tool.Controls
+const shellCalls = controls.control("shell")
+declare const toolName: Tool.Name
+controls.control(toolName)
+export type ShellControlIsTyped = Assert<
+  Equal<
+    Effect.Success<typeof shellCalls>,
+    Tool.ControlledCalls<Tool.ShellInput, Tool.ShellResult>
+  >
+>
+const controlled = OpenCodeDriver.use(controlledOptions, ({ tools }) =>
+  tools.control("shell").pipe(Effect.asVoid),
+)
+export type ControlledUseIsRunnable = Assert<
+  Equal<Effect.Services<typeof controlled>, never>
 >

--- a/packages/drive/docs/driver-consolidation-plan.md
+++ b/packages/drive/docs/driver-consolidation-plan.md
@@ -83,6 +83,11 @@ Expose the existing OpenCode SDK as `opencode` after introducing one service-reg
 
 Extend the canonical OpenCode simulation protocol to model delayed tool completion, structured success, failure, cancellation, concurrency, and partial input. Expose this only through programs, never through convenience CLI command flags.
 
+Drive's plugin-backed runtime controls now cover the supported `shell`,
+`webfetch`, and `websearch` adapters. This follow-up remains about canonical,
+provider-neutral simulation for arbitrary tools rather than expanding those
+Drive-owned adapters.
+
 ### Semantic UI Snapshot
 
 Add roles, labels, stable identity, selected/expanded/disabled state, and hierarchy to the canonical OpenCode frontend protocol. Drive should consume those semantics instead of deriving them from terminal text.

--- a/packages/drive/docs/open-code-driver-api.md
+++ b/packages/drive/docs/open-code-driver-api.md
@@ -192,6 +192,57 @@ yield* secondary.ui.screenshot("secondary")
 yield* oc.settle()
 ```
 
+## Runtime tool control uses statically declared adapters
+
+Declare the built-in tool names Drive should intercept before OpenCode starts,
+then control each invocation through the live `tools` capability. Undeclared
+tools keep their real OpenCode implementations.
+
+```ts
+const program = OpenCodeDriver.use(
+  { tools: ["shell"] },
+  ({ tools, llm, ui }) =>
+    Effect.gen(function* () {
+      const shells = yield* tools.control("shell")
+      yield* llm.queue(
+        Llm.toolCall({
+          index: 0,
+          id: "call_build",
+          name: "shell",
+          input: { command: "bun run build" },
+        }),
+        Llm.toolCall({
+          index: 1,
+          id: "call_test",
+          name: "shell",
+          input: { command: "bun run test" },
+        }),
+        Llm.finish("tool-calls"),
+      )
+      yield* ui.submit("Build and test")
+
+      const build = yield* shells.take("call_build")
+      const test = yield* shells.take("call_test")
+      yield* test.succeed({ output: "Tests passed\n", exit: 0 })
+      yield* build.succeed({ output: "Build passed\n", exit: 0 })
+    }),
+)
+```
+
+`take(callID)` reserves and accepts one known invocation independently of
+arrival order. `take()` accepts the oldest unclaimed invocation. Exact-ID
+waiters take precedence over generic waiters, so parallel calls may settle in
+any deliberate order. Each call may emit serialized progress and then succeed
+or fail exactly once. `awaitInterrupted()` completes when transport or
+controller interruption wins before terminal settlement.
+
+The program must take and terminally settle every intercepted invocation it
+expects. Driver scope closure fails blocked `take` operations, interrupts
+unresolved calls, and waits for transport cleanup. The callback-style
+`tools(registry)` configuration remains available
+for fixed handlers; callback-controlled tools are not also available through
+the runtime `tools.control` capability.
+
 ## LLM response description is separate from live LLM control
 
 `Llm` is a pure data module. `llm` is the live capability that queues, sends, and serves responses.

--- a/packages/drive/docs/open-code-driver-architecture.md
+++ b/packages/drive/docs/open-code-driver-architecture.md
@@ -5,7 +5,7 @@ sites are documented in [OpenCode Driver API](./open-code-driver-api.md).
 
 ## Domain Model
 
-`OpenCodeDriver` composes four resources:
+`OpenCodeDriver` composes these resources:
 
 ```text
 OpenCodeDriver
@@ -15,6 +15,7 @@ OpenCodeDriver
   tuis          additional frontend process factory
   ui            convenience alias for tui.ui
   llm           shared simulated-model control
+  tools         runtime control for declared tool adapters
 ```
 
 The names distinguish the two kinds of client involved:
@@ -24,6 +25,8 @@ The names distinguish the two kinds of client involved:
   optional `recording`.
 - `Tuis` launches and supervises additional frontend processes connected to
   the same server.
+- `tools` accepts independently controlled invocations for adapters declared
+  before OpenCode starts.
 - Transport-level JSON-RPC clients remain private implementation details.
 
 `defineScript` consumes these exact capabilities. It adds a branded module
@@ -41,6 +44,8 @@ Effect Scope
     server process
     TUI processes
     launch descriptors and logs
+    CLI script ToolController
+      controlled invocation exchanges
   OpenCodeServer
     backend simulation connection
     LLM controller
@@ -48,7 +53,15 @@ Effect Scope
     TUI supervisor
       primary TUI scope
       additional TUI scopes
+  Library ToolController
+    controlled invocation exchanges
 ```
+
+Library drivers create their ToolController before project preparation and
+pass that controller into `OpenCodeInstance`. CLI scripts create the controller
+inside `OpenCodeInstance`. Prepared drivers and script contexts derive controls
+from their instance, so the controller that wrote the plugin configuration is
+structurally the controller exposed at runtime.
 
 `OpenCodeDriver.make(options)` requires `Scope.Scope`. It returns once the
 server, generated SDK client, primary TUI, and simulation connections are
@@ -70,6 +83,20 @@ Settlement is one shared terminal operation. It runs in this order:
 rejects new launches and `llm` rejects new responses. `OpenCodeDriver.use`
 combines a user-program failure with a settlement failure rather than hiding
 either cause.
+
+## Tool Control Lifecycle
+
+`ToolController` installs only statically declared or callback-registered
+adapters into OpenCode's project configuration. Each runtime-controlled tool
+owns one exchange that matches incoming requests to exact-ID or FIFO waiters.
+Each accepted call owns a terminal Deferred, an interruption Deferred, and a
+one-permit Semaphore that serializes progress with terminal commitment.
+
+Controller scope release closes blocked waiters, marks unresolved calls
+interrupted, aborts active HTTP transports, and waits for handler finalizers.
+Terminal commitment uses a synchronous first-writer-wins Deferred completion;
+Drive guarantees exactly-once acceptance inside the controller, not delivery
+across a transport disconnect.
 
 ## TUI Lifecycle
 

--- a/packages/drive/src/cli/script.ts
+++ b/packages/drive/src/cli/script.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
 import * as OpenCodeDriver from "../driver/index.js"
 import type * as OpenCodeTui from "../driver/client.js"
 import * as OpenCodeUi from "../driver/ui.js"
@@ -9,6 +10,7 @@ import * as PreparedDriver from "../driver/prepared.js"
 import type * as OpenCodeInstance from "../instance/runtime.js"
 import { createScriptFileSystem } from "../script/filesystem.js"
 import { hasGitMetadata } from "../script/project.js"
+import { Names as ToolNames } from "../tool/types.js"
 import type {
   AutomaticScriptDefinition,
   ScriptDefinition,
@@ -128,6 +130,7 @@ export const runScript = Effect.fn("DriveCli.runScript")(function* (
       kill: prepared.server.kill,
     },
     llm: prepared.llm,
+    tools: instance.tools,
     artifacts: instance.artifacts,
   }
   const primaryTui = prepared.primary
@@ -184,10 +187,14 @@ function isScriptDefinition(value: unknown): value is ScriptDefinition {
     (value.config === undefined || isJsonObject(value.config)) &&
     (value.tuiConfig === undefined || isJsonObject(value.tuiConfig)) &&
     (value.setup === undefined || typeof value.setup === "function") &&
-    (value.tools === undefined || typeof value.tools === "function") &&
+    (value.tools === undefined || isToolConfiguration(value.tools)) &&
     (value.tui === undefined || isTuiOptions(value.tui)) &&
     (!("launch" in value) || value.launch === "manual")
   )
+}
+
+function isToolConfiguration(value: unknown) {
+  return typeof value === "function" || Schema.is(ToolNames)(value)
 }
 
 function isTuiOptions(value: unknown) {

--- a/packages/drive/src/driver/index.ts
+++ b/packages/drive/src/driver/index.ts
@@ -33,7 +33,7 @@ export interface Options {
   readonly config?: OpenCodeConfig
   readonly tuiConfig?: OpenCodeTuiConfig
   readonly setup?: Setup
-  readonly tools?: Tool.Setup
+  readonly tools?: Tool.Configuration
   readonly tui?: OpenCodeTui.TuiOptions
   readonly opencode?: OpenCodeServer.Target
   readonly keepArtifacts?: boolean
@@ -46,6 +46,8 @@ export interface Driver {
   /** Convenience alias for the primary TUI's UI. */
   readonly ui: OpenCodeUi.Ui
   readonly llm: Llm
+  /** Runtime controls for tools declared by name in the driver options. */
+  readonly tools: Tool.Controls
   readonly tuis: OpenCodeTui.Tuis
   readonly artifacts: string
   /** Validates queued LLM work, stops TUIs, and exports recordings. */
@@ -65,7 +67,7 @@ const makeWithServices = Effect.fn("OpenCodeDriver.makeWithServices")(
       project: options.project,
       config: options.config,
       tui: options.tuiConfig,
-      setup: ToolController.composeSetup(toolController, options.tools, options.setup),
+      setup: ToolController.composeSetup(toolController, options.setup),
       keepArtifacts: options.keepArtifacts,
     })
     const instance = yield* OpenCodeInstance.make({
@@ -76,7 +78,7 @@ const makeWithServices = Effect.fn("OpenCodeDriver.makeWithServices")(
       dev: options.opencode?.dev,
       env: options.opencode?.env,
       visible: options.opencode?.visible,
-    }).pipe(Effect.mapError((cause) => error("server.prepare", cause)))
+    }, toolController).pipe(Effect.mapError((cause) => error("server.prepare", cause)))
     const prepared = yield* PreparedDriver.makeWithServices(instance, {
       visible: options.opencode?.visible,
       tui: options.tui,

--- a/packages/drive/src/driver/prepared.ts
+++ b/packages/drive/src/driver/prepared.ts
@@ -42,7 +42,7 @@ export interface Prepared {
 export const makeWithServices = Effect.fn("OpenCodeDriver.makePreparedWithServices")(
   function* (
     instance: OpenCodeInstance.Instance,
-    options: Options = {},
+    options: Options,
   ) {
     const server = yield* OpenCodeServer.make({
       instance,
@@ -110,6 +110,7 @@ export const makeWithServices = Effect.fn("OpenCodeDriver.makePreparedWithServic
           tui: primary,
           ui: primary.ui,
           llm,
+          tools: instance.tools,
           tuis: server.tuis,
           artifacts: instance.artifacts,
           settle: () => settle,
@@ -142,7 +143,7 @@ export const makeWithServices = Effect.fn("OpenCodeDriver.makePreparedWithServic
 
 export const make = (
   instance: OpenCodeInstance.Instance,
-  options: Options = {},
+  options: Options,
 ) =>
   makeWithServices(instance, options).pipe(
     Effect.provide(SimulationConnector.layer),

--- a/packages/drive/src/instance/runtime.ts
+++ b/packages/drive/src/instance/runtime.ts
@@ -46,7 +46,7 @@ export interface Options {
   readonly config?: OpenCodeConfig
   readonly tui?: OpenCodeTuiConfig
   readonly setup?: Setup
-  readonly tools?: Tool.Setup
+  readonly tools?: Tool.Configuration
   readonly log?: (message: string) => void
 }
 
@@ -65,6 +65,7 @@ export interface Instance {
     readonly ui: string
     readonly backend: string
   }
+  readonly tools: Tool.Controls
   readonly recording: Effect.Effect<RecordingPaths | undefined>
   readonly primary: Effect.Effect<Process.Running, OpenCodeInstanceError>
   readonly launchServer: Effect.Effect<
@@ -104,6 +105,7 @@ const State = Data.taggedEnum<State>()
 
 export const make = Effect.fn("OpenCodeInstance.make")(function* (
   options: Options,
+  configuredTools?: ToolController.Controller,
 ) {
   const artifacts = resolve(options.artifacts)
   const logs = join(artifacts, "logs")
@@ -117,11 +119,13 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
     ui: `ws://127.0.0.1:${yield* freePort}`,
     backend: `ws://127.0.0.1:${yield* freePort}`,
   }
-  const toolController = yield* ToolController.make(options.tools)
+  const toolController = configuredTools ?? (yield* ToolController.make(options.tools))
   const database = yield* Config.string("OPENCODE_DRIVE_DB").pipe(
     Config.withDefault(":memory:"),
   )
-  const setup = ToolController.composeSetup(toolController, options.tools, options.setup)
+  const setup = configuredTools === undefined
+    ? ToolController.composeSetup(toolController, options.setup)
+    : options.setup
   if (
     options.project !== undefined ||
     options.config !== undefined ||
@@ -556,6 +560,7 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
     logs,
     visible: options.visible ?? false,
     endpoints,
+    tools: toolController.controls,
     recording: Ref.get(state).pipe(Effect.map((current) => current.recording)),
     primary: Ref.get(state).pipe(
       Effect.flatMap((current) =>

--- a/packages/drive/src/script/types.ts
+++ b/packages/drive/src/script/types.ts
@@ -37,6 +37,8 @@ export interface ScriptContext {
   readonly tuis: OpenCodeTui.Tuis
   readonly server: ScriptServer
   readonly llm: Llm
+  /** Runtime controls for tools declared by name on the script. */
+  readonly tools: Tool.Controls
   readonly artifacts: string
 }
 
@@ -59,8 +61,8 @@ export interface AutomaticScriptDefinition {
   readonly tuiConfig?: OpenCodeTuiConfig
   /** Runs once before OpenCode starts. */
   readonly setup?: Setup
-  /** Declares built-in tool replacements before OpenCode starts. */
-  readonly tools?: Tool.Setup
+  /** Declares runtime-controlled tool names or fixed replacements before OpenCode starts. */
+  readonly tools?: Tool.Configuration
   /** Configures the automatically launched primary TUI. */
   readonly tui?: OpenCodeTui.TuiOptions
   /** Runs after the UI and LLM connections are ready, and again after restart. */
@@ -78,8 +80,8 @@ export interface ManualScriptDefinition {
   readonly tuiConfig?: OpenCodeTuiConfig
   /** Runs once before OpenCode starts. */
   readonly setup?: Setup
-  /** Declares built-in tool replacements before OpenCode starts. */
-  readonly tools?: Tool.Setup
+  /** Declares runtime-controlled tool names or fixed replacements before OpenCode starts. */
+  readonly tools?: Tool.Configuration
   /** Defaults for TUIs launched by the script. */
   readonly tui?: OpenCodeTui.TuiOptions
   /** Runs after the shared service and LLM connection are ready. */

--- a/packages/drive/src/tool/controller.ts
+++ b/packages/drive/src/tool/controller.ts
@@ -1,9 +1,11 @@
 import { fileURLToPath } from "node:url"
 import * as Cause from "effect/Cause"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
+import * as Semaphore from "effect/Semaphore"
 import type {
   JsonValue,
   OpenCodeConfig,
@@ -11,15 +13,22 @@ import type {
 } from "../project.js"
 import {
   Failure,
+  ControlError,
   ShellInput,
   ShellResult,
   WebFetchInput,
   WebFetchResult,
   WebSearchInput,
   WebSearchResult,
+  type Configuration,
+  type ControlledCall,
+  type ControlledCalls,
+  type ControlledCallsFor,
+  type Controls,
+  type Handler,
+  type Name,
   type Registration,
   type Registry,
-  type Setup,
   type ShellHandler,
   type WebFetchHandler,
   type WebSearchHandler,
@@ -46,6 +55,7 @@ type Definition = {
   readonly invoke: (
     input: unknown,
     index: number,
+    id: string,
     progress: (result: Result) => Effect.Effect<void>,
   ) => Effect.Effect<Result, unknown>
 }
@@ -59,16 +69,38 @@ const ExecutionRequest = Schema.Struct({
 })
 const encoder = new TextEncoder()
 
+function controlError(
+  operation: ControlError["operation"],
+  reason: ControlError["reason"],
+  name: Name,
+  callID?: string,
+) {
+  const message =
+    reason === "not-controlled"
+      ? `tool is not configured for runtime control: ${name}`
+      : reason === "controller-closed"
+        ? callID === undefined
+          ? `tool controller is closed: ${name}`
+          : `${name} tool call ${callID} was interrupted because the controller closed`
+        : reason === "already-claimed"
+          ? `${name} tool call already claimed: ${callID}`
+          : reason === "already-settled"
+            ? `${name} tool call ${callID} is settled`
+            : `${name} tool call ${callID} is interrupted`
+  return new ControlError({ operation, reason, name, callID, message })
+}
+
 export interface Controller {
+  readonly enabled: boolean
+  readonly controls: Controls
   readonly configure: (config: OpenCodeConfig) => void
 }
 
 export function composeSetup(
   controller: Controller,
-  tools: Setup | undefined,
   setup: ProjectSetup | undefined,
 ): ProjectSetup | undefined {
-  if (tools === undefined && setup === undefined) return undefined
+  if (!controller.enabled && setup === undefined) return undefined
   return (context) =>
     Effect.suspend(() => {
       const configured: unknown = setup === undefined
@@ -87,8 +119,13 @@ function isEffect(value: unknown): value is Effect.Effect<unknown, unknown> {
   return Effect.isEffect(value)
 }
 
-export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
+export const make = Effect.fn("ToolController.make")(function* (configuration?: Configuration) {
   const definitions = new Map<string, Definition>()
+  const closeControls: Array<Effect.Effect<void>> = []
+  let closed = false
+  const controlledCalls: {
+    [Tool in Name]?: ControlledCallsFor<Tool>
+  } = {}
   const add = (name: string, definition: Definition) => {
     if (definitions.has(name)) throw new Error(`tool handler already registered: ${name}`)
     definitions.set(name, definition)
@@ -97,62 +134,106 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
   function handle(name: "webfetch", handler: WebFetchHandler): void
   function handle(name: "websearch", handler: WebSearchHandler): void
   function handle(...registration: Registration) {
-      switch (registration[0]) {
-        case "shell": {
-          const handler = registration[1]
-          add("shell", {
-            schema: ShellInput,
-            invoke: (raw, index, progress) =>
-              Effect.gen(function* () {
-                const input = yield* Schema.decodeUnknownEffect(ShellInput)(raw)
-                const result = yield* handler({
-                  input,
-                  index,
-                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
-                })
-                return yield* Schema.decodeUnknownEffect(ShellResult)(result)
-              }),
-          })
-          return
-        }
-        case "webfetch": {
-          const handler = registration[1]
-          add("webfetch", {
-            schema: WebFetchInput,
-            invoke: (raw, index, progress) =>
-              Effect.gen(function* () {
-                const input = yield* Schema.decodeUnknownEffect(WebFetchInput)(raw)
-                const result = yield* handler({
-                  input,
-                  index,
-                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
-                })
-                return yield* Schema.decodeUnknownEffect(WebFetchResult)(result)
-              }),
-          })
-          return
-        }
-        case "websearch": {
-          const handler = registration[1]
-          add("websearch", {
-            schema: WebSearchInput,
-            invoke: (raw, index, progress) =>
-              Effect.gen(function* () {
-                const input = yield* Schema.decodeUnknownEffect(WebSearchInput)(raw)
-                const result = yield* handler({
-                  input,
-                  index,
-                  progress: (value) => progress(typeof value === "string" ? { output: value } : value),
-                })
-                return yield* Schema.decodeUnknownEffect(WebSearchResult)(result)
-              }),
-          })
-        }
+    switch (registration[0]) {
+      case "shell": {
+        const handler = registration[1]
+        add("shell", {
+          schema: ShellInput,
+          invoke: (raw, index, id, progress) =>
+            Effect.gen(function* () {
+              const input = yield* Schema.decodeUnknownEffect(ShellInput)(raw)
+              const result = yield* handler({
+                id,
+                input,
+                index,
+                progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+              })
+              return yield* Schema.decodeUnknownEffect(ShellResult)(result)
+            }),
+        })
+        return
       }
+      case "webfetch": {
+        const handler = registration[1]
+        add("webfetch", {
+          schema: WebFetchInput,
+          invoke: (raw, index, id, progress) =>
+            Effect.gen(function* () {
+              const input = yield* Schema.decodeUnknownEffect(WebFetchInput)(raw)
+              const result = yield* handler({
+                id,
+                input,
+                index,
+                progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+              })
+              return yield* Schema.decodeUnknownEffect(WebFetchResult)(result)
+            }),
+        })
+        return
+      }
+      case "websearch": {
+        const handler = registration[1]
+        add("websearch", {
+          schema: WebSearchInput,
+          invoke: (raw, index, id, progress) =>
+            Effect.gen(function* () {
+              const input = yield* Schema.decodeUnknownEffect(WebSearchInput)(raw)
+              const result = yield* handler({
+                id,
+                input,
+                index,
+                progress: (value) => progress(typeof value === "string" ? { output: value } : value),
+              })
+              return yield* Schema.decodeUnknownEffect(WebSearchResult)(result)
+            }),
+        })
+      }
+    }
   }
   const registry: Registry = { handle }
-  setup?.(registry)
-  if (definitions.size === 0) return { configure() {} } satisfies Controller
+  if (typeof configuration === "function") configuration(registry)
+  if (Array.isArray(configuration)) {
+    for (const name of configuration) {
+      switch (name) {
+        case "shell": {
+          const controlled = makeControlledHandler<ShellInput, ShellResult>("shell")
+          handle("shell", controlled.handler)
+          controlledCalls.shell = controlled.calls
+          closeControls.push(controlled.close)
+          break
+        }
+        case "webfetch": {
+          const controlled = makeControlledHandler<WebFetchInput, WebFetchResult>("webfetch")
+          handle("webfetch", controlled.handler)
+          controlledCalls.webfetch = controlled.calls
+          closeControls.push(controlled.close)
+          break
+        }
+        case "websearch": {
+          const controlled = makeControlledHandler<WebSearchInput, WebSearchResult>("websearch")
+          handle("websearch", controlled.handler)
+          controlledCalls.websearch = controlled.calls
+          closeControls.push(controlled.close)
+          break
+        }
+        default:
+          throw new Error(`unsupported controlled tool: ${String(name)}`)
+      }
+    }
+  }
+  function control<Tool extends Name>(
+    name: Tool,
+  ): Effect.Effect<ControlledCallsFor<Tool>, ControlError> {
+    if (closed)
+      return Effect.fail(controlError("control", "controller-closed", name))
+    const calls = controlledCalls[name]
+    return calls === undefined
+      ? Effect.fail(controlError("control", "not-controlled", name))
+      : Effect.succeed(calls)
+  }
+  const controls: Controls = { control }
+  if (definitions.size === 0)
+    return { enabled: false, controls, configure() {} } satisfies Controller
 
   const token = crypto.randomUUID()
   const indexes = new Map<string, number>()
@@ -195,6 +276,8 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
     (server) =>
       Effect.gen(function* () {
         closing = true
+        closed = true
+        yield* Effect.all(closeControls, { discard: true })
         yield* Effect.sync(() => {
           for (const controller of active.keys())
             controller.abort(new Error("Drive tool controller stopped"))
@@ -214,6 +297,8 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
   )
 
   return {
+    enabled: true,
+    controls,
     configure(config) {
       const current = config.plugins
       if (current !== undefined && !Array.isArray(current))
@@ -228,6 +313,205 @@ export const make = Effect.fn("ToolController.make")(function* (setup?: Setup) {
     },
   } satisfies Controller
 })
+
+function makeControlledHandler<Input, Output>(name: Name): {
+  readonly calls: ControlledCalls<Input, Output>
+  readonly handler: Handler<Input, Output>
+  readonly close: Effect.Effect<void>
+} {
+  type Call = ControlledCall<Input, Output>
+  type Waiter = {
+    readonly id?: string
+    readonly resume: (effect: Effect.Effect<Call, ControlError>) => void
+    delivered?: Active
+  }
+  type Interruption = "transport-interrupted" | "controller-closed"
+  type Active = {
+    readonly call: Call
+    claimed: boolean
+    readonly interrupt: (reason: Interruption) => void
+  }
+
+  const records = new Map<string, Active>()
+  const waiters: Waiter[] = []
+  let closed = false
+
+  const deliver = (record: Active) => {
+    // A caller waiting for this exact ID wins over an earlier generic waiter.
+    const exact = waiters.findIndex((waiter) => waiter.id === record.call.id)
+    const index = exact >= 0
+      ? exact
+      : waiters.findIndex((waiter) => waiter.id === undefined)
+    if (index < 0) {
+      record.claimed = false
+      return
+    }
+    const [waiter] = waiters.splice(index, 1)
+    if (waiter === undefined)
+      throw new Error(`missing ${name} tool call waiter`)
+    record.claimed = true
+    waiter.delivered = record
+    waiter.resume(Effect.succeed(record.call))
+  }
+
+  const offer = (record: Active) =>
+    Effect.suspend(() => {
+      const id = record.call.id
+      if (closed)
+        return Effect.fail(new Failure({
+          message: controlError("take", "controller-closed", name, id).message,
+        }))
+      if (records.has(id))
+        return Effect.fail(new Failure({
+          message: `duplicate ${name} tool call ID: ${id}`,
+        }))
+      records.set(id, record)
+      deliver(record)
+      return Effect.void
+    })
+
+  function take(): Effect.Effect<Call, ControlError>
+  function take(id: string): Effect.Effect<Call, ControlError>
+  function take(id?: string): Effect.Effect<Call, ControlError> {
+    return Effect.callback<Call, ControlError>((resume) => {
+      if (closed) {
+        resume(Effect.fail(controlError("take", "controller-closed", name, id)))
+        return undefined
+      }
+      if (
+        id !== undefined &&
+        (records.get(id)?.claimed === true || waiters.some((waiter) => waiter.id === id))
+      ) {
+        resume(Effect.fail(controlError("take", "already-claimed", name, id)))
+        return undefined
+      }
+      let record = id === undefined ? undefined : records.get(id)
+      if (id === undefined) {
+        for (const candidate of records.values()) {
+          if (candidate.claimed) continue
+          record = candidate
+          break
+        }
+      }
+      if (record !== undefined) {
+        record.claimed = true
+        resume(Effect.succeed(record.call))
+        return Effect.sync(() => {
+          if (!closed && records.get(record.call.id) === record) {
+            record.claimed = false
+            deliver(record)
+          }
+          return undefined
+        })
+      }
+      const waiter: Waiter = { id, resume }
+      waiters.push(waiter)
+      return Effect.sync(() => {
+        const index = waiters.indexOf(waiter)
+        if (index >= 0) {
+          waiters.splice(index, 1)
+          return undefined
+        }
+        const delivered = waiter.delivered
+        if (
+          delivered !== undefined &&
+          !closed &&
+          records.get(delivered.call.id) === delivered
+        ) {
+          delivered.claimed = false
+          deliver(delivered)
+        }
+        return undefined
+      })
+    })
+  }
+
+  const handler: Handler<Input, Output> = (context) =>
+    Effect.uninterruptibleMask((restore) => Effect.gen(function* () {
+      const result = Deferred.makeUnsafe<Output, Failure>()
+      const interrupted = Deferred.makeUnsafe<void>()
+      const operations = Semaphore.makeUnsafe(1)
+      let state: "pending" | "settled" | Interruption = "pending"
+      const unavailable = (operation: ControlError["operation"]) => {
+        if (state === "pending") return undefined
+        return controlError(
+          operation,
+          state === "settled" ? "already-settled" : state,
+          name,
+          context.id,
+        )
+      }
+      const commit = (
+        operation: "succeed" | "fail",
+        completion: Effect.Effect<Output, Failure>,
+      ) =>
+        // Accepted progress must finish before the one terminal commitment.
+        operations.withPermit(
+          Effect.suspend(() => {
+            const failure = unavailable(operation)
+            if (failure !== undefined) return Effect.fail(failure)
+            return Effect.sync(() => {
+              state = "settled"
+              return Deferred.doneUnsafe(result, completion)
+                ? undefined
+                : controlError(operation, "already-settled", name, context.id)
+            }).pipe(
+              Effect.flatMap((failure) =>
+                failure === undefined ? Effect.void : Effect.fail(failure),
+              ),
+            )
+          }),
+        )
+      const call: Call = {
+        id: context.id,
+        input: context.input,
+        index: context.index,
+        progress: (output) =>
+          operations.withPermit(
+            Effect.suspend(() => {
+              const failure = unavailable("progress")
+              return failure === undefined ? context.progress(output) : Effect.fail(failure)
+            }),
+          ),
+        succeed: (output) => commit("succeed", Effect.succeed(output)),
+        fail: (message) => commit("fail", Effect.fail(new Failure({ message }))),
+        awaitInterrupted: () => Deferred.await(interrupted),
+      }
+      const record: Active = {
+        call,
+        claimed: false,
+        interrupt: (reason) => {
+          if (state !== "pending") return
+          state = reason
+          Deferred.doneUnsafe(interrupted, Effect.void)
+          Deferred.doneUnsafe(result, Effect.interrupt)
+        },
+      }
+      return yield* offer(record).pipe(
+        Effect.andThen(restore(Deferred.await(result))),
+        Effect.onInterrupt(() => Effect.sync(() => record.interrupt("transport-interrupted"))),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (records.get(context.id) === record)
+              records.delete(context.id)
+          }),
+        ),
+      )
+    }))
+
+  const close = Effect.sync(() => {
+    if (closed) return
+    closed = true
+    for (const waiter of waiters)
+      waiter.resume(Effect.fail(
+        controlError("take", "controller-closed", name, waiter.id),
+      ))
+    waiters.length = 0
+    for (const record of records.values()) record.interrupt("controller-closed")
+  })
+
+  return { calls: { take }, handler, close }
+}
 
 function execute(
   request: Request,
@@ -275,7 +559,12 @@ function execute(
       }
     }
     const index = nextIndex(indexes, name)
-    return yield* definition.invoke(input, index, (value) => send({ type: "progress", result: value }))
+    return yield* definition.invoke(
+      input,
+      index,
+      body.context.callID,
+      (value) => send({ type: "progress", result: value }),
+    )
   })
   void writer.closed.catch((cause) => controller.abort(cause))
   const completion = (async () => {
@@ -323,7 +612,7 @@ function startBackgroundShell(
 ): BackgroundJob {
   const controller = new AbortController()
   let output = ""
-  const result = definition.invoke(input, index, (value) =>
+  const result = definition.invoke(input, index, shellID, (value) =>
     Effect.sync(() => {
       encodeEvent({ type: "progress", result: value })
       output = value.output

--- a/packages/drive/src/tool/types.ts
+++ b/packages/drive/src/tool/types.ts
@@ -65,7 +65,29 @@ export class Failure extends Schema.TaggedErrorClass<Failure>()(
   { message: Schema.String },
 ) {}
 
+export const Name = Schema.Literals(["shell", "webfetch", "websearch"])
+export type Name = typeof Name.Type
+export const Names = Schema.Array(Name)
+
+export class ControlError extends Schema.TaggedErrorClass<ControlError>()(
+  "OpenCodeDrive.ToolControlError",
+  {
+    operation: Schema.Literals(["control", "take", "progress", "succeed", "fail"]),
+    reason: Schema.Literals([
+      "not-controlled",
+      "controller-closed",
+      "already-claimed",
+      "already-settled",
+      "transport-interrupted",
+    ]),
+    name: Name,
+    callID: Schema.optional(Schema.String),
+    message: Schema.String,
+  },
+) {}
+
 export interface Context<Input, Result> {
+  readonly id: string
   readonly input: Input
   /** Zero-based invocation index for this handler. */
   readonly index: number
@@ -80,15 +102,51 @@ export type ShellHandler = Handler<ShellInput, ShellResult>
 export type WebFetchHandler = Handler<WebFetchInput, WebFetchResult>
 export type WebSearchHandler = Handler<WebSearchInput, WebSearchResult>
 
-export type Registration =
-  | readonly [name: "shell", handler: ShellHandler]
-  | readonly [name: "webfetch", handler: WebFetchHandler]
-  | readonly [name: "websearch", handler: WebSearchHandler]
+export interface ToolTypes {
+  readonly shell: { readonly input: ShellInput; readonly result: ShellResult }
+  readonly webfetch: { readonly input: WebFetchInput; readonly result: WebFetchResult }
+  readonly websearch: { readonly input: WebSearchInput; readonly result: WebSearchResult }
+}
+
+export type HandlerFor<Tool extends Name> = Handler<
+  ToolTypes[Tool]["input"],
+  ToolTypes[Tool]["result"]
+>
+
+export type Registration = {
+  readonly [Tool in Name]: readonly [name: Tool, handler: HandlerFor<Tool>]
+}[Name]
 
 export interface Registry {
-  handle(name: "shell", handler: ShellHandler): void
-  handle(name: "webfetch", handler: WebFetchHandler): void
-  handle(name: "websearch", handler: WebSearchHandler): void
+  handle<Tool extends Name>(name: Tool, handler: HandlerFor<Tool>): void
 }
 
 export type Setup = (tools: Registry) => void
+
+export type Configuration = Setup | typeof Names.Type
+
+export interface ControlledCall<Input, Result> {
+  readonly id: string
+  readonly input: Input
+  readonly index: number
+  readonly progress: (output: string | Result) => Effect.Effect<void, ControlError>
+  readonly succeed: (result: Result) => Effect.Effect<void, ControlError>
+  /** Commits a failed remote tool result; this Effect fails only when control is no longer available. */
+  readonly fail: (message: string) => Effect.Effect<void, ControlError>
+  /** Completes only when interruption wins before `succeed` or `fail`. */
+  readonly awaitInterrupted: () => Effect.Effect<void>
+}
+
+export interface ControlledCalls<Input, Result> {
+  take(): Effect.Effect<ControlledCall<Input, Result>, ControlError>
+  take(id: string): Effect.Effect<ControlledCall<Input, Result>, ControlError>
+}
+
+export type ControlledCallsFor<Tool extends Name> = ControlledCalls<
+  ToolTypes[Tool]["input"],
+  ToolTypes[Tool]["result"]
+>
+
+export interface Controls {
+  control<Tool extends Name>(name: Tool): Effect.Effect<ControlledCallsFor<Tool>, ControlError>
+}

--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -834,6 +834,35 @@ describe("opencode-drive", () => {
     expect((await Bun.file(join(artifacts, "launches.txt")).text()).trim().split("\n")).toHaveLength(2)
   }, 60_000)
 
+  test("controls a statically declared tool from the running script", async () => {
+    const root = await temporary()
+    const child = spawn(
+      [
+        "start",
+        "--name",
+        "tool-control-script-test",
+        "--script",
+        fixture("tool-control-script.ts"),
+        "--",
+        process.execPath,
+        fixture("fake-opencode.ts"),
+      ],
+      root,
+    )
+    const stderr = new Response(child.stderr).text()
+    expect(await child.exited).toBe(0)
+    const artifacts = artifactPath(await stderr)
+    roots.push(artifacts)
+    const events = (await Bun.file(join(artifacts, "tool-control-events.jsonl")).text())
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line))
+    expect(events).toEqual([
+      { type: "progress", result: { output: "script progress\n" } },
+      { type: "success", result: { output: "script success\n", exit: 0 } },
+    ])
+  }, 60_000)
+
   test("closes the automatic script's primary TUI", async () => {
     const root = await temporary()
     const child = spawn(

--- a/packages/drive/test/driver/index.test.ts
+++ b/packages/drive/test/driver/index.test.ts
@@ -223,6 +223,35 @@ it.live("injects declared tool handlers for library drivers", () =>
   }),
 )
 
+it.live("exposes runtime controls for tools declared by name", () =>
+  Effect.gen(function* () {
+    const artifacts = yield* OpenCodeDriver.use(
+      {
+        keepArtifacts: true,
+        opencode: { command: fakeOpenCode },
+        tools: ["shell"],
+      },
+      (driver) =>
+        Effect.gen(function* () {
+          yield* driver.tools.control("shell")
+          return driver.artifacts
+        }),
+    )
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(() => rm(artifacts, { recursive: true, force: true })),
+    )
+    const config = yield* Effect.promise(() =>
+      readFile(`${artifacts}/files/.opencode/opencode.jsonc`, "utf8").then(JSON.parse),
+    )
+    expect(config.plugins).toEqual([
+      expect.objectContaining({
+        package: expect.stringMatching(/\/src\/tool\/plugin\.js$/),
+        options: expect.objectContaining({ tools: ["shell"] }),
+      }),
+    ])
+  }),
+)
+
 it.live("returns structured evidence from the safe lifecycle boundary", () =>
   Effect.gen(function* () {
     const result = yield* OpenCodeDriver.useReport(

--- a/packages/drive/test/fixtures/tool-control-script.ts
+++ b/packages/drive/test/fixtures/tool-control-script.ts
@@ -1,0 +1,57 @@
+import { defineScript } from "opencode-drive"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+
+export default defineScript({
+  tools: ["shell"],
+  run: ({ tools, artifacts }) =>
+    Effect.gen(function* () {
+      const shells = yield* tools.control("shell")
+      const options = yield* Effect.tryPromise(async () => {
+        const config: unknown = await Bun.file(
+          `${artifacts}/files/.opencode/opencode.jsonc`,
+        ).json()
+        if (typeof config !== "object" || config === null || !("plugins" in config))
+          throw new Error("script config has no plugins")
+        const plugins = config.plugins
+        if (!Array.isArray(plugins)) throw new Error("script plugins are not an array")
+        const plugin = plugins.find(
+          (value) => typeof value === "object" && value !== null && "options" in value,
+        )
+        if (typeof plugin !== "object" || plugin === null || !("options" in plugin))
+          throw new Error("Drive tool plugin is missing")
+        const value = plugin.options
+        if (
+          typeof value !== "object" ||
+          value === null ||
+          !("endpoint" in value) ||
+          typeof value.endpoint !== "string" ||
+          !("token" in value) ||
+          typeof value.token !== "string"
+        )
+          throw new Error("Drive tool plugin options are invalid")
+        return { endpoint: value.endpoint, token: value.token }
+      })
+      const response = yield* Effect.tryPromise((signal) =>
+        fetch(`${options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${options.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            input: { command: "controlled from script" },
+            context: { callID: "call_script_control" },
+          }),
+          signal,
+        }).then((value) => value.text()),
+      ).pipe(Effect.forkScoped)
+      const shell = yield* shells.take("call_script_control")
+      yield* shell.progress("script progress\n")
+      yield* shell.succeed({ output: "script success\n", exit: 0 })
+      const events = yield* Fiber.join(response)
+      yield* Effect.promise(() =>
+        Bun.write(`${artifacts}/tool-control-events.jsonl`, events),
+      )
+    }),
+})

--- a/packages/drive/test/manual/tui-regressions/README.md
+++ b/packages/drive/test/manual/tui-regressions/README.md
@@ -81,3 +81,23 @@ OPENCODE_DRIVE_SEED=42 OPENCODE_DRIVE_STEPS=20 \
 Re-run a failure with the same seed and step count. Transition preconditions constrain actions to valid idle, pending, streaming, tool-input, and running-tool states. Tool input is chunked so interruption can occur before parsing completes; advancing the tool response dispatches a blocking question tool so interruption can also occur during execution. Interrupted tool parts must settle with an aborted error in the server projection. A queued prompt must have exactly one owner across pending input and projected history. Completion can promote it into the next model step, interruption can leave it awaiting resume, and provider failure can promote it into a replacement execution. Shared invariants also require the latest prompt and settled output to remain visible, the server projection to retain the active prompt, the composer to become actionable after terminal execution, and internal transport defects to stay out of the UI.
 
 Interruption uses the existing `llm.pending` simulation capability. If OpenCode rejects a response write after terminating the invocation, Drive confirms that the invocation is no longer pending and settles the response as externally terminated. If the invocation remains pending or the query fails, Drive preserves the original write failure.
+
+## Multi-tool interleavings
+
+`multi-tool-interleavings.ts` launches shell, question, read, and glob calls in
+one assistant step. It holds the shell open while three permissions coexist,
+approves the question so its form is hidden behind the remaining read and glob
+permissions, and lets glob complete while read permission stays visible. It
+then rejects read, answers the form, and releases shell last. Permission
+rejection interrupts the whole assistant step after sibling tools settle, so
+the probe submits a recovery prompt. It verifies mixed backend states,
+settlement order, final projected tool states, post-interruption reuse, and
+preserves terminal frames for both prompt-priority states:
+
+```sh
+bun run --cwd packages/drive drive check \
+  test/manual/tui-regressions/multi-tool-interleavings.ts
+bun run --cwd packages/drive drive start --name tui-multi-tool-interleavings \
+  --script test/manual/tui-regressions/multi-tool-interleavings.ts \
+  --dev "$OPENCODE_DEV"
+```

--- a/packages/drive/test/manual/tui-regressions/README.md
+++ b/packages/drive/test/manual/tui-regressions/README.md
@@ -85,7 +85,8 @@ Interruption uses the existing `llm.pending` simulation capability. If OpenCode 
 ## Multi-tool interleavings
 
 `multi-tool-interleavings.ts` launches shell, question, read, and glob calls in
-one assistant step. It holds the shell open while three permissions coexist,
+one assistant step. Drive controls the declared shell by call ID from `run`,
+holding it open while three permissions coexist,
 approves the question so its form is hidden behind the remaining read and glob
 permissions, and lets glob complete while read permission stays visible. It
 then rejects read, answers the form, and releases shell last. Permission

--- a/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
+++ b/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
@@ -1,0 +1,240 @@
+import { defineScript, Llm, Tool } from "../../../src/index.js"
+import { Deferred, Effect, Schedule, Stream } from "effect"
+
+const shellCallID = "call_multi_shell"
+const questionCallID = "call_multi_question"
+const readCallID = "call_multi_read"
+const globCallID = "call_multi_glob"
+const question = "Which runtime should the multi-tool probe use?"
+
+let shellStarted: Deferred.Deferred<void> | undefined
+let releaseShell: Deferred.Deferred<void> | undefined
+
+export default defineScript({
+  project: {
+    files: {
+      "fixture.txt": "multi-tool fixture\n",
+    },
+  },
+  config: {
+    autoupdate: false,
+    permissions: [
+      { action: "*", resource: "*", effect: "ask" },
+      { action: "shell", resource: "*", effect: "allow" },
+    ],
+  },
+  tools: (tools) => {
+    tools.handle("shell", ({ progress }) =>
+      Effect.gen(function* () {
+        const started = shellStarted
+        const release = releaseShell
+        if (started === undefined || release === undefined)
+          return yield* new Tool.Failure({ message: "shell controls were not initialized" })
+        yield* progress("multi-tool shell remains active\n")
+        yield* Deferred.succeed(started, undefined)
+        yield* Deferred.await(release)
+        return { output: "multi-tool shell completed\n", exit: 0 }
+      }),
+    )
+  },
+  run: ({ ui, llm, opencode, artifacts }) =>
+    Effect.scoped(Effect.gen(function* () {
+      shellStarted = yield* Deferred.make<void>()
+      releaseShell = yield* Deferred.make<void>()
+      const executionInterrupted = yield* Deferred.make<void>()
+      const toolSettlements: Array<string> = []
+
+      yield* opencode.event.subscribe().pipe(
+        Stream.runForEach((event) => {
+          if (event.type === "session.tool.success" || event.type === "session.tool.failed")
+            toolSettlements.push(`${event.type}:${event.data.callID}`)
+          if (event.type === "session.execution.interrupted")
+            return Deferred.succeed(executionInterrupted, undefined).pipe(Effect.asVoid)
+          return Effect.void
+        }),
+        Effect.forkScoped,
+      )
+
+      yield* llm.queue(
+        Llm.toolCall({
+          index: 0,
+          id: shellCallID,
+          name: "shell",
+          input: { command: "hold multi-tool shell" },
+        }),
+        Llm.toolCall({
+          index: 1,
+          id: questionCallID,
+          name: "question",
+          input: {
+            questions: [
+              {
+                question,
+                header: "Runtime",
+                options: [
+                  { label: "Bun", description: "Use Bun for the probe." },
+                  { label: "Node", description: "Use Node for the probe." },
+                ],
+                multiple: false,
+              },
+            ],
+          },
+        }),
+        Llm.toolCall({
+          index: 2,
+          id: readCallID,
+          name: "read",
+          input: { path: "fixture.txt" },
+        }),
+        Llm.toolCall({
+          index: 3,
+          id: globCallID,
+          name: "glob",
+          input: { pattern: "**/*.txt", path: ".", limit: 100 },
+        }),
+        Llm.finish("tool-calls"),
+      )
+      yield* llm.queue(Llm.text("multi-tool-interleaving-complete"))
+
+      yield* ui.submit("Run a shell, ask a question, and read the fixture concurrently.")
+      yield* Deferred.await(shellStarted)
+      const sessionID = yield* poll(
+        opencode.session.list({ limit: 1, order: "desc" }).pipe(
+          Effect.map((sessions) => sessions.data[0]?.id),
+        ),
+        "current session",
+      )
+      const permissions = yield* poll(
+        opencode.permission.list({ sessionID }).pipe(
+          Effect.map((items) => {
+            const questionPermission = items.find(
+              (item) => item.source?.type === "tool" && item.source.callID === questionCallID,
+            )
+            const readPermission = items.find(
+              (item) => item.source?.type === "tool" && item.source.callID === readCallID,
+            )
+            const globPermission = items.find(
+              (item) => item.source?.type === "tool" && item.source.callID === globCallID,
+            )
+            return questionPermission && readPermission && globPermission
+              ? { question: questionPermission, read: readPermission, glob: globPermission }
+              : undefined
+          }),
+        ),
+        "question, read, and glob permissions",
+      )
+
+      yield* opencode.permission.reply({
+        sessionID,
+        requestID: permissions.question.id,
+        reply: "once",
+      })
+      const form = yield* poll(
+        Effect.all({
+          forms: opencode.form.list({ sessionID }),
+          permissions: opencode.permission.list({ sessionID }),
+        }).pipe(
+          Effect.map(({ forms, permissions: current }) =>
+            forms[0] &&
+            current.some((item) => item.id === permissions.read.id) &&
+            current.some((item) => item.id === permissions.glob.id)
+              ? forms[0]
+              : undefined,
+          ),
+        ),
+        "question form behind the read and glob permissions",
+      )
+      yield* saveFrame(artifacts, "permission-over-form", yield* ui.capture())
+      yield* ui.screenshot("permission-over-form")
+      yield* ui.waitFor("Permission required", { timeout: 10_000 })
+
+      yield* opencode.permission.reply({
+        sessionID,
+        requestID: permissions.glob.id,
+        reply: "once",
+      })
+      yield* poll(
+        opencode.message.list({ sessionID, limit: 20, order: "desc" }).pipe(
+          Effect.map((messages) => {
+            const glob = messages.data
+              .flatMap((message) => message.type === "assistant" ? message.content : [])
+              .find((part) => part.type === "tool" && part.id === globCallID)
+            return glob?.type === "tool" && glob.state.status === "completed"
+              ? glob
+              : undefined
+          }),
+        ),
+        "glob completion while read permission remains",
+      )
+      const remaining = yield* opencode.permission.list({ sessionID })
+      if (!remaining.some((item) => item.id === permissions.read.id))
+        return yield* Effect.fail(new Error("read permission disappeared before rejection"))
+
+      yield* opencode.permission.reply({
+        sessionID,
+        requestID: permissions.read.id,
+        reply: "reject",
+      })
+      yield* ui.waitFor(question, { timeout: 10_000 })
+      yield* saveFrame(artifacts, "form-with-running-shell", yield* ui.capture())
+      yield* ui.screenshot("form-with-running-shell")
+
+      yield* ui.enter()
+      yield* poll(
+        opencode.form.state({ sessionID, formID: form.id }).pipe(
+          Effect.map((state) => state.status === "answered" ? state : undefined),
+        ),
+        "answered question form",
+      )
+
+      yield* Deferred.succeed(releaseShell, undefined)
+      yield* Deferred.await(executionInterrupted)
+      yield* ui.submit("Recover after the rejected concurrent tool.")
+      yield* ui.waitFor("multi-tool-interleaving-complete", { timeout: 15_000 })
+      const messages = yield* opencode.message.list({ sessionID, limit: 20, order: "desc" })
+      const tools = messages.data.flatMap((message) =>
+        message.type === "assistant"
+          ? message.content.filter((part) => part.type === "tool")
+          : [],
+      )
+      const statuses = new Map(tools.map((tool) => [tool.id, tool.state.status]))
+      if (
+        statuses.get(shellCallID) !== "completed" ||
+        statuses.get(questionCallID) !== "completed" ||
+        statuses.get(globCallID) !== "completed" ||
+        statuses.get(readCallID) !== "error"
+      )
+        return yield* Effect.fail(
+          new Error(`unexpected final tool states: ${JSON.stringify(Object.fromEntries(statuses))}`),
+        )
+      const expected = [
+        `session.tool.success:${globCallID}`,
+        `session.tool.success:${questionCallID}`,
+        `session.tool.success:${shellCallID}`,
+        `session.tool.failed:${readCallID}`,
+      ]
+      const relevant = toolSettlements.filter((item) => expected.includes(item))
+      if (relevant.join("\n") !== expected.join("\n"))
+        return yield* Effect.fail(
+          new Error(`unexpected tool settlement order: ${JSON.stringify(relevant)}`),
+        )
+    })),
+})
+
+function poll<A, E, R>(effect: Effect.Effect<A | undefined, E, R>, description: string) {
+  return Effect.repeat(effect, {
+    until: (value): value is A => value !== undefined,
+    schedule: Schedule.spaced(50),
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: 10_000,
+      orElse: () => Effect.fail(new Error(`timed out waiting for ${description}`)),
+    }),
+  )
+}
+
+function saveFrame(artifacts: string, name: string, frame: unknown) {
+  return Effect.tryPromise(() =>
+    Bun.write(`${artifacts}/${name}.frame.json`, JSON.stringify(frame, null, 2)),
+  ).pipe(Effect.asVoid)
+}

--- a/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
+++ b/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
@@ -1,4 +1,4 @@
-import { defineScript, Llm, Tool } from "../../../src/index.js"
+import { defineScript, Llm } from "../../../src/index.js"
 import { Deferred, Effect, Schedule, Stream } from "effect"
 
 const shellCallID = "call_multi_shell"
@@ -6,9 +6,6 @@ const questionCallID = "call_multi_question"
 const readCallID = "call_multi_read"
 const globCallID = "call_multi_glob"
 const question = "Which runtime should the multi-tool probe use?"
-
-let shellStarted: Deferred.Deferred<void> | undefined
-let releaseShell: Deferred.Deferred<void> | undefined
 
 export default defineScript({
   project: {
@@ -23,24 +20,10 @@ export default defineScript({
       { action: "shell", resource: "*", effect: "allow" },
     ],
   },
-  tools: (tools) => {
-    tools.handle("shell", ({ progress }) =>
-      Effect.gen(function* () {
-        const started = shellStarted
-        const release = releaseShell
-        if (started === undefined || release === undefined)
-          return yield* new Tool.Failure({ message: "shell controls were not initialized" })
-        yield* progress("multi-tool shell remains active\n")
-        yield* Deferred.succeed(started, undefined)
-        yield* Deferred.await(release)
-        return { output: "multi-tool shell completed\n", exit: 0 }
-      }),
-    )
-  },
-  run: ({ ui, llm, opencode, artifacts }) =>
+  tools: ["shell"],
+  run: ({ ui, llm, opencode, artifacts, tools }) =>
     Effect.scoped(Effect.gen(function* () {
-      shellStarted = yield* Deferred.make<void>()
-      releaseShell = yield* Deferred.make<void>()
+      const shells = yield* tools.control("shell")
       const executionInterrupted = yield* Deferred.make<void>()
       const toolSettlements: Array<string> = []
 
@@ -97,7 +80,8 @@ export default defineScript({
       yield* llm.queue(Llm.text("multi-tool-interleaving-complete"))
 
       yield* ui.submit("Run a shell, ask a question, and read the fixture concurrently.")
-      yield* Deferred.await(shellStarted)
+      const shell = yield* shells.take(shellCallID)
+      yield* shell.progress("multi-tool shell remains active\n")
       const sessionID = yield* poll(
         opencode.session.list({ limit: 1, order: "desc" }).pipe(
           Effect.map((sessions) => sessions.data[0]?.id),
@@ -187,17 +171,17 @@ export default defineScript({
         "answered question form",
       )
 
-      yield* Deferred.succeed(releaseShell, undefined)
+      yield* shell.succeed({ output: "multi-tool shell completed\n", exit: 0 })
       yield* Deferred.await(executionInterrupted)
       yield* ui.submit("Recover after the rejected concurrent tool.")
       yield* ui.waitFor("multi-tool-interleaving-complete", { timeout: 15_000 })
       const messages = yield* opencode.message.list({ sessionID, limit: 20, order: "desc" })
-      const tools = messages.data.flatMap((message) =>
+      const toolParts = messages.data.flatMap((message) =>
         message.type === "assistant"
           ? message.content.filter((part) => part.type === "tool")
           : [],
       )
-      const statuses = new Map(tools.map((tool) => [tool.id, tool.state.status]))
+      const statuses = new Map(toolParts.map((tool) => [tool.id, tool.state.status]))
       if (
         statuses.get(shellCallID) !== "completed" ||
         statuses.get(questionCallID) !== "completed" ||

--- a/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
+++ b/packages/drive/test/manual/tui-regressions/multi-tool-interleavings.ts
@@ -218,6 +218,7 @@ export default defineScript({
         return yield* Effect.fail(
           new Error(`unexpected tool settlement order: ${JSON.stringify(relevant)}`),
         )
+      return undefined
     })),
 })
 

--- a/packages/drive/test/tool/controller.test.ts
+++ b/packages/drive/test/tool/controller.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Deferred, Effect } from "effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
@@ -22,9 +22,9 @@ it.effect("streams progress before shell success and failure", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const controller = yield* ToolController.make((tools) => {
-        tools.handle("shell", ({ input, index, progress }) =>
+        tools.handle("shell", ({ id, input, index, progress }) =>
           Effect.gen(function* () {
-            yield* progress(`running ${index}: ${input.command}\n`)
+            yield* progress(`running ${id}/${index}: ${input.command}\n`)
             if (input.command === "fail")
               return yield* new Failure({ message: "controlled failure" })
             return { output: "controlled success\n", exit: 7 }
@@ -59,11 +59,11 @@ it.effect("streams progress before shell success and failure", () =>
         })
 
       expect(yield* invoke("succeed")).toEqual([
-        { type: "progress", result: { output: "running 0: succeed\n" } },
+        { type: "progress", result: { output: "running call_succeed/0: succeed\n" } },
         { type: "success", result: { output: "controlled success\n", exit: 7 } },
       ])
       expect(yield* invoke("fail")).toEqual([
-        { type: "progress", result: { output: "running 1: fail\n" } },
+        { type: "progress", result: { output: "running call_fail/1: fail\n" } },
         { type: "failure", message: "controlled failure" },
       ])
     }),
@@ -76,9 +76,331 @@ it.effect("does not inject a plugin without handlers", () =>
       const controller = yield* ToolController.make()
       const config: OpenCodeConfig = {}
       controller.configure(config)
+      expect(ToolController.composeSetup(controller, undefined)).toBeUndefined()
       expect(config).toEqual({})
     }),
   ),
+)
+
+it.effect("controls parallel calls independently by tool call ID", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const shells = yield* controller.controls.control("shell")
+      const invoke = (id: string, command: string) =>
+        Effect.promise(async () => {
+          const response = await fetch(`${injected.options.endpoint}/execute/shell`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${injected.options.token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ input: { command }, context: { callID: id } }),
+          })
+          return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+        })
+
+      const buildResponse = yield* invoke("call_build", "bun run build").pipe(Effect.forkScoped)
+      const testResponse = yield* invoke("call_test", "bun run test").pipe(Effect.forkScoped)
+      const test = yield* shells.take("call_test")
+      const build = yield* shells.take("call_build")
+
+      expect(test).toMatchObject({ id: "call_test", input: { command: "bun run test" } })
+      expect(build).toMatchObject({ id: "call_build", input: { command: "bun run build" } })
+      expect([build.index, test.index].sort((left, right) => left - right)).toEqual([0, 1])
+      expect(yield* shells.take("call_test").pipe(Effect.flip)).toMatchObject({
+        _tag: "OpenCodeDrive.ToolControlError",
+        message: "shell tool call already claimed: call_test",
+      })
+
+      yield* test.progress("testing\n")
+      yield* build.progress("building\n")
+      yield* test.succeed({ output: "tests passed\n", exit: 0 })
+      yield* build.fail("build failed")
+
+      expect(yield* Fiber.join(testResponse)).toEqual([
+        { type: "progress", result: { output: "testing\n" } },
+        { type: "success", result: { output: "tests passed\n", exit: 0 } },
+      ])
+      expect(yield* Fiber.join(buildResponse)).toEqual([
+        { type: "progress", result: { output: "building\n" } },
+        { type: "failure", message: "build failed" },
+      ])
+      expect(yield* test.fail("late failure").pipe(Effect.flip)).toMatchObject({
+        _tag: "OpenCodeDrive.ToolControlError",
+        operation: "fail",
+        reason: "already-settled",
+        message: "shell tool call call_test is settled",
+      })
+      expect(yield* test.progress("late progress\n").pipe(Effect.flip)).toMatchObject({
+        _tag: "OpenCodeDrive.ToolControlError",
+        operation: "progress",
+        reason: "already-settled",
+      })
+      const repeatedResponse = yield* invoke("call_test", "bun run test again").pipe(Effect.forkScoped)
+      const repeated = yield* shells.take("call_test")
+      expect(repeated).toMatchObject({ id: "call_test", input: { command: "bun run test again" } })
+      yield* repeated.succeed({ output: "tests passed again\n", exit: 0 })
+      expect(yield* Fiber.join(repeatedResponse)).toEqual([
+        { type: "success", result: { output: "tests passed again\n", exit: 0 } },
+      ])
+    }),
+  ),
+)
+
+it.effect("retains call ID ownership while rejecting concurrent duplicates", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const shells = yield* controller.controls.control("shell")
+      const invoke = (command: string) =>
+        Effect.promise(async () => {
+          const response = await fetch(`${injected.options.endpoint}/execute/shell`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${injected.options.token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              input: { command },
+              context: { callID: "call_same" },
+            }),
+          })
+          return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+        })
+
+      const firstResponse = yield* invoke("first").pipe(Effect.forkScoped)
+      const first = yield* shells.take("call_same")
+      expect(yield* invoke("second")).toEqual([
+        { type: "failure", message: "duplicate shell tool call ID: call_same" },
+      ])
+      expect(yield* shells.take("call_same").pipe(Effect.flip)).toMatchObject({
+        reason: "already-claimed",
+        callID: "call_same",
+      })
+      expect(yield* invoke("third")).toEqual([
+        { type: "failure", message: "duplicate shell tool call ID: call_same" },
+      ])
+
+      yield* first.succeed({ output: "first complete\n", exit: 0 })
+      yield* Fiber.join(firstResponse)
+      const reusedResponse = yield* invoke("reused").pipe(Effect.forkScoped)
+      const reused = yield* shells.take("call_same")
+      expect(reused.input.command).toBe("reused")
+      yield* reused.succeed({ output: "reused complete\n", exit: 0 })
+      yield* Fiber.join(reusedResponse)
+    }),
+  ),
+)
+
+it.effect("gives an exact call ID waiter precedence over a generic waiter", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const shells = yield* controller.controls.control("shell")
+      const generic = yield* shells.take().pipe(Effect.forkScoped)
+      const exact = yield* shells.take("call_b").pipe(Effect.forkScoped)
+      const invoke = (id: string) =>
+        Effect.promise(async () => {
+          const response = await fetch(`${injected.options.endpoint}/execute/shell`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${injected.options.token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ input: { command: id }, context: { callID: id } }),
+          })
+          return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+        })
+      const responseB = yield* invoke("call_b").pipe(Effect.forkScoped)
+      const responseA = yield* invoke("call_a").pipe(Effect.forkScoped)
+
+      const callB = yield* Fiber.join(exact)
+      const callA = yield* Fiber.join(generic)
+      expect(callB.id).toBe("call_b")
+      expect(callA.id).toBe("call_a")
+      yield* callB.succeed({ output: "b\n" })
+      yield* callA.succeed({ output: "a\n" })
+      yield* Fiber.join(responseB)
+      yield* Fiber.join(responseA)
+    }),
+  ),
+)
+
+it.effect("accepts exactly one concurrent terminal operation", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const shells = yield* controller.controls.control("shell")
+      const response = yield* Effect.promise(async () => {
+        const request = fetch(`${injected.options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${injected.options.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ input: { command: "race" }, context: { callID: "call_race" } }),
+        }).then((response) => response.text())
+        return { request }
+      })
+      const call = yield* shells.take("call_race")
+      const start = yield* Deferred.make<void>()
+      const attempts = yield* Effect.all([
+        Deferred.await(start).pipe(
+          Effect.andThen(call.succeed({ output: "won\n" })),
+          Effect.exit,
+        ),
+        Deferred.await(start).pipe(
+          Effect.andThen(call.fail("lost")),
+          Effect.exit,
+        ),
+      ], { concurrency: "unbounded" }).pipe(
+        Effect.forkChild,
+      )
+      yield* Deferred.succeed(start, undefined)
+      const exits = yield* Fiber.join(attempts)
+      expect(exits.filter(Exit.isSuccess)).toHaveLength(1)
+      expect(exits.filter(Exit.isFailure)).toHaveLength(1)
+      const events = (yield* Effect.promise(() => response.request)).trim().split("\n").map((line) => JSON.parse(line))
+      expect(events).toHaveLength(1)
+      expect(["success", "failure"]).toContain(events[0]?.type)
+    }),
+  ),
+)
+
+it.effect("releases an interrupted waiter and reports transport interruption", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const shells = yield* controller.controls.control("shell")
+      const abandoned = yield* shells.take("call_wait").pipe(Effect.forkScoped)
+      yield* Fiber.interrupt(abandoned)
+
+      const request = new AbortController()
+      const response = fetch(`${injected.options.endpoint}/execute/shell`, {
+        method: "POST",
+        signal: request.signal,
+        headers: {
+          authorization: `Bearer ${injected.options.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          input: { command: "wait" },
+          context: { callID: "call_wait" },
+        }),
+      }).catch(() => undefined)
+      const call = yield* shells.take("call_wait")
+      request.abort()
+      yield* call.awaitInterrupted()
+      yield* Effect.promise(() => response)
+
+      expect(yield* call.succeed({ output: "late\n" }).pipe(Effect.flip)).toMatchObject({
+        _tag: "OpenCodeDrive.ToolControlError",
+        message: "shell tool call call_wait is interrupted",
+      })
+    }),
+  ),
+)
+
+it.effect("rejects runtime control for tools not declared by name", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make((tools) => {
+        tools.handle("shell", () => Effect.succeed({ output: "legacy handler\n" }))
+      })
+      expect(yield* controller.controls.control("shell").pipe(Effect.flip)).toMatchObject({
+        _tag: "OpenCodeDrive.ToolControlError",
+        message: "tool is not configured for runtime control: shell",
+      })
+    }),
+  ),
+)
+
+it.effect("closes blocked runtime controls with the controller scope", () =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make()
+    const controller = yield* ToolController.make(["shell"]).pipe(Scope.provide(scope))
+    const shells = yield* controller.controls.control("shell")
+    const waiting = yield* shells.take("call_never").pipe(Effect.forkChild)
+
+    yield* Scope.close(scope, Exit.void)
+
+    expect(yield* Fiber.join(waiting).pipe(Effect.flip)).toMatchObject({
+      _tag: "OpenCodeDrive.ToolControlError",
+      operation: "take",
+      reason: "controller-closed",
+      name: "shell",
+    })
+    expect(yield* controller.controls.control("shell").pipe(Effect.flip)).toMatchObject({
+      _tag: "OpenCodeDrive.ToolControlError",
+      operation: "control",
+      reason: "controller-closed",
+      name: "shell",
+    })
+  }),
+)
+
+it.effect("interrupts claimed calls when the controller scope closes", () =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make()
+    const controller = yield* ToolController.make(["shell"]).pipe(Scope.provide(scope))
+    const config: OpenCodeConfig = {}
+    controller.configure(config)
+    const injected = (config.plugins as Array<{
+      options: { endpoint: string; token: string }
+    }>)[0]!
+    const shells = yield* controller.controls.control("shell")
+    const response = fetch(`${injected.options.endpoint}/execute/shell`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        input: { command: "wait" },
+        context: { callID: "call_shutdown" },
+      }),
+    }).catch(() => undefined)
+    const call = yield* shells.take("call_shutdown")
+    const interrupted = yield* call.awaitInterrupted().pipe(Effect.forkChild)
+
+    yield* Scope.close(scope, Exit.void)
+    yield* Fiber.join(interrupted)
+    yield* Effect.promise(() => response)
+
+    expect(yield* call.succeed({ output: "late\n" }).pipe(Effect.flip)).toMatchObject({
+      _tag: "OpenCodeDrive.ToolControlError",
+      operation: "succeed",
+      reason: "controller-closed",
+      name: "shell",
+      callID: "call_shutdown",
+    })
+  }),
 )
 
 it.effect("routes typed webfetch and websearch handlers independently", () =>
@@ -184,6 +506,59 @@ it.effect("settles background shells immediately and retains their completion", 
       release.resolve()
       expect(yield* Effect.promise(() => completion)).toEqual({
         shellID: "call_background",
+        command: "compile",
+        state: "completed",
+        output: "compile complete\n",
+      })
+    }),
+  ),
+)
+
+it.effect("controls a background shell after its launch response", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const controller = yield* ToolController.make(["shell"])
+      const config: OpenCodeConfig = {}
+      controller.configure(config)
+      const injected = (config.plugins as Array<{
+        options: { endpoint: string; token: string }
+      }>)[0]!
+      const headers = {
+        authorization: `Bearer ${injected.options.token}`,
+        "content-type": "application/json",
+      }
+      const shells = yield* controller.controls.control("shell")
+      const started = yield* Effect.promise(async () => {
+        const response = await fetch(`${injected.options.endpoint}/execute/shell`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            input: { command: "compile", background: true },
+            context: { callID: "call_controlled_background" },
+          }),
+        })
+        return (await response.text()).trim().split("\n").map((line) => JSON.parse(line))
+      })
+      expect(started).toEqual([
+        {
+          type: "success",
+          result: {
+            output: "The command was moved to the background.",
+            shellID: "call_controlled_background",
+            status: "running",
+          },
+        },
+      ])
+
+      const shell = yield* shells.take("call_controlled_background")
+      yield* shell.progress("compiling\n")
+      const completion = fetch(
+        `${injected.options.endpoint}/background/call_controlled_background`,
+        { headers },
+      ).then((response) => response.json())
+      yield* shell.succeed({ output: "compile complete\n", exit: 0 })
+      expect(yield* Effect.promise(() => completion)).toEqual({
+        shellID: "call_controlled_background",
         command: "compile",
         state: "completed",
         output: "compile complete\n",

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -184,43 +184,69 @@ Drive prefers protocol negotiation and reports explicit legacy fallback. Set `op
 
 ### Simulated Shell Execution
 
-Use `tools` to replace shell execution without changing the model-visible tool
-schema. The handler receives typed input, a zero-based call index, and an Effect
-progress function. Foreground handler Effects are interrupted when OpenCode
-interrupts the session, the transport disconnects, or Drive shuts down; use
-Effect finalizers for cancellation cleanup. Detached background shell handlers
-continue after their launch response and are interrupted when Drive shuts down.
-Unregistered tools remain real.
+Declare the built-in tools Drive should intercept, then control each invocation
+from the running program. Unregistered tools remain real. Calls may be accepted
+in arrival order or by the stable ID supplied in `Llm.toolCall`, so parallel
+invocations can progress and settle independently.
+
+```ts
+import { Effect } from "effect"
+import { Llm, OpenCodeDriver } from "opencode-drive"
+
+export default OpenCodeDriver.use({ tools: ["shell"] }, ({ tools, llm, ui }) =>
+  Effect.gen(function* () {
+    const shells = yield* tools.control("shell")
+    yield* llm.queue(
+      Llm.toolCall({
+        index: 0,
+        id: "call_shell",
+        name: "shell",
+        input: { command: "compile" },
+      }),
+      Llm.finish("tool-calls"),
+    )
+    yield* ui.submit("Compile the project")
+    const shell = yield* shells.take("call_shell")
+    yield* shell.progress(`Running ${shell.input.command}\n`)
+    yield* shell.succeed({ output: "Controlled success\n", exit: 0 })
+  }),
+)
+```
+
+The same declaration and runtime `tools` capability are available in
+`defineScript`. Supported adapters are `shell`, `webfetch`, and `websearch`.
+Each progress value replaces the visible tool output, so send accumulated text
+when earlier lines should remain visible. Calls settle exactly once;
+`awaitInterrupted()` observes session interruption or transport disconnection.
+
+The callback form remains available for fixed behavior that does not need
+runtime orchestration:
 
 ```ts
 import { Effect } from "effect"
 import { Tool } from "opencode-drive"
 
 const tools = (registry: Tool.Registry) => {
-  registry.handle("shell", ({ input, index, progress }) =>
+  registry.handle("shell", ({ input, progress }) =>
     Effect.gen(function* () {
       yield* progress(`Running ${input.command}\n`)
-      if (index === 0)
-        return yield* new Tool.Failure({ message: "Controlled failure" })
       return { output: "Controlled success\n", exit: 0 }
     }),
   )
 }
-
-export default OpenCodeDriver.use({ tools }, (driver) => program(driver))
 ```
 
-The same `tools` callback is accepted by `defineScript`. Supported adapters are
-`shell`, `webfetch`, and `websearch`; unregistered tools remain real.
-Each progress value replaces the visible tool output, so send accumulated text
-when earlier lines should remain visible.
+Foreground callback handler Effects are interrupted when OpenCode interrupts
+the session, the transport disconnects, or Drive shuts down. Detached
+background shell handlers continue after their launch response and are
+interrupted when Drive shuts down.
 
 ## Effect Scripts
 
 Use `defineScript` with `start --script` when the workflow must have a stable
 instance name, be visible, rerun on `restart`, or explicitly launch and kill
 its server and TUIs. `setup` and `run` return Effects. Operations on `fs`,
-`ui`, `llm`, `server`, and `tuis` also return Effects; there is no
+`ui`, `llm`, `tools`, `server`, and `tuis` also return Effects; there is no
 Promise API or compatibility shim.
 
 ```ts


### PR DESCRIPTION
## What

Add Drive-owned runtime control for selected OpenCode tools. Scripts and library drivers can statically declare `shell`, `webfetch`, or `websearch`, accept concurrent invocations by stable call ID, stream progress, and settle each call independently.

```ts
tools: ["shell"],
run: ({ tools }) => Effect.gen(function* () {
  const shells = yield* tools.control("shell")
  const shell = yield* shells.take("call_build")
  yield* shell.progress("building\n")
  yield* shell.succeed({ output: "built\n", exit: 0 })
})
```

The existing callback-style `tools(registry)` API remains available for fixed handlers. Undeclared tools continue to use OpenCode's real implementations.

## How

- `src/tool/controller.ts` hosts declared adapters, routes exact-ID and FIFO waiters, serializes progress with terminal commitment, and owns interruption/shutdown cleanup.
- Runtime calls expose typed `id`, `input`, `index`, `progress`, `succeed`, `fail`, and `awaitInterrupted` operations with structured `ControlError` failures.
- One insertion-ordered owner map prevents duplicate IDs from releasing or stealing active calls. Effect callback cleanup safely returns a call when a suspended `take` is interrupted.
- `OpenCodeInstance` owns the controller used to configure its plugin; prepared drivers and script contexts derive controls from that instance.
- Background shells return their launch response immediately while the controlled call continues to drive retained completion state.
- The multi-tool interleaving probe now uses the public runtime-control API as its first feature-level consumer.
- README, API/architecture docs, agent skill guidance, compile contracts, and a minor changeset document the public surface.

## Scope

- This is Drive-only. It does not change OpenCode or add backend control to CLI command flags.
- Runtime adapters are limited to `shell`, `webfetch`, and `websearch`.
- Array declarations and callback registration remain intentionally exclusive.
- Exactly-once settlement is a Drive-local acceptance guarantee, not a delivery guarantee after an HTTP transport disconnect.

## Testing

- `bun run test`: 153 Effect tests, 51 CLI integration tests, and 28 catalog tests passed.
- `bun run check`: package/catalog lint, typecheck, generated catalog validation, tests, and builds passed.
- `cd packages/drive && bun run drive check test/manual/tui-regressions/multi-tool-interleavings.ts`
- `cd packages/drive && bun pm pack --dry-run`, followed by packed-artifact installation and `Tool` export validation in a clean consumer.
- Live multi-tool probe passed against OpenCode `v2` at `bef6cfbffe`, including permission-over-form priority, form-with-running-shell state, exact sibling settlement, interruption, and session recovery.

## Demo

The question form exists, but read and glob permissions retain prompt priority while the runtime-controlled shell stays active:

![Permission shown over pending form](https://assets.kitlangton.dev/anomalyco/opencode-drive/pr-32/permission-over-form-runtime-controls-cc415061aa36.png)

After glob completes and read is rejected, the form appears while the controlled shell remains active:

![Form shown with running controlled shell](https://assets.kitlangton.dev/anomalyco/opencode-drive/pr-32/form-with-running-controlled-shell-f5a17f0ed679.png)

## Flow

```mermaid
sequenceDiagram
  participant Program as Drive program
  participant Controls as Tool controls
  participant Adapter as OpenCode tool adapter
  participant OpenCode

  Program->>Controls: control("shell")
  Program->>Controls: take("call_build")
  OpenCode->>Adapter: shell(input, call_build)
  Adapter->>Controls: offer call_build
  Controls-->>Program: typed controlled call
  Program->>Controls: progress("building")
  Controls-->>Adapter: progress event
  Adapter-->>OpenCode: streamed progress
  Program->>Controls: succeed(result)
  Controls-->>Adapter: terminal result
  Adapter-->>OpenCode: success event
```
