### PR TITLE
fix(recording): preserve frame timing

### DIFF
--- a/.changeset/preserve-recording-timing.md
+++ b/.changeset/preserve-recording-timing.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Preserve recorded frame timing during MP4 encoding and reduce work for dense or unchanged terminal output.

--- a/packages/drive/src/recording/encode.ts
+++ b/packages/drive/src/recording/encode.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto"
-import { copyFile, link, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { runFfmpeg } from "./ffmpeg.js"
+import { resolveFps } from "./frame-rate.js"
 
 export interface ImageFrame {
   readonly atMs: number
@@ -24,30 +25,36 @@ export async function encodeFrames(
 ) {
   const final = frames.at(-1)
   if (!final) throw new Error("recording has no frames")
-  const fps = options.fps ?? 60
+  const fps = resolveFps(options.fps)
+  const frameIntervalMs = 1000 / fps
   await mkdir(dirname(output), { recursive: true })
   const directory = await mkdtemp(join(tmpdir(), "opencode-drive-recording-"))
   const progress = progressReporter(options.onProgress)
   try {
     const unique = new Map<string, string>()
+    const renderedFrames: string[] = []
     for (const [index, frame] of frames.entries()) {
       options.signal?.throwIfAborted()
-      const hash = createHash("sha256").update(frame.key).digest("hex")
-      let rendered = unique.get(hash)
+      let rendered = unique.get(frame.key)
       if (!rendered) {
-        rendered = join(directory, `unique-${hash}.png`)
-        await writeFile(rendered, await frame.render(), { signal: options.signal })
-        unique.set(hash, rendered)
+        const hash = createHash("sha256").update(frame.key).digest("hex")
+        rendered = `unique-${hash}.png`
+        await writeFile(join(directory, rendered), await frame.render(), { signal: options.signal })
+        unique.set(frame.key, rendered)
       }
-      await linkOrCopy(rendered, join(directory, `frame-${String(index).padStart(8, "0")}.png`))
+      renderedFrames.push(rendered)
       progress(((index + 1) / frames.length) * 90)
     }
     const concat = join(directory, "frames.ffconcat")
-    const entries = frames.flatMap((frame, index) => {
-      const next = frames[index + 1]
-      const file = `file frame-${String(index).padStart(8, "0")}.png`
-      return next ? [file, `duration ${(next.atMs - frame.atMs) / 1000}`] : [file]
-    })
+    const firstAtMs = frames[0]!.atMs
+    const lastFrameIndex = Math.max(0, Math.ceil((final.atMs - firstAtMs) / frameIntervalMs - 1e-9))
+    const entries: string[] = []
+    let sourceIndex = 0
+    for (let index = 0; index <= lastFrameIndex; index++) {
+      const atMs = firstAtMs + index * frameIntervalMs
+      while (frames[sourceIndex + 1] && frames[sourceIndex + 1]!.atMs <= atMs + 1e-9) sourceIndex++
+      entries.push(`file ${renderedFrames[sourceIndex]!}`)
+    }
     await writeFile(concat, `ffconcat version 1.0\n${entries.join("\n")}\n`, {
       signal: options.signal,
     })
@@ -72,7 +79,7 @@ export async function encodeFrames(
         "-movflags",
         "+faststart",
         "-fps_mode",
-        "vfr",
+        "cfr",
         output,
       ],
       options.signal,
@@ -80,14 +87,6 @@ export async function encodeFrames(
     progress(100)
   } finally {
     await rm(directory, { recursive: true, force: true })
-  }
-}
-
-async function linkOrCopy(source: string, destination: string) {
-  try {
-    await link(source, destination)
-  } catch {
-    await copyFile(source, destination)
   }
 }
 

--- a/packages/drive/src/recording/export.ts
+++ b/packages/drive/src/recording/export.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, extname } from "node:path"
 import { encodeFrames } from "./encode.js"
@@ -47,14 +48,13 @@ export async function exportRecording(
     )
     progress(100)
   } else if (extension === ".mp4") {
-    const frameKeys = new WeakMap<object, number>()
-    let nextFrameKey = 0
+    const frameKeys = new WeakMap<object, string>()
     await encodeFrames(
       frames.map((sample) => {
         const label = header(sample.atMs)
         let frameKey = frameKeys.get(sample.frame)
         if (frameKey === undefined) {
-          frameKey = nextFrameKey++
+          frameKey = createHash("sha256").update(JSON.stringify(sample.frame)).digest("hex")
           frameKeys.set(sample.frame, frameKey)
         }
         return {

--- a/packages/drive/src/recording/frame-rate.ts
+++ b/packages/drive/src/recording/frame-rate.ts
@@ -1,0 +1,6 @@
+const DefaultFps = 60
+
+export function resolveFps(fps = DefaultFps) {
+  if (!Number.isFinite(fps) || fps <= 0) throw new Error("fps must be a positive finite number")
+  return fps
+}

--- a/packages/drive/src/recording/replay.ts
+++ b/packages/drive/src/recording/replay.ts
@@ -1,4 +1,5 @@
 import { decodeTimeline } from "./decode.js"
+import { resolveFps } from "./frame-rate.js"
 import { createTerminalParser, type TerminalParserFactory } from "./terminal.js"
 import type { SampledFrame, TimelineHeader } from "./types.js"
 
@@ -13,18 +14,13 @@ interface InternalReplayOptions extends ReplayOptions {
   terminalFactory?: TerminalParserFactory
 }
 
-function sampleInterval(fps: number) {
-  if (!Number.isFinite(fps) || fps <= 0) throw new Error("fps must be a positive finite number")
-  return 1000 / fps
-}
-
 export async function replayRecording(path: string, options: ReplayOptions = {}): Promise<SampledFrame[]> {
   return replay(path, options)
 }
 
 export async function replay(path: string, options: InternalReplayOptions = {}): Promise<SampledFrame[]> {
   options.signal?.throwIfAborted()
-  const interval = sampleInterval(options.fps ?? 60)
+  const interval = 1000 / resolveFps(options.fps)
   if (options.startAtMs !== undefined && (!Number.isFinite(options.startAtMs) || options.startAtMs < 0))
     throw new Error("startAtMs must be a non-negative finite number")
   if (options.durationMs !== undefined && (!Number.isFinite(options.durationMs) || options.durationMs < 0))
@@ -41,7 +37,15 @@ export async function replay(path: string, options: InternalReplayOptions = {}):
   const endAt = options.durationMs === undefined ? Number.POSITIVE_INFINITY : startAt + options.durationMs
   let nextSample = startAt
   let finalAt = 0
-  let snapshot = terminal.snapshot()
+  let snapshot: SampledFrame["frame"] | undefined
+  let dirty = true
+  const currentSnapshot = () => {
+    if (dirty || !snapshot) {
+      snapshot = terminal.snapshot()
+      dirty = false
+    }
+    return snapshot
+  }
 
   for (;;) {
     const next = await records.next()
@@ -54,27 +58,31 @@ export async function replay(path: string, options: InternalReplayOptions = {}):
       break
     }
     while (nextSample < event.at_ms && nextSample <= endAt) {
-      frames.push({ atMs: nextSample, frame: snapshot })
+      frames.push({ atMs: nextSample, frame: currentSnapshot() })
       nextSample += interval
     }
-    if (event.type === "output") terminal.write(Buffer.from(event.data, "base64"))
-    else terminal.resize(event.cols, event.rows)
-    snapshot = terminal.snapshot()
+    if (event.type === "output") {
+      const data = Buffer.from(event.data, "base64")
+      terminal.write(data)
+      if (data.length > 0) dirty = true
+    } else {
+      terminal.resize(event.cols, event.rows)
+      dirty = true
+    }
     finalAt = event.at_ms
   }
-  terminal.finish()
-  snapshot = terminal.snapshot()
+  if (terminal.finish()) dirty = true
 
   const targetFinal = options.durationMs === undefined ? Math.max(startAt, finalAt) : endAt
   while (nextSample <= targetFinal) {
-    frames.push({ atMs: nextSample, frame: snapshot })
+    frames.push({ atMs: nextSample, frame: currentSnapshot() })
     nextSample += interval
   }
   const final = frames.at(-1)
   if (final && Math.abs(final.atMs - targetFinal) < 0.000_001) {
     frames[frames.length - 1] = { ...final, atMs: targetFinal }
   } else {
-    frames.push({ atMs: targetFinal, frame: snapshot })
+    frames.push({ atMs: targetFinal, frame: currentSnapshot() })
   }
   if (options.startAtMs !== undefined) {
     return frames.map((sample) => ({ ...sample, atMs: sample.atMs - startAt }))

--- a/packages/drive/src/recording/terminal.ts
+++ b/packages/drive/src/recording/terminal.ts
@@ -9,7 +9,7 @@ const SyncEnd = Buffer.from("\x1b[?2026l")
 
 export interface TerminalParser {
   write(data: Uint8Array): void
-  finish(): void
+  finish(): boolean
   resize(cols: number, rows: number): void
   snapshot(): CapturedFrame
 }
@@ -93,9 +93,10 @@ class GhosttyTerminal implements TerminalParser {
   }
 
   finish() {
-    if (!this.pending.length) return
+    if (!this.pending.length) return false
     this.core.writeRaw(this.pending)
     this.pending = Buffer.alloc(0)
+    return true
   }
 
   resize(cols: number, rows: number) {

--- a/packages/drive/test/recording/export-dedupe.test.ts
+++ b/packages/drive/test/recording/export-dedupe.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, test, vi } from "vitest"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ImageFrame } from "../../src/recording/encode.js"
+
+const encoded = vi.hoisted(() => ({ frames: [] as ReadonlyArray<ImageFrame> }))
+
+vi.mock("../../src/recording/encode.js", () => ({
+  encodeFrames: vi.fn(async (frames: ReadonlyArray<ImageFrame>) => {
+    encoded.frames = frames
+  }),
+}))
+
+import { exportRecording } from "../../src/recording/export.js"
+
+const directories: string[] = []
+
+afterEach(async () => {
+  encoded.frames = []
+  await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+test("deduplicates equal snapshots with distinct identities", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "drive-export-dedupe-test-"))
+  directories.push(directory)
+  const timeline = join(directory, "timeline.jsonl")
+  await writeFile(
+    timeline,
+    [
+      JSON.stringify({ type: "header", version: 1, cols: 8, rows: 2, encoding: "base64" }),
+      JSON.stringify({
+        type: "output",
+        at_ms: 0,
+        data: Buffer.from("ready").toString("base64"),
+      }),
+      JSON.stringify({ type: "output", at_ms: 500, data: "" }),
+      "",
+    ].join("\n"),
+  )
+
+  await exportRecording(timeline, join(directory, "video.mp4"))
+
+  expect(encoded.frames).toHaveLength(31)
+  expect(new Set(encoded.frames.map((frame) => frame.key))).toHaveLength(1)
+})

--- a/packages/drive/test/recording/export.test.ts
+++ b/packages/drive/test/recording/export.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createCanvas, loadImage } from "@napi-rs/canvas"
-import { exportRecording, joinFrames, renderFrame } from "../../src/recording/index.js"
+import { encodeFrames, exportRecording, joinFrames, renderFrame } from "../../src/recording/index.js"
 
 const directories: string[] = []
 
@@ -26,6 +26,16 @@ test("exports the final frame as a PNG and creates its parent", async () => {
   expect(result).toEqual({ frames: 1, durationMs: 0, width: 40, height: 40 })
   expect((await readFile(output)).subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
   expect((await stat(output)).size).toBeGreaterThan(100)
+})
+
+test("rejects invalid encoding frame rates", async () => {
+  await expect(
+    encodeFrames(
+      [{ atMs: 0, key: "frame", render: () => Buffer.alloc(0) }],
+      join(tmpdir(), "invalid-frame-rate.mp4"),
+      { fps: 0 },
+    ),
+  ).rejects.toThrow("fps must be a positive finite number")
 })
 
 test("renders an optional recording header", async () => {
@@ -220,6 +230,52 @@ test("rejects invalid capture font overrides", async () => {
 })
 
 if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
+  test("preserves irregular frame timing at the requested frame rate", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "drive-encode-ffmpeg-test-"))
+    directories.push(directory)
+    const image = (background: number) =>
+      renderFrame({
+        cols: 1,
+        rows: 1,
+        cursor: { row: 0, col: 0, visible: false },
+        lines: [{ spans: [{ text: " ", width: 1, fg: 0xffffff, bg: background, attributes: 0 }] }],
+      })
+    const output = join(directory, "video.mp4")
+    await encodeFrames(
+      [
+        { atMs: 0, key: "red", render: () => image(0xff0000) },
+        { atMs: 1_000, key: "green", render: () => image(0x00ff00) },
+        { atMs: 1_200, key: "blue", render: () => image(0x0000ff) },
+      ],
+      output,
+      { fps: 5 },
+    )
+
+    expect(probeVideo(output)).toEqual(["5/1", "1.400000", "7"])
+
+    const finalFrame = join(directory, "final.png")
+    const decoded = Bun.spawnSync([
+      "ffmpeg",
+      "-v",
+      "error",
+      "-i",
+      output,
+      "-vf",
+      "reverse",
+      "-frames:v",
+      "1",
+      finalFrame,
+    ])
+    expect(decoded.exitCode).toBe(0)
+    const final = await loadImage(finalFrame)
+    const canvas = createCanvas(final.width, final.height)
+    const context = canvas.getContext("2d")
+    context.drawImage(final, 0, 0)
+    const pixel = context.getImageData(5, 10, 1, 1).data
+    expect(pixel[2]).toBeGreaterThan(200)
+    expect(pixel[0]).toBeLessThan(80)
+  })
+
   test("exports a 60 FPS H.264 MP4 with the off-grid final frame", async () => {
     const directory = await mkdtemp(join(tmpdir(), "drive-export-ffmpeg-test-"))
     directories.push(directory)
@@ -241,7 +297,7 @@ if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
         }),
         JSON.stringify({
           type: "output",
-          at_ms: 450,
+          at_ms: 455,
           data: Buffer.from("\r\x1b[48;2;0;0;255mBBBB").toString("base64"),
         }),
         "",
@@ -251,26 +307,13 @@ if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
     const progress: number[] = []
     const result = await exportRecording(timeline, output, { onProgress: (percent) => progress.push(percent) })
     const data = await readFile(output)
-    expect(result.frames).toBe(28)
-    expect(result.durationMs).toBe(450)
+    expect(result.frames).toBe(29)
+    expect(result.durationMs).toBe(455)
     expect(data.subarray(4, 8).toString()).toBe("ftyp")
     expect(data.length).toBeGreaterThan(500)
     expect(progress).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
 
-    const probe = Bun.spawnSync([
-      "ffprobe",
-      "-v",
-      "error",
-      "-select_streams",
-      "v:0",
-      "-show_entries",
-      "stream=avg_frame_rate,duration,nb_frames",
-      "-of",
-      "default=noprint_wrappers=1:nokey=1",
-      output,
-    ])
-    expect(probe.exitCode).toBe(0)
-    expect(probe.stdout.toString().trim().split("\n")).toEqual(["60/1", "0.466667", "28"])
+    expect(probeVideo(output)).toEqual(["60/1", "0.483333", "29"])
 
     const finalFrame = join(directory, "final.png")
     const decoded = Bun.spawnSync([
@@ -294,6 +337,23 @@ if (Bun.which("ffmpeg") && Bun.which("ffprobe")) {
     expect(pixel[2]).toBeGreaterThan(200)
     expect(pixel[0]).toBeLessThan(80)
   })
+}
+
+function probeVideo(path: string) {
+  const probe = Bun.spawnSync([
+    "ffprobe",
+    "-v",
+    "error",
+    "-select_streams",
+    "v:0",
+    "-show_entries",
+    "stream=avg_frame_rate,duration,nb_frames",
+    "-of",
+    "default=noprint_wrappers=1:nokey=1",
+    path,
+  ])
+  expect(probe.exitCode).toBe(0)
+  return probe.stdout.toString().trim().split("\n")
 }
 
 function renderImport(env: Record<string, string>) {

--- a/packages/drive/test/recording/replay.test.ts
+++ b/packages/drive/test/recording/replay.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { replayRecording } from "../../src/recording/index.js"
+import { replay } from "../../src/recording/replay.js"
 
 const directories: string[] = []
 
@@ -95,6 +96,42 @@ describe("replayRecording", () => {
     expect(frames.at(-1)!.atMs).toBe(1_000)
     expect(frames.every((frame) => lineText(frame.frame) === "ready")).toBe(true)
     expect(new Set(frames.map((frame) => frame.frame)).size).toBe(1)
+  })
+
+  test("captures terminal state at sample boundaries instead of every event", async () => {
+    let snapshots = 0
+    let dirty = false
+    const frames = await replay(
+      await recording(Array.from({ length: 101 }, (_, atMs) => [atMs, "x"])),
+      {
+        fps: 10,
+        terminalFactory: async (cols, rows) => ({
+          write: () => {
+            dirty = true
+          },
+          resize: () => {
+            dirty = true
+          },
+          finish: () => false,
+          snapshot: () => {
+            snapshots++
+            return {
+              cols,
+              rows,
+              cursor: { row: 0, col: 0, visible: false },
+              lines: Array.from({ length: rows }, (_, row) => ({
+                spans: row === 0 && dirty
+                  ? [{ text: "ready", width: 5, fg: 0xffffff, bg: 0x080808, attributes: 0 }]
+                  : [],
+              })),
+            }
+          },
+        }),
+      },
+    )
+
+    expect(frames.map((frame) => frame.atMs)).toEqual([0, 100])
+    expect(snapshots).toBe(2)
   })
 
   test("trims blank startup time and rebases the first visible frame", async () => {


### PR DESCRIPTION
## What

Preserve `ImageFrame.atMs` timing when exporting constant-rate MP4 recordings, while reducing capture and filesystem work for dense or unchanged terminal output.

## Before / After

**Before:** FFmpeg received `-r` as an input option over one concat entry per source frame. Irregular frames at 0 ms, 1000 ms, and 1200 ms encoded as three 5 FPS frames lasting 0.6 seconds, discarding the supplied timing. Replay also captured the complete terminal grid after every event, and equal snapshots with different object identities rendered separately.

**After:** Drive samples source timestamps onto the requested CFR grid before invoking FFmpeg. The same input becomes seven 5 FPS frames lasting 1.4 seconds, with the final frame preserved. Replay captures lazily at sample boundaries, and structurally equal snapshots share one render key.

## How

- `src/recording/encode.ts` selects frames from `atMs`, references unique PNGs directly from the concat manifest, and removes per-sample hardlinks.
- `src/recording/replay.ts` captures terminal state only when a requested sample needs it.
- `src/recording/export.ts` caches a structural digest once per snapshot object so equal states deduplicate across identities.
- `src/recording/frame-rate.ts` centralizes the 60 FPS default and positive-finite validation.
- Recording regressions cover irregular timestamps, a genuinely off-grid final state, dense event streams, invalid rates, and equal-snapshot deduplication.

## Scope

This keeps 60 FPS as the default and retains the existing custom `fps` quality/performance control. It does not change timeline capture, terminal rendering, or the public result shape.

## Testing

- `bun run test:effect test/recording/export.test.ts test/recording/replay.test.ts test/recording/export-dedupe.test.ts` (23 passed)
- `bun run test:effect` (147 passed)
- `bun run test:cli` (51 passed)
- `bun run lint`
- `bun run typecheck`
- `bun pm pack --dry-run`
- FFprobe verifies exact 5 FPS and 60 FPS output, duration, frame count, and final-frame pixels.

## Flow

```mermaid
flowchart LR
  Timeline[Timeline events] --> Replay[Lazy replay sampling]
  Replay --> Frames[Timestamped frames]
  Frames --> CFR[CFR frame selection]
  CFR --> Unique[Unique rendered PNGs]
  Unique --> MP4[FFmpeg MP4]
```