### PR TITLE
chore: release opencode-drive 1.4.3

### DIFF
--- a/.changeset/control-write.md
+++ b/.changeset/control-write.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Restore controlled tools against the current V2 plugin API and add typed runtime control for write calls.

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # opencode-drive
 
+## 1.4.3
+
+### Patch Changes
+
+- 99561ad: Restore controlled tools against the current V2 plugin API and add typed runtime control for write calls.
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive` 1.4.3 with the pending patch change:

- Restore controlled tools against the current V2 plugin API and add typed runtime control for write calls.

## How

- Consumes the pending Changeset.
- Updates `packages/drive/package.json` and `packages/drive/CHANGELOG.md`.

## Testing

- Merge CI passed.
- `bun run release:validate`
- 205 library tests passed.
- 58 CLI integration tests passed.
- Packed `opencode-drive-1.4.3.tgz` and inspected its 95 files.
- Installed the tarball in a clean consumer and imported every public package export.
- Ran the packed CLI and confirmed `opencode-drive v1.4.3`.
