### PR TITLE
chore: release opencode-drive 1.2.0

### DIFF
--- a/.changeset/run-scoped-media.md
+++ b/.changeset/run-scoped-media.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": minor
----
-
-Write screenshots and recordings beneath run- and restart-scoped media directories so named outputs cannot overwrite earlier runs.

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/drive": {
       "name": "opencode-drive",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "bin": {
         "opencode-drive": "bin/opencode-drive",
       },

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # opencode-drive
 
+## 1.2.0
+
+### Minor Changes
+
+- 4e0c002: Write screenshots and recordings beneath run- and restart-scoped media directories so named outputs cannot overwrite earlier runs.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive@1.2.0` with run- and restart-generation-scoped media outputs from #36.

## How

- Consume `.changeset/run-scoped-media.md`.
- Bump the package and workspace lockfile from `1.1.0` to `1.2.0`.
- Add the generated changelog entry.

## Testing

- `bun run release:validate`
- 158 Effect tests passed.
- 52 CLI integration tests passed.
- Packed artifact contains 94 expected files.
- Installed `opencode-drive-1.2.0.tgz` in a clean consumer.
- Loaded every public entry point and typechecked runtime controls for `shell`, `webfetch`, and `websearch`.
