### PR TITLE
chore: release opencode-drive 1.3.0

### DIFF
--- a/.changeset/semantic-ui-snapshots.md
+++ b/.changeset/semantic-ui-snapshots.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": minor
----
-
-Expose semantic UI snapshots, exact semantic node polling, and safe semantic-node clicks for compatible OpenCode endpoints.

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/drive": {
       "name": "opencode-drive",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "opencode-drive": "bin/opencode-drive",
       },

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # opencode-drive
 
+## 1.3.0
+
+### Minor Changes
+
+- 7caebeb: Expose semantic UI snapshots, exact semantic node polling, and safe semantic-node clicks for compatible OpenCode endpoints.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive@1.3.0` with semantic UI snapshots, exact semantic-node polling, and safe semantic-node clicks from #40.

## How

- Consume `.changeset/semantic-ui-snapshots.md`.
- Bump the package and workspace lockfile from `1.2.0` to `1.3.0`.
- Add the generated changelog entry.

## Testing

- `bun run release:validate`
- 162 Effect tests passed.
- 53 CLI integration tests passed.
- Lint and typecheck passed.
- Frozen install passed after versioning.
- Packed artifact contains 94 expected files.
- Installed `opencode-drive-1.3.0.tgz` in a clean consumer.
- Loaded all seven public entry points from the packed artifact.
