### PR TITLE
chore: release opencode-drive 1.4.1

### DIFF
--- a/.changeset/concurrent-start-ownership.md
+++ b/.changeset/concurrent-start-ownership.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Prevent concurrent detached launchers from stealing prepared instance ownership and spawning competing daemon processes.

--- a/.changeset/current-opencode-dev.md
+++ b/.changeset/current-opencode-dev.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Restore compatibility with current OpenCode V2 checkouts and packed Drive installations. Drive now uses V2's built-in simulation transport and provider shape, isolates scripted service ports and command forms, and compiles standalone scripts against the launching Drive toolchain without package installation or source-directory links.

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # opencode-drive
 
+## 1.4.1
+
+### Patch Changes
+
+- 6a8d52b: Prevent concurrent detached launchers from stealing prepared instance ownership and spawning competing daemon processes.
+- d71356f: Restore compatibility with current OpenCode V2 checkouts and packed Drive installations. Drive now uses V2's built-in simulation transport and provider shape, isolates scripted service ports and command forms, and compiles standalone scripts against the launching Drive toolchain without package installation or source-directory links.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive@1.4.1` with the detached-start ownership fix and current OpenCode V2/script-runtime compatibility from #48.

## How

- Bump `opencode-drive` from `1.4.0` to `1.4.1`.
- Consume both pending patch changesets.
- Add both fixes to `packages/drive/CHANGELOG.md`.

## Scope

This PR contains only Changesets-generated release metadata. The implementation was reviewed and merged in #48 and the preceding detached-start ownership change.

## Testing

- `bun run release:validate` (204 Effect/Vitest tests, 57 CLI integration tests, lint, typecheck, package dry-run)
- Packed artifact contains 95 files and reports `opencode-drive@1.4.1`
- Packed artifact installed with Bun's isolated linker in a clean consumer
- Installed `opencode-drive check` and `opencode-drive run` verified public exports, local-helper bundling, and version output
