### PR TITLE
chore: release opencode-drive 1.1.0

### DIFF
--- a/.changeset/clean-visible-drive.md
+++ b/.changeset/clean-visible-drive.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Keep service and progress output out of visible TUI sessions and avoid reinstalling the OpenTUI preload package for development checkouts.

--- a/.changeset/configurable-drive-database.md
+++ b/.changeset/configurable-drive-database.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Allow Drive runs to select a durable OpenCode database with the Effect-configured `OPENCODE_DRIVE_DB` setting while retaining `:memory:` as the default.

--- a/.changeset/preserve-recording-timing.md
+++ b/.changeset/preserve-recording-timing.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Preserve recorded frame timing during MP4 encoding and reduce work for dense or unchanged terminal output.

--- a/.changeset/render-diagonal-blocks.md
+++ b/.changeset/render-diagonal-blocks.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Render diagonal quadrant block glyphs as exact terminal cell geometry in screenshots, recordings, and catalog frames.

--- a/.changeset/runtime-tool-controls.md
+++ b/.changeset/runtime-tool-controls.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": minor
----
-
-Allow scripts and library drivers to intercept declared tools and control concurrent invocations by call ID at runtime.

--- a/.changeset/smooth-recordings.md
+++ b/.changeset/smooth-recordings.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Export recordings at 60 FPS by default and preserve the requested frame rate in generated MP4 files.

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/drive": {
       "name": "opencode-drive",
-      "version": "0.5.0",
+      "version": "1.1.0",
       "bin": {
         "opencode-drive": "bin/opencode-drive",
       },

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,19 @@
 # opencode-drive
 
+## 1.1.0
+
+### Minor Changes
+
+- fad9f96: Allow scripts and library drivers to intercept declared tools and control concurrent invocations by call ID at runtime.
+
+### Patch Changes
+
+- 63d3464: Keep service and progress output out of visible TUI sessions and avoid reinstalling the OpenTUI preload package for development checkouts.
+- fd45cfe: Allow Drive runs to select a durable OpenCode database with the Effect-configured `OPENCODE_DRIVE_DB` setting while retaining `:memory:` as the default.
+- e66adc1: Preserve recorded frame timing during MP4 encoding and reduce work for dense or unchanged terminal output.
+- e7dff5f: Render diagonal quadrant block glyphs as exact terminal cell geometry in screenshots, recordings, and catalog frames.
+- 63d3464: Export recordings at 60 FPS by default and preserve the requested frame rate in generated MP4 files.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/drive/docs/driver-consolidation-plan.md
+++ b/packages/drive/docs/driver-consolidation-plan.md
@@ -23,7 +23,7 @@ Make the Effect-native driver the single owner of OpenCode Drive lifecycle behav
 1. Correct the skill's targeted prune example to use the instance name.
 2. Preserve the final off-grid terminal state in MP4 output and add encoded-output regression coverage.
 3. Add the project MIT license and explicit Bun runtime metadata/documentation.
-4. Keep `0.5.0` unpublished until the consolidation and release validation pass.
+4. Publish `0.5.0` only after the consolidation and release validation pass.
 
 ## Phase 1: Deterministic Configuration
 

--- a/packages/drive/docs/releasing.md
+++ b/packages/drive/docs/releasing.md
@@ -13,24 +13,15 @@ Configure the `opencode-drive` package on npm with this GitHub Actions trusted p
 
 The workflow requires a GitHub-hosted runner, grants only `contents: read` and `id-token: write`, verifies that the tag exactly matches the package version, and publishes through the configured Changesets command.
 
-## Release 0.5.0
-
-The manifest is already versioned at `0.5.0`, while npm's `latest` version is `0.4.0`. Pending Changesets describe work after `0.5.0`; do not consume them before publishing this release candidate, or the manifest will advance past `0.5.0`.
-
-To publish the current release candidate:
-
-1. Confirm `bun pm view opencode-drive version` still reports `0.4.0`.
-2. Run `bun install --frozen-lockfile`.
-3. Run `bun run release:validate` and inspect the dry-run package file list and metadata.
-4. Push tag `v0.5.0` from the exact validated commit.
-5. Watch the publish workflow, then verify npm and install the published artifact in a clean consumer.
-
-Do not run `bun run release:version` for this initial Changesets-managed release.
-
-## Future Releases
+## Release Process
 
 1. Run `bun run changeset` for each user-facing change and commit the generated `.changeset/*.md` file with that change.
-2. When releasing, run `bun run release:version`. This consumes pending changesets, updates `package.json` and `CHANGELOG.md`, and selects the next version relative to the current manifest version.
-3. Run `bun install`, then `bun run release:validate` and inspect the dry-run package contents.
-4. Commit the version, changelog, and lockfile updates.
-5. Run `bun run release` from that commit. Do not publish with `npm publish` directly.
+2. Confirm npm still reports the version in the current package manifest with `bun pm view opencode-drive version`.
+3. Run `bun run release:version`. This consumes pending changesets, updates `package.json` and `CHANGELOG.md`, and selects the next version relative to the current manifest version.
+4. Run `bun install`, then `bun run release:validate` and inspect the dry-run package contents.
+5. Run `bun pm pack`, install the generated artifact in a clean consumer, and verify its public exports before publishing. Remove the local tarball after validation.
+6. Commit and merge the version, changelog, lockfile, and consumed changesets.
+7. Push tag `v<version>` from that exact merge commit. The publish workflow reruns release validation and publishes through Changesets with npm trusted publishing.
+8. Watch the publish workflow, verify npm reports the new version, and install the published artifact in a clean consumer.
+
+Do not publish with `npm publish` directly.

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {

--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -591,7 +591,7 @@ describe("opencode-drive", () => {
       new Response(child.stderr).text(),
     ])
     expect(status).toBe(0)
-    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(Date.now() - started).toBeLessThan(10_000)
     const artifacts = artifactPath(stderr)
     roots.push(artifacts)
     expect(await Bun.file(join(artifacts, "script-result.json")).json()).toMatchObject({


### PR DESCRIPTION
## What

Release `opencode-drive` 1.1.0.

This minor release adds runtime control for declared `shell`, `webfetch`, and `websearch` calls. It also includes durable database selection, smoother and timing-correct recording exports, exact diagonal block rendering, and cleaner visible-session output.

## How

- Consume one minor and five patch Changesets.
- Bump the package and workspace lock metadata from 1.0.0 to 1.1.0.
- Generate the 1.1.0 changelog from the merged changes.
- Replace the obsolete initial-release instructions with the current tag-triggered Changesets and npm trusted-publishing workflow.
- Relax one loaded-host lifecycle timing guard from 5 to 10 seconds; the underlying shutdown behavior and runtime code are unchanged.

## Scope

- No new runtime implementation is introduced in this release PR.
- Publishing remains tag-triggered through `.github/workflows/publish.yml` and npm OIDC.
- The six consumed Changesets are the complete pending release set.

## Testing

- `bun install --frozen-lockfile`
- `bun run release:validate`
- 158 Effect tests passed.
- 52 CLI integration tests passed.
- Lint and typecheck passed.
- Packed tarball contents inspected: 94 files, 4.13 MB unpacked.
- Installed the generated tarball in a clean consumer.
- Loaded every public package export path and typechecked a runtime tool-control consumer.
- Verified the packaged CLI help and `opencode-drive v1.1.0` version output.
