### PR TITLE
chore: release opencode-drive 1.4.2

### DIFF
--- a/.changeset/clean-box-drawing.md
+++ b/.changeset/clean-box-drawing.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Render light box-drawing borders as continuous geometric primitives.

--- a/.changeset/lazy-recording-fonts.md
+++ b/.changeset/lazy-recording-fonts.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Defer recording font initialization so source-checkout scripts can start without loading a duplicate renderer.

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # opencode-drive
 
+## 1.4.2
+
+### Patch Changes
+
+- b524213: Render light box-drawing borders as continuous geometric primitives.
+- a24a09d: Defer recording font initialization so source-checkout scripts can start without loading a duplicate renderer.
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive` 1.4.2 with the pending patch changes:

- Render light box-drawing borders as continuous geometric primitives.
- Defer recording font initialization for source-checkout scripts.

## How

- Consumes the two pending Changesets.
- Updates `packages/drive/package.json` and `packages/drive/CHANGELOG.md`.

## Testing

- `bun run release:validate`
- 205 library tests passed.
- 58 CLI integration tests passed.
- Packed `opencode-drive-1.4.2.tgz` and installed it in a clean consumer.
- Imported every public package export from the clean consumer.
- Ran the packed CLI and confirmed `opencode-drive v1.4.2`.
