### PR TITLE
chore: release opencode-drive 1.4.4

### DIFF
--- a/.changeset/local-screenshots.md
+++ b/.changeset/local-screenshots.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Render screenshots locally from captured terminal frames instead of requiring OpenCode to own PNG rendering.

--- a/.changeset/strict-command-params.md
+++ b/.changeset/strict-command-params.md
@@ -1,6 +1,0 @@
----
-"opencode-drive": patch
----
-
-Deliver named arrows and modified special keys through terminal escape sequences,
-and reject unsupported UI command parameters instead of silently dropping them.

--- a/.changeset/tidy-apes-drive.md
+++ b/.changeset/tidy-apes-drive.md
@@ -1,5 +1,0 @@
----
-"opencode-drive": patch
----
-
-Support current OpenCode V2 development checkouts and reject checkouts without simulation support.

--- a/packages/drive/CHANGELOG.md
+++ b/packages/drive/CHANGELOG.md
@@ -1,5 +1,14 @@
 # opencode-drive
 
+## 1.4.4
+
+### Patch Changes
+
+- 30cbc47: Render screenshots locally from captured terminal frames instead of requiring OpenCode to own PNG rendering.
+- 3d451b5: Deliver named arrows and modified special keys through terminal escape sequences,
+  and reject unsupported UI command parameters instead of silently dropping them.
+- 72cc762: Support current OpenCode V2 development checkouts and reject checkouts without simulation support.
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode-drive",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Drive real and simulated OpenCode instances",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release `opencode-drive@1.4.4` with the three queued patch changes:

- Render screenshots locally from captured terminal frames.
- Support current OpenCode V2 development checkouts.
- Deliver named arrows and modified special keys correctly while rejecting unsupported UI command parameters.

## How

- Applies the pending Changesets.
- Updates `packages/drive/package.json` and `CHANGELOG.md`.
- Consumes the three release notes now represented in the changelog.

## Testing

- `bun run release:validate`
- 211 Effect/Vitest tests passed.
- 58 CLI integration tests passed.
- Packed 96 files into a 1.61 MB tarball.
- Installed the tarball in a clean consumer.
- Imported every public package export from the installed artifact.
- Ran the installed `opencode-drive --help` binary.
