### PR TITLE
fix: address repository audit findings

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Deploy
         working-directory: apps/catalog
-        run: bun run deploy
+        run: |
+          bun run build
+          bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -42,11 +42,13 @@ jobs:
           bun run --cwd packages/drive test
           bun run --cwd apps/catalog check
 
+      - name: Build
+        working-directory: apps/catalog
+        run: bun run build
+
       - name: Deploy
         working-directory: apps/catalog
-        run: |
-          bun run build
-          bunx wrangler deploy
+        run: bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/apps/catalog/catalog/capture-sets.test.ts
+++ b/apps/catalog/catalog/capture-sets.test.ts
@@ -28,7 +28,17 @@ describe("capture revision sets", () => {
       fresh: false,
       jobs: 3,
       workerOutput: undefined,
+      workerVariantId: undefined,
     })
+  })
+
+  test("accepts the parent-planned worker variant ID", () => {
+    expect(
+      parseCaptureOptions(
+        ["--worker-output", ".tmp/workers", "--worker-variant-id", "abc123-opencode"],
+        "/tmp/opencode",
+      ).workerVariantId,
+    ).toBe("abc123-opencode")
   })
 
   test("defaults to the canonical v2 branch instead of a stale checkout HEAD", () => {

--- a/apps/catalog/catalog/public-path.test.ts
+++ b/apps/catalog/catalog/public-path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { publicFilePath } from "./public-path"
+
+describe("catalog public paths", () => {
+  const root = "/catalog/public"
+
+  test("resolves nested public assets", () => {
+    expect(publicFilePath(root, "/captures/opencode/home.frame.json")).toBe(
+      "/catalog/public/captures/opencode/home.frame.json",
+    )
+  })
+
+  test("rejects encoded traversal and malformed paths", () => {
+    expect(publicFilePath(root, "/%252e%252e%2fpackage.json")).toBeUndefined()
+    expect(publicFilePath(root, "/../package.json")).toBeUndefined()
+    expect(publicFilePath(root, "/%zz")).toBeUndefined()
+  })
+})

--- a/apps/catalog/catalog/public-path.ts
+++ b/apps/catalog/catalog/public-path.ts
@@ -1,0 +1,25 @@
+import { isAbsolute, relative, resolve, sep } from "node:path"
+
+export function publicFilePath(root: string, pathname: string) {
+  const decoded = fullyDecode(pathname)
+  if (decoded === undefined || decoded.includes("\\")) return undefined
+
+  const path = resolve(root, decoded.replace(/^\/+/, ""))
+  const fromRoot = relative(root, path)
+  if (fromRoot === "" || isAbsolute(fromRoot) || fromRoot === ".." || fromRoot.startsWith(`..${sep}`))
+    return undefined
+  return path
+}
+
+function fullyDecode(value: string) {
+  try {
+    for (let index = 0; index < 8; index++) {
+      const decoded = decodeURIComponent(value)
+      if (decoded === value) return decoded
+      value = decoded
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}

--- a/apps/catalog/catalog/worker.test.ts
+++ b/apps/catalog/catalog/worker.test.ts
@@ -22,6 +22,7 @@ describe("catalog worker", () => {
     expect(assetPath("/lab/catalog")).toBe("/index.html")
     expect(assetPath("/lab/catalog/")).toBe("/index.html")
     expect(assetPath("/lab/catalog/deep-link")).toBe("/index.html")
+    expect(assetPath("/lab/catalogue")).toBeUndefined()
   })
 
   test("strips the catalog prefix from assets", () => {

--- a/apps/catalog/scripts/capture-opencode-drive.ts
+++ b/apps/catalog/scripts/capture-opencode-drive.ts
@@ -338,7 +338,7 @@ function isCaptureId(value: string): value is CaptureId {
 
 try {
   const captured =
-    options.workerOutput === undefined && variants.length > 1 && options.jobs > 1
+    options.workerOutput === undefined && options.flow === undefined && variants.length > 1 && options.jobs > 1
       ? await captureVariantProcesses(options, variants)
       : await Effect.runPromise(Effect.forEach(variants, captureVariant, { concurrency: 1 }))
   const expectedIds = captured[0]?.map((capture) => capture.id) ?? []
@@ -424,6 +424,8 @@ async function captureVariantProcesses(
           "1",
           "--worker-output",
           output,
+          "--worker-variant-id",
+          variant.id,
         ]
         const child = Bun.spawn(args, {
           cwd: fileURLToPath(new URL("..", import.meta.url)),
@@ -459,10 +461,6 @@ async function prepareCaptureSets(options: ReturnType<typeof parseCaptureOptions
       const revision = await git(options.opencode, "rev-parse", `${ref}^{commit}`)
       if (revisions.has(revision)) continue
       const committedAt = await git(options.opencode, "show", "-s", "--format=%cI", revision)
-      if (ref === "HEAD") {
-        revisions.set(revision, { ref, committedAt, path: options.opencode })
-        continue
-      }
       const path = fileURLToPath(new URL(`../.tmp/capture-worktrees/${revision}/`, import.meta.url))
       const preparedRevision = await preparedWorktreeRevision(path)
       if (options.fresh || preparedRevision !== revision) {
@@ -483,7 +481,7 @@ async function prepareCaptureSets(options: ReturnType<typeof parseCaptureOptions
     for (const [revision, preparedRevision] of revisions) {
       for (const theme of options.themes) {
         variants.push({
-          id: captureSetId(revision, theme, revisions.size > 1),
+          id: options.workerVariantId ?? captureSetId(revision, theme, revisions.size > 1),
           label: captureSetLabel(revision, theme),
           source: captureSource(options.opencode),
           revision,

--- a/apps/catalog/scripts/capture-sets.ts
+++ b/apps/catalog/scripts/capture-sets.ts
@@ -9,6 +9,7 @@ export interface CaptureOptions {
   readonly fresh: boolean
   readonly jobs: number
   readonly workerOutput: string | undefined
+  readonly workerVariantId: string | undefined
 }
 
 export function parseCaptureOptions(args: ReadonlyArray<string>, defaultOpenCode: string): CaptureOptions {
@@ -19,6 +20,7 @@ export function parseCaptureOptions(args: ReadonlyArray<string>, defaultOpenCode
   let fresh = false
   let jobs = 3
   let workerOutput: string | undefined
+  let workerVariantId: string | undefined
 
   for (let index = 0; index < args.length; index++) {
     const argument = args[index]
@@ -34,6 +36,7 @@ export function parseCaptureOptions(args: ReadonlyArray<string>, defaultOpenCode
     else if (argument === "--flow") flow = value
     else if (argument === "--jobs") jobs = Number(value)
     else if (argument === "--worker-output") workerOutput = resolve(value)
+    else if (argument === "--worker-variant-id") workerVariantId = value
     else throw new Error(`Unknown capture argument: ${argument}`)
   }
 
@@ -47,6 +50,7 @@ export function parseCaptureOptions(args: ReadonlyArray<string>, defaultOpenCode
     fresh,
     jobs,
     workerOutput,
+    workerVariantId,
   }
 }
 

--- a/apps/catalog/scripts/generate-og.ts
+++ b/apps/catalog/scripts/generate-og.ts
@@ -17,6 +17,7 @@ import {
   baselineOffset,
   drawBlockGlyph,
 } from "opencode-drive/frame"
+import type { FrameArtifact } from "../catalog/schema"
 
 const CardWidth = 1200
 const CardHeight = 630
@@ -38,21 +39,7 @@ for (const [file, family] of [
   if (!GlobalFonts.registerFromPath(path, family)) throw new Error(`Failed to register OG font: ${path}`)
 }
 
-interface FrameSpan {
-  readonly text: string
-  readonly fg: readonly [number, number, number, number]
-  readonly bg: readonly [number, number, number, number]
-  readonly attributes: number
-  readonly width: number
-}
-
-interface FrameArtifact {
-  readonly cols: number
-  readonly rows: number
-  readonly lines: ReadonlyArray<{ readonly spans: ReadonlyArray<FrameSpan> }>
-}
-
-function color([red, green, blue, alpha]: FrameSpan["fg"], opacity = 1) {
+function color([red, green, blue, alpha]: FrameArtifact["lines"][number]["spans"][number]["fg"], opacity = 1) {
   return `rgba(${red}, ${green}, ${blue}, ${(alpha / 255) * opacity})`
 }
 

--- a/apps/catalog/server.ts
+++ b/apps/catalog/server.ts
@@ -1,6 +1,8 @@
+import { fileURLToPath } from "node:url"
+import { publicFilePath } from "./catalog/public-path"
 import index from "./src/index.html"
 
-const publicDirectory = new URL("./public/", import.meta.url)
+const publicDirectory = fileURLToPath(new URL("./public/", import.meta.url))
 const port = Number(process.env.PORT ?? "4187")
 
 const contentTypes = new Map([
@@ -20,29 +22,22 @@ const server = Bun.serve({
   },
   async fetch(request) {
     const url = new URL(request.url)
-    const path = normalizePath(url.pathname)
+    const path = publicFilePath(publicDirectory, url.pathname)
     if (!path) return new Response("Not found", { status: 404 })
 
-    const file = Bun.file(new URL(path, publicDirectory))
+    const file = Bun.file(path)
     if (!(await file.exists())) return new Response("Not found", { status: 404 })
 
     return new Response(file, {
       headers: {
         "cache-control": "no-store",
-        "content-type": contentType(path),
+        "content-type": contentType(url.pathname),
       },
     })
   },
 })
 
 console.log(`OpenCode terminal catalog: http://localhost:${server.port}`)
-
-function normalizePath(pathname: string) {
-  const decoded = decodeURIComponent(pathname)
-  const path = decoded.replace(/^\/+/, "")
-  if (path === "" || path.includes("..") || path.includes("\\")) return undefined
-  return path
-}
 
 function contentType(path: string) {
   const dot = path.lastIndexOf(".")

--- a/apps/catalog/src/components/TerminalFrame.tsx
+++ b/apps/catalog/src/components/TerminalFrame.tsx
@@ -85,10 +85,15 @@ export function TerminalFrame({ frame, label, lazy = false }: TerminalFrameProps
 function loadFrame(src: string) {
   const existing = cache.get(src)
   if (existing) return existing
-  const pending = fetch(`${catalogBasePath()}${src}`).then(async (response) => {
-    if (!response.ok) throw new Error(`Failed to load terminal frame: ${response.status}`)
-    return response.json() as Promise<FrameArtifact>
-  })
+  const pending = fetch(`${catalogBasePath()}${src}`)
+    .then(async (response) => {
+      if (!response.ok) throw new Error(`Failed to load terminal frame: ${response.status}`)
+      return response.json() as Promise<FrameArtifact>
+    })
+    .catch((cause) => {
+      if (cache.get(src) === pending) cache.delete(src)
+      throw cause
+    })
   cache.set(src, pending)
   return pending
 }

--- a/apps/catalog/worker.ts
+++ b/apps/catalog/worker.ts
@@ -18,6 +18,7 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
     const path = assetPath(url.pathname)
+    if (path === undefined) return new Response("Not found", { status: 404 })
     const assetUrl = new URL(url)
     assetUrl.pathname = path
     const catalog = path === "/index.html"
@@ -45,7 +46,9 @@ export default {
 }
 
 export function assetPath(pathname: string) {
-  const path = pathname.slice("/lab/catalog".length)
+  const prefix = "/lab/catalog"
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) return undefined
+  const path = pathname.slice(prefix.length)
   return path === "" || path === "/" || !path.includes(".") ? "/index.html" : path
 }
 

--- a/apps/catalog/wrangler.jsonc
+++ b/apps/catalog/wrangler.jsonc
@@ -13,7 +13,11 @@
   },
   "routes": [
     {
-      "pattern": "dev.opencode.ai/lab/catalog*",
+      "pattern": "dev.opencode.ai/lab/catalog",
+      "zone_name": "opencode.ai",
+    },
+    {
+      "pattern": "dev.opencode.ai/lab/catalog/*",
       "zone_name": "opencode.ai",
     },
   ],

--- a/packages/drive/src/instance/control.ts
+++ b/packages/drive/src/instance/control.ts
@@ -1,5 +1,5 @@
 import { rm } from "node:fs/promises"
-import { connect, createServer } from "node:net"
+import { connect, createServer, type Socket } from "node:net"
 import type {
   ResponseConfiguration,
   ResponseUpdate,
@@ -20,7 +20,12 @@ export async function listenControl(
     ) => Promise<ResponseConfiguration>
   },
 ) {
+  const idleSockets = new Set<Socket>()
   const server = createServer((socket) => {
+    idleSockets.add(socket)
+    socket.on("close", () => idleSockets.delete(socket))
+    socket.on("error", () => idleSockets.delete(socket))
+    socket.setTimeout(30_000, () => socket.destroy())
     let buffer = ""
     socket.setEncoding("utf8")
     socket.on("data", (data) => {
@@ -31,6 +36,7 @@ export async function listenControl(
         return
       }
       if (!buffer.includes("\n")) return
+      idleSockets.delete(socket)
       socket.removeAllListeners("data")
       const progress = (percent: number) => socket.write(`progress ${percent}\n`)
       void handle(buffer.slice(0, buffer.indexOf("\n")), progress).then(
@@ -55,6 +61,7 @@ export async function listenControl(
   }
   await listen(server, path)
   return async () => {
+    for (const socket of idleSockets) socket.destroy()
     await new Promise<void>((resolve) => server.close(() => resolve()))
     await rm(path, { force: true })
   }

--- a/packages/drive/src/instance/service.ts
+++ b/packages/drive/src/instance/service.ts
@@ -58,6 +58,8 @@ function isServiceInfo(value: unknown): value is { readonly pid: number } {
     typeof value === "object" &&
     value !== null &&
     "pid" in value &&
-    typeof value.pid === "number"
+    typeof value.pid === "number" &&
+    Number.isSafeInteger(value.pid) &&
+    value.pid > 1
   )
 }

--- a/packages/drive/test/instance/control.test.ts
+++ b/packages/drive/test/instance/control.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { connect } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { listenControl } from "../../src/instance/control.js"
+
+const roots: Array<string> = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("instance control", () => {
+  it("closes while an idle client is connected", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-drive-control-"))
+    roots.push(root)
+    const path = join(root, "control.sock")
+    const close = await listenControl(path, {
+      restart: async () => undefined,
+      stop: async () => ({ screenshots: [] }),
+      responses: async () => ({ types: [], tools: [] }),
+    })
+    const socket = connect(path)
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve)
+      socket.once("error", reject)
+    })
+
+    await expect(close()).resolves.toBeUndefined()
+    expect(socket.destroyed).toBe(true)
+  })
+})

--- a/packages/drive/test/instance/service.test.ts
+++ b/packages/drive/test/instance/service.test.ts
@@ -1,0 +1,28 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import * as Effect from "effect/Effect"
+import { stopService } from "../../src/instance/service.js"
+
+const roots: Array<string> = []
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("stopService", () => {
+  it("ignores unsafe process identifiers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-drive-service-"))
+    roots.push(root)
+    const state = join(root, "state")
+    await mkdir(join(state, "opencode"), { recursive: true })
+    await Bun.write(join(state, "opencode", "service.json"), JSON.stringify({ pid: -1 }))
+    const kill = vi.spyOn(process, "kill")
+
+    await Effect.runPromise(stopService(state))
+
+    expect(kill).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Fixes concrete correctness, security, deployment, and capture issues found by a repository-wide review of Drive and the catalog.

## Before / After

**Before:** malformed service state could pass a negative PID to `process.kill`, an idle control client could block shutdown, the catalog dev server could read files outside `public/` through double-encoded traversal, sibling `/lab/catalogue` URLs were claimed by the Worker, parallel capture workers lost revision-qualified IDs, flow previews printed deleted paths, and the Cloudflare token was present while build scripts ran.

**After:** process IDs are constrained to safe positive integers, idle sockets are closed without interrupting active stop requests, public file resolution is root-confined, Worker routes are exact, capture workers preserve planned IDs and sequential preview semantics, `HEAD` captures use detached commits, failed frame fetches can retry, and only the Wrangler step receives the deployment token.

## How

- `packages/drive`: validates service PIDs and tracks idle control sockets, with regression tests.
- `apps/catalog`: adds path-safe public asset resolution, exact Worker routing, retryable frame caching, deterministic parallel capture IDs, durable flow preview behavior, and committed-only `HEAD` capture preparation.
- `.github/workflows`: separates build and deploy credential scopes while retaining post-deploy verification.
- OG generation consumes the canonical persisted frame type and CI avoids duplicate catalog generation.

## Scope

Larger architectural findings such as artifact leases, atomic visible-instance registration, transactional capture publication, and renderer consolidation are intentionally excluded from this focused fix set.

## Testing

- `bun run check`
- `bun run test`
- `bun run build && bunx wrangler deploy --dry-run` in `apps/catalog`
- `gitleaks protect --redact --no-banner`
- 220 Effect/Vitest tests, 58 CLI integration tests, and 40 catalog tests pass

## Flow

```mermaid
sequenceDiagram
  participant GitHub as GitHub Actions
  participant Build as Catalog build
  participant Wrangler as Wrangler deploy
  participant Cloudflare as Cloudflare
  GitHub->>Build: Build without deployment secret
  Build-->>GitHub: Production assets
  GitHub->>Wrangler: Inject dedicated token
  Wrangler->>Cloudflare: Deploy exact catalog routes
  GitHub->>Cloudflare: Verify live catalog
```