### PR TITLE
chore: release opencode-drive 1.4.0

### DIFF
--- a/.changeset/provider-tool-lifecycle.md
+++ b/.changeset/provider-tool-lifecycle.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": minor
----
-
-Control arbitrary provider-backed tool lifecycles with dynamic registration, structured progress, success, failure, cancellation, and reconnect-safe replay.

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # opencode-drive
 
+## 1.4.0
+
+### Minor Changes
+
+- c20d147: Control arbitrary provider-backed tool lifecycles with dynamic registration, structured progress, success, failure, cancellation, and reconnect-safe replay.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
**What**

Release `opencode-drive@1.4.0` with provider-neutral runtime control for arbitrary native OpenCode tool lifecycles.

**How**

- Consumes `.changeset/provider-tool-lifecycle.md`.
- Bumps `packages/drive/package.json` from `1.3.0` to `1.4.0`.
- Adds the generated `1.4.0` entry to `packages/drive/CHANGELOG.md`.

**Scope**

- Contains only generated Changesets release metadata for the already-merged PR #42.
- Publishing remains tag-driven through `.github/workflows/publish.yml`; this PR does not publish directly.

**Testing**

- `bun run release:validate`: lint, typecheck, 30 Effect files / 202 tests, and package dry-run passed.
- `bun run test:cli`: 54 CLI integration tests passed.
- Packed `opencode-drive-1.4.0.tgz`: 95 files, 1.61 MB.
- Installed the tarball in a clean consumer and typechecked `Tool.Controls.attach/take` plus all seven public entry points.
- Imported every public entry point and ran `opencode-drive --help` from the clean consumer.
- Confirmed npm `latest` remains `1.3.0` before release.
