### PR TITLE
fix(frame): render diagonal quadrant blocks

### DIFF
--- a/.changeset/render-diagonal-blocks.md
+++ b/.changeset/render-diagonal-blocks.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Render diagonal quadrant block glyphs as exact terminal cell geometry in screenshots, recordings, and catalog frames.

--- a/packages/drive/src/frame/index.ts
+++ b/packages/drive/src/frame/index.ts
@@ -62,6 +62,17 @@ export const BlockGlyphs: Record<string, GlyphRect> = {
   "╹": { x: CellWidth / 2 - 1, y: 0, width: 2, height: CellHeight / 2, stretch: false },
 }
 
+const diagonalBlockGlyphs: Record<string, ReadonlyArray<Omit<GlyphRect, "stretch">>> = {
+  "▚": [
+    { x: 0, y: 0, width: CellWidth / 2, height: CellHeight / 2 },
+    { x: CellWidth / 2, y: CellHeight / 2, width: CellWidth / 2, height: CellHeight / 2 },
+  ],
+  "▞": [
+    { x: CellWidth / 2, y: 0, width: CellWidth / 2, height: CellHeight / 2 },
+    { x: 0, y: CellHeight / 2, width: CellWidth / 2, height: CellHeight / 2 },
+  ],
+}
+
 /**
  * Draws a block/bar glyph geometrically. Returns false when the character is
  * not a geometric primitive and must be drawn with fonts instead.
@@ -76,11 +87,17 @@ export const drawBlockGlyph = (
   cells = 1,
 ): boolean => {
   const glyph = BlockGlyphs[char]
-  if (glyph === undefined) return false
-  const width = glyph.stretch
-    ? glyph.width + (cells - 1) * CellWidth
-    : glyph.width
-  context.fillRect(x + glyph.x, y + glyph.y, width, glyph.height)
+  if (glyph !== undefined) {
+    const width = glyph.stretch
+      ? glyph.width + (cells - 1) * CellWidth
+      : glyph.width
+    context.fillRect(x + glyph.x, y + glyph.y, width, glyph.height)
+    return true
+  }
+  const quadrants = diagonalBlockGlyphs[char]
+  if (quadrants === undefined) return false
+  for (const quadrant of quadrants)
+    context.fillRect(x + quadrant.x, y + quadrant.y, quadrant.width, quadrant.height)
   return true
 }
 

--- a/packages/drive/test/frame.test.ts
+++ b/packages/drive/test/frame.test.ts
@@ -35,6 +35,22 @@ describe("frame geometry", () => {
     ])
   })
 
+  it("draws diagonal quadrant blocks edge-to-edge", () => {
+    const rects: Array<readonly [number, number, number, number]> = []
+    const context = {
+      fillRect: (x: number, y: number, width: number, height: number) =>
+        void rects.push([x, y, width, height]),
+    }
+    expect(drawBlockGlyph(context, "▚", 0, 0)).toBe(true)
+    expect(drawBlockGlyph(context, "▞", CellWidth, 0)).toBe(true)
+    expect(rects).toEqual([
+      [0, 0, CellWidth / 2, CellHeight / 2],
+      [CellWidth / 2, CellHeight / 2, CellWidth / 2, CellHeight / 2],
+      [CellWidth + CellWidth / 2, 0, CellWidth / 2, CellHeight / 2],
+      [CellWidth, CellHeight / 2, CellWidth / 2, CellHeight / 2],
+    ])
+  })
+
   it("uses distinct attribute bits", () => {
     const bits = Object.values(TextStyle)
     expect(new Set(bits).size).toBe(bits.length)


### PR DESCRIPTION
## What

Render `▚` and `▞` as exact terminal-cell geometry in screenshots, recordings, and catalog frames instead of relying on font glyph metrics.

## Before / After

**Before:** diagonal quadrant blocks went through font rendering, where glyph side bearings made the Snake joints look narrower than full terminal quadrants.

**After:** each glyph is drawn as two exact half-cell rectangles, matching terminal geometry edge to edge.

## How

- `packages/drive/src/frame/index.ts` defines the two quadrant pairs and draws them through the shared renderer-neutral block path.
- `packages/drive/test/frame.test.ts` locks down all rectangle coordinates for both glyphs.
- A patch changeset records the visible rendering correction.

## Scope

This only changes geometric rendering for `▚` and `▞`. Other symbols continue using their existing block geometry or fallback fonts.

## Testing

- `bun run test:effect test/frame.test.ts test/recording/export.test.ts` (17 passed)
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

## Demo

Deterministic Drive capture using the diagonal Snake glyphs:

![activity-head-thinking.png](https://github.com/user-attachments/assets/874998b2-2cc5-436a-984d-5d0d4518374d)

## Flow

```mermaid
flowchart LR
  Glyph[Captured ▚ or ▞] --> Geometry[Shared frame geometry]
  Geometry --> Rectangles[Two half-cell rectangles]
  Rectangles --> Output[PNG, MP4, or catalog canvas]
```