### PR TITLE
chore(catalog): harden deployment workflow

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -22,6 +22,10 @@ jobs:
   deploy:
     if: github.repository == 'anomalyco/opencode-drive' && github.ref_name == 'main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: catalog-production
+      url: https://dev.opencode.ai/lab/catalog
     steps:
       - uses: actions/checkout@v6
 
@@ -43,3 +47,6 @@ jobs:
         run: bun run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Verify deployment
+        run: curl --fail --retry 5 --retry-all-errors --retry-delay 2 --silent --show-error --output /dev/null https://dev.opencode.ai/lab/catalog

--- a/apps/catalog/AGENTS.md
+++ b/apps/catalog/AGENTS.md
@@ -140,6 +140,25 @@ For UI changes, verify in a real browser at desktop and mobile widths:
 
 For protocol changes, also run the OpenCode simulation tests and the full OpenCode Drive test suite.
 
+## Deployment
+
+The catalog deploys to <https://dev.opencode.ai/lab/catalog> through `.github/workflows/deploy-catalog.yml`. The workflow runs automatically for relevant changes merged to `main` and can be triggered manually from GitHub Actions or with:
+
+```bash
+gh workflow run deploy-catalog.yml --ref main -R anomalyco/opencode-drive
+```
+
+The workflow validates Drive and the catalog before deploying. It requires the repository Actions secret `CLOUDFLARE_API_TOKEN`, scoped to edit Workers and routes in the Anomaly Cloudflare account. `wrangler.jsonc` pins that account; do not remove or replace the account ID with a secret.
+
+After triggering a deployment, wait for the workflow and verify the live route:
+
+```bash
+gh run watch --exit-status -R anomalyco/opencode-drive
+curl --fail --silent --show-error --output /dev/null https://dev.opencode.ai/lab/catalog
+```
+
+Do not deploy from a feature branch. For an exceptional local deployment, run `bun run deploy` from `apps/catalog` only after `bun run check`, and confirm `bunx wrangler whoami` has access to the Anomaly account.
+
 ## Dependencies
 
 The catalog consumes OpenCode Drive as a Bun workspace dependency (`"opencode-drive": "workspace:*"`) and imports only its published entry points (`opencode-drive`, `opencode-drive/driver`, `opencode-drive/client` for protocol schemas, and the browser-safe `opencode-drive/frame` for renderer geometry). Never import package-internal `src/` paths.

--- a/apps/catalog/wrangler.jsonc
+++ b/apps/catalog/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "opencode-lab-catalog",
+  "account_id": "15d29c8639fd3733b1b5486a2acfd968",
   "main": "worker.ts",
   "compatibility_date": "2026-08-12",
   "workers_dev": false,


### PR DESCRIPTION
## What

Makes catalog deployment safer and easier to trigger from GitHub Actions. The workflow continues to deploy relevant changes merged to `main` and supports manual dispatch.

## How

- Pins Wrangler to the Anomaly Cloudflare account so local and CI deployments cannot silently target a personal account.
- Associates deployments with the `catalog-production` GitHub environment and live URL.
- Adds a deployment timeout and post-deploy health check.
- Documents automatic, manual, and exceptional local deployment procedures in `apps/catalog/AGENTS.md`.

## Scope

The repository still needs access to the organization-level `CLOUDFLARE_API_TOKEN` Actions secret. The `catalog-production` environment has already been created.

## Testing

- `bun run check` in `apps/catalog`
- `bunx wrangler deploy --dry-run` in `apps/catalog`
- `git diff --check`
- 37 catalog tests pass

## Flow

```mermaid
sequenceDiagram
  participant GitHub as GitHub Actions
  participant Catalog as Catalog checks
  participant Cloudflare as Cloudflare Workers
  participant Live as dev.opencode.ai
  GitHub->>Catalog: Validate Drive and catalog
  Catalog-->>GitHub: Checks pass
  GitHub->>Cloudflare: Deploy with repository secret
  Cloudflare-->>GitHub: Deployment complete
  GitHub->>Live: Verify HTTP health
```