### PR TITLE
fix(drive): update Effect and OpenCode V2 compatibility

### DIFF
--- a/.changeset/current-v2.md
+++ b/.changeset/current-v2.md
@@ -1,0 +1,20 @@
+---
+"opencode-drive": major
+---
+
+Update Drive to the current OpenCode V2 client (`0.0.0-dev-18516`) and its
+matching Effect V4 stack (`4.0.0-rc.111`). Effect is now an exact peer dependency
+so consumer programs and Drive share the same Effect types and runtime.
+Effect `rc.112` is available, but the current V2 client, protocol, and schema
+packages still require `rc.111`.
+
+Migrate schema-backed errors and RPC JSON codecs, and preserve optional CLI
+boolean flags with explicit false defaults. Static tool adapters now emit
+native V2 progress metadata, result metadata, and `Tool.Error` failures.
+
+Dynamic tool controls follow the current V2 protocol: change
+`invocation.progress({ structured: { phase: "searching" } })` to
+`invocation.progress({ phase: "searching" })`, and read the model call ID from
+`invocation.context.id` instead of `invocation.context.callID`.
+`finish({ structured, content })` and LLM queue/send/serve/title sequencing,
+cancellation, reconnection, supervision, and settlement retain their contracts.

--- a/apps/catalog/catalog/schema.ts
+++ b/apps/catalog/catalog/schema.ts
@@ -138,11 +138,11 @@ export const CatalogIssue = Schema.Struct({
 
 export interface CatalogIssue extends Schema.Schema.Type<typeof CatalogIssue> {}
 
-export class CatalogBuildError extends Schema.TaggedErrorClass<CatalogBuildError>()("CatalogBuildError", {
+export class CatalogBuildError extends Schema.TaggedError<CatalogBuildError>()("CatalogBuildError", {
   issues: Schema.NonEmptyArray(CatalogIssue),
 }) {}
 
-export class CatalogBoundaryError extends Schema.TaggedErrorClass<CatalogBoundaryError>()("CatalogBoundaryError", {
+export class CatalogBoundaryError extends Schema.TaggedError<CatalogBoundaryError>()("CatalogBoundaryError", {
   boundary: Schema.NonEmptyString,
   cause: Schema.Defect(),
 }) {}

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -32,7 +32,7 @@
     "@types/bun": "^1.3.14",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "effect": "4.0.0-beta.101",
+    "effect": "4.0.0-rc.111",
     "opencode-drive": "workspace:*",
     "oxlint": "1.60.0",
     "typescript": "^7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@types/bun": "^1.3.14",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-rc.111",
         "opencode-drive": "workspace:*",
         "oxlint": "1.60.0",
         "typescript": "^7.0.2",
@@ -32,31 +32,37 @@
     },
     "packages/drive": {
       "name": "opencode-drive",
-      "version": "1.4.3",
+      "version": "1.4.5",
       "bin": {
         "opencode-drive": "bin/opencode-drive",
       },
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.101",
-        "@effect/platform-node-shared": "4.0.0-beta.101",
+        "@effect/platform-node": "4.0.0-rc.111",
+        "@effect/platform-node-shared": "4.0.0-rc.111",
         "@napi-rs/canvas": "1.0.2",
-        "@opencode-ai/client": "0.0.0-next-17010",
+        "@opencode-ai/client": "0.0.0-dev-18516",
         "@opentui/core": "0.4.5",
         "@types/bun": "1.3.13",
         "@typescript/native-preview": "7.0.0-dev.20251207.1",
         "@wterm/core": "0.3.0",
         "@wterm/ghostty": "0.3.0",
-        "effect": "4.0.0-beta.101",
       },
       "devDependencies": {
-        "@effect/vitest": "4.0.0-beta.101",
+        "@effect/vitest": "4.0.0-rc.111",
         "@tsconfig/bun": "1.0.9",
+        "effect": "4.0.0-rc.111",
         "oxlint": "1.60.0",
         "oxlint-tsgolint": "0.21.0",
         "typescript": "5.8.2",
         "vitest": "4.1.10",
       },
+      "peerDependencies": {
+        "effect": "4.0.0-rc.111",
+      },
     },
+  },
+  "overrides": {
+    "@effect/platform-node-shared": "4.0.0-rc.111",
   },
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
@@ -111,11 +117,11 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.101", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.101", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.101", "ioredis": "^5.7.0" } }, "sha512-pClk7dmMtHgM6Byu7CzGfrPvZ1/4BwmrRlCg2Op+iJozMkwVUxq8v4beK8b9SvxsliJjHZFznjvkVLX7LQjBqw=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-rc.111", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.111", "mime": "^4.1.0", "undici": "^8.10.0" }, "peerDependencies": { "effect": "^4.0.0-rc.111", "redis": ">=5.0.0 <7.0.0" } }, "sha512-oy1i7HsOGg/5r+DuBe5+ddmnUhnXmyZFPFPXZCBdO/RQpHK3PIFe1/2UMGxZE+ngDymrSksuQTSgQLF6P+MLqw=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.101", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.101" } }, "sha512-g4L7XiyJSNJLJVhlslyg2zBCQsoKQf1y1gd+Yfd+3wD9ymC+m7ymbd/5FGqnT1aXV6E2AwRr4D/R1eyRUikvWQ=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.101", "", { "peerDependencies": { "effect": "^4.0.0-beta.101", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-F5Ur8pZYti0xkZFyb4hPZt8RrKQ1XBoC28ZkKxc7N1iPbhE9fWOvlWA1NC2XlN2wWG08yb5g5jR53LdOxjlhpQ=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-rc.111", "", { "peerDependencies": { "effect": "^4.0.0-rc.111", "vitest": ">=4.1.0 <5.0.0" } }, "sha512-YDaEVT+grREBVMzykRNFtJwGxy02achzT0WXZYwMJA4ukzuB9krkgQ5roc3N6zhC3NQq/j4IyM32/Pcov7AhHw=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -235,8 +241,6 @@
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
-    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
-
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -291,11 +295,11 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-next-17010", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-next-17010", "@opencode-ai/schema": "0.0.0-next-17010" }, "peerDependencies": { "effect": "4.0.0-beta.101" }, "optionalPeers": ["effect"] }, "sha512-NrmgWgWyf86J+WS9C1XYHyv7pg3Dc73+0tCEeft+UNEV5j4oeEycaWyQ9bi9qKBeSwe9UrMgA7pN9ogkyA3iRQ=="],
+    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-dev-18516", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-dev-18516", "@opencode-ai/schema": "0.0.0-dev-18516" }, "peerDependencies": { "effect": "4.0.0-rc.111", "solid-js": ">=1.9.0" }, "optionalPeers": ["effect", "solid-js"] }, "sha512-Mirtx/MIk0IxppfYGNhjwiDxMkH6tRKbaC2zS2m5nfA1trm2UPAq/MmFCgaKjZjAg/oiG2TEhvjT8HlVYz+D3Q=="],
 
-    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-next-17010", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-17010", "effect": "4.0.0-beta.101" } }, "sha512-Tg0hKjO3xi0IWNb5nECzqanfuOCx/bEls9gbJ1fw1JdIHGYY4Ug6kMpr+6pTrte+Mo/8yOOOrrpDek1VHPl4Nw=="],
+    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-dev-18516", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-dev-18516", "effect": "4.0.0-rc.111" } }, "sha512-IhjPwVDt0aGJb3aN63riUUte0B5ScrBhwmajeBM/L3CU8YUgndIZv+XWxCZhCp0KOj3zKWdyrSMd/nlwAeyO2A=="],
 
-    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-next-17010", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101" } }, "sha512-K0ZDy1o2NgyBTHsE6JjGuZdRMcvb8tgJstBwh5xh0gawohcKPT7mYo1XNe7p2okPCVBQMduG41Dq5rV46ZdHJw=="],
+    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-dev-18516", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111" } }, "sha512-WbNo0D6u6NG4En9zKdDfJLtP5DutgWDH3K7sckn3OtHElHLGNbaQ/dV/8qPQNDhrbac2uxfJDGtoND0ku7f0zA=="],
 
     "@opencode-drive/catalog": ["@opencode-drive/catalog@workspace:apps/catalog"],
 
@@ -374,6 +378,16 @@
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@redis/bloom": ["@redis/bloom@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag=="],
+
+    "@redis/client": ["@redis/client@6.2.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q=="],
+
+    "@redis/json": ["@redis/json@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ=="],
+
+    "@redis/search": ["@redis/search@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ=="],
+
+    "@redis/time-series": ["@redis/time-series@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
@@ -531,7 +545,7 @@
 
     "chardet": ["chardet@2.2.0", "", {}, "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="],
 
-    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -541,10 +555,6 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
-
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -553,7 +563,7 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "effect": ["effect@4.0.0-beta.101", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA=="],
+    "effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -583,8 +593,6 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
@@ -605,10 +613,6 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
-
-    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
-
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -626,8 +630,6 @@
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
-
-    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -671,13 +673,9 @@
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
-
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
@@ -737,9 +735,7 @@
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
-    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
-
-    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+    "redis": ["redis@6.2.1", "", { "dependencies": { "@redis/bloom": "6.2.1", "@redis/client": "6.2.1", "@redis/json": "6.2.1", "@redis/search": "6.2.1", "@redis/time-series": "6.2.1" } }, "sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
@@ -775,8 +771,6 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
-    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
-
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -799,21 +793,17 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
@@ -829,7 +819,7 @@
 
     "wrangler": ["wrangler@4.110.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260708.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260708.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg=="],
 
-    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0"
+  },
+  "overrides": {
+    "@effect/platform-node-shared": "4.0.0-rc.111"
   }
 }

--- a/packages/drive/README.md
+++ b/packages/drive/README.md
@@ -9,6 +9,11 @@ This project gives your agents control over OpenCode:
 
 OpenCode Drive requires [Bun](https://bun.sh/) 1.3.14 or newer. MP4 recording export also requires `ffmpeg` on `PATH`.
 
+Effect programs must use `effect@4.0.0-rc.111`, Drive's exact peer dependency.
+The platform and test packages use the same release as the current V2 client,
+`@opencode-ai/client@0.0.0-dev-18516`. Effect's `latest` tag still selects V3;
+`rc.112` is newer but does not satisfy this client's exact Effect requirement.
+
 Install dependencies with:
 
 ```sh
@@ -345,8 +350,8 @@ export default OpenCodeDriver.use(({ tools, llm, ui }) =>
 
     const lookup = yield* tools.take("call_lookup")
     yield* lookup.progress({
-      structured: { phase: "searching" },
-      content: [{ type: "text", text: "Searching" }],
+      phase: "searching",
+      output: "Searching",
     })
     yield* lookup.finish({
       structured: { answer: 42 },
@@ -361,6 +366,11 @@ rerunning a claimed call. `awaitCancelled()` completes when OpenCode interrupts
 the native invocation before `finish` or `fail`. Dynamic registrations survive
 the tool-only controller reconnecting; an intentional server generation change
 cancels unresolved calls and reapplies the desired set after launch.
+
+Dynamic tool progress follows the current V2 protocol: pass a JSON metadata
+record directly, not a `{ structured, content }` wrapper. The model call ID is
+`lookup.context.id`; `lookup.id` remains the producer invocation ID. Terminal
+`finish({ structured, content })` is unchanged.
 
 Declare which built-in tools Drive should intercept with `tools`, then control
 their invocations inside `run`. Each tool controller accepts calls in arrival

--- a/packages/drive/docs/open-code-driver-api.md
+++ b/packages/drive/docs/open-code-driver-api.md
@@ -274,8 +274,8 @@ yield* tools.attach({
 
 const invocation = yield* tools.take("call_lookup")
 yield* invocation.progress({
-  structured: { phase: "searching" },
-  content: [{ type: "text", text: "Searching" }],
+  phase: "searching",
+  output: "Searching",
 })
 yield* invocation.finish({
   structured: { answer: 42 },
@@ -283,7 +283,7 @@ yield* invocation.finish({
 })
 ```
 
-`take(callID)` matches `context.callID`, the model call ID supplied to
+`take(callID)` matches `context.id`, the model call ID supplied to
 `Llm.toolCall`; `invocation.id` is the producer's transport identity. Drive
 deduplicates invocation replay after a controller reconnect and retries
 progress or terminal operations with the same producer identity and progress

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -58,20 +58,23 @@
     "release:validate": "bun run check && bun run test && bun pm pack --dry-run"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.101",
-    "@effect/platform-node-shared": "4.0.0-beta.101",
+    "@effect/platform-node": "4.0.0-rc.111",
+    "@effect/platform-node-shared": "4.0.0-rc.111",
     "@napi-rs/canvas": "1.0.2",
-    "@opencode-ai/client": "0.0.0-next-17010",
+    "@opencode-ai/client": "0.0.0-dev-18516",
     "@opentui/core": "0.4.5",
     "@types/bun": "1.3.13",
     "@typescript/native-preview": "7.0.0-dev.20251207.1",
     "@wterm/core": "0.3.0",
-    "@wterm/ghostty": "0.3.0",
-    "effect": "4.0.0-beta.101"
+    "@wterm/ghostty": "0.3.0"
+  },
+  "peerDependencies": {
+    "effect": "4.0.0-rc.111"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.101",
+    "@effect/vitest": "4.0.0-rc.111",
     "@tsconfig/bun": "1.0.9",
+    "effect": "4.0.0-rc.111",
     "oxlint": "1.60.0",
     "oxlint-tsgolint": "0.21.0",
     "typescript": "5.8.2",

--- a/packages/drive/src/cli/index.ts
+++ b/packages/drive/src/cli/index.ts
@@ -106,6 +106,7 @@ const startCommand = Command.make(
   {
     name: startName,
     daemon: Flag.boolean("daemon").pipe(
+      Flag.withDefault(false),
       Flag.withHidden,
       Flag.withDescription("Run as detached instance owner"),
     ),
@@ -113,11 +114,16 @@ const startCommand = Command.make(
       Flag.optional,
       Flag.withDescription("JavaScript or TypeScript automation module"),
     ),
-    visible: Flag.boolean("visible").pipe(Flag.withDescription("Show OpenCode in the terminal")),
+    visible: Flag.boolean("visible").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Show OpenCode in the terminal"),
+    ),
     record: Flag.boolean("record").pipe(
+      Flag.withDefault(false),
       Flag.withDescription("Record the complete headless session and export it on stop"),
     ),
     keypressOverlay: Flag.boolean("keypress-overlay").pipe(
+      Flag.withDefault(false),
       Flag.withDescription("Show recent key presses in screenshots and recordings"),
     ),
     dev: Flag.string("dev").pipe(
@@ -185,6 +191,7 @@ const pruneCommand = Command.make(
   {
     name: pruneName,
     force: Flag.boolean("force").pipe(
+      Flag.withDefault(false),
       Flag.withDescription("Delete all matching artifact directories, including active ones"),
     ),
   },

--- a/packages/drive/src/driver/error.ts
+++ b/packages/drive/src/driver/error.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema"
 
-export class OpenCodeDriverError extends Schema.TaggedErrorClass<OpenCodeDriverError>()(
+export class OpenCodeDriverError extends Schema.TaggedError<OpenCodeDriverError>()(
   "OpenCodeDriverError",
   {
     operation: Schema.String,

--- a/packages/drive/src/driver/llm-errors.ts
+++ b/packages/drive/src/driver/llm-errors.ts
@@ -3,7 +3,7 @@ import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
 
 /** Rejection of an LLM control call made in an incompatible response mode. */
-export class LlmModeError extends Schema.TaggedErrorClass<LlmModeError>()(
+export class LlmModeError extends Schema.TaggedError<LlmModeError>()(
   "LlmModeError",
   {
     operation: Schema.Literals(["queue", "send", "serve", "title"]),
@@ -12,7 +12,7 @@ export class LlmModeError extends Schema.TaggedErrorClass<LlmModeError>()(
 ) {}
 
 /** Failure of an LLM controller operation or its backend connection. */
-export class LlmControllerError extends Schema.TaggedErrorClass<LlmControllerError>()(
+export class LlmControllerError extends Schema.TaggedError<LlmControllerError>()(
   "LlmControllerError",
   {
     operation: Schema.String,
@@ -22,7 +22,7 @@ export class LlmControllerError extends Schema.TaggedErrorClass<LlmControllerErr
 ) {}
 
 /** Settlement ended with unused responses or unexpected requests. */
-export class LlmSettlementError extends Schema.TaggedErrorClass<LlmSettlementError>()(
+export class LlmSettlementError extends Schema.TaggedError<LlmSettlementError>()(
   "LlmSettlementError",
   {
     unusedResponses: Schema.Number,

--- a/packages/drive/src/driver/llm-responder.ts
+++ b/packages/drive/src/driver/llm-responder.ts
@@ -33,7 +33,7 @@ export interface Responder {
   ) => Effect.Effect<void, LlmControllerError>
 }
 
-class InvocationTerminated extends Schema.TaggedErrorClass<InvocationTerminated>()(
+class InvocationTerminated extends Schema.TaggedError<InvocationTerminated>()(
   "InvocationTerminated",
   {},
 ) {}

--- a/packages/drive/src/driver/ui.ts
+++ b/packages/drive/src/driver/ui.ts
@@ -46,7 +46,7 @@ export type EffectPredicate<E> = (
  * A UI RPC did not answer within the request timeout: the control plane is
  * unresponsive. Script runs treat this as fatal.
  */
-export class UiTimeoutError extends Schema.TaggedErrorClass<UiTimeoutError>()(
+export class UiTimeoutError extends Schema.TaggedError<UiTimeoutError>()(
   "UiTimeoutError",
   {
     operation: Schema.String,
@@ -61,7 +61,7 @@ export class UiTimeoutError extends Schema.TaggedErrorClass<UiTimeoutError>()(
  * UI matching. The control plane stayed responsive; scripts may catch this to
  * branch on "did X appear in time?".
  */
-export class UiWaitTimeoutError extends Schema.TaggedErrorClass<UiWaitTimeoutError>()(
+export class UiWaitTimeoutError extends Schema.TaggedError<UiWaitTimeoutError>()(
   "UiWaitTimeoutError",
   {
     operation: Schema.String,
@@ -71,7 +71,7 @@ export class UiWaitTimeoutError extends Schema.TaggedErrorClass<UiWaitTimeoutErr
   },
 ) {}
 
-export class UiElementAmbiguousError extends Schema.TaggedErrorClass<UiElementAmbiguousError>()(
+export class UiElementAmbiguousError extends Schema.TaggedError<UiElementAmbiguousError>()(
   "UiElementAmbiguousError",
   {
     count: Schema.Number,
@@ -82,7 +82,7 @@ export class UiElementAmbiguousError extends Schema.TaggedErrorClass<UiElementAm
   }
 }
 
-export class UiNodeAmbiguousError extends Schema.TaggedErrorClass<UiNodeAmbiguousError>()(
+export class UiNodeAmbiguousError extends Schema.TaggedError<UiNodeAmbiguousError>()(
   "UiNodeAmbiguousError",
   {
     count: Schema.Number,
@@ -93,7 +93,7 @@ export class UiNodeAmbiguousError extends Schema.TaggedErrorClass<UiNodeAmbiguou
   }
 }
 
-export class UiCapabilityError extends Schema.TaggedErrorClass<UiCapabilityError>()(
+export class UiCapabilityError extends Schema.TaggedError<UiCapabilityError>()(
   "UiCapabilityError",
   {
     capability: Schema.Literals(["ui.snapshot", "ui.click.semantic"]),
@@ -101,7 +101,7 @@ export class UiCapabilityError extends Schema.TaggedErrorClass<UiCapabilityError
   },
 ) {}
 
-export class UiWaitOptionsError extends Schema.TaggedErrorClass<UiWaitOptionsError>()(
+export class UiWaitOptionsError extends Schema.TaggedError<UiWaitOptionsError>()(
   "UiWaitOptionsError",
   {
     field: Schema.Literals(["timeout", "interval"]),
@@ -110,7 +110,7 @@ export class UiWaitOptionsError extends Schema.TaggedErrorClass<UiWaitOptionsErr
   },
 ) {}
 
-export class UiPredicateError extends Schema.TaggedErrorClass<UiPredicateError>()(
+export class UiPredicateError extends Schema.TaggedError<UiPredicateError>()(
   "UiPredicateError",
   {
     cause: Schema.Defect(),
@@ -118,7 +118,7 @@ export class UiPredicateError extends Schema.TaggedErrorClass<UiPredicateError>(
   },
 ) {}
 
-export class UiScreenshotError extends Schema.TaggedErrorClass<UiScreenshotError>()(
+export class UiScreenshotError extends Schema.TaggedError<UiScreenshotError>()(
   "UiScreenshotError",
   {
     cause: Schema.Defect(),

--- a/packages/drive/src/instance/error.ts
+++ b/packages/drive/src/instance/error.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema"
 
-export class OpenCodeInstanceError extends Schema.TaggedErrorClass<OpenCodeInstanceError>()(
+export class OpenCodeInstanceError extends Schema.TaggedError<OpenCodeInstanceError>()(
   "OpenCodeInstanceError",
   {
     operation: Schema.String,

--- a/packages/drive/src/instance/process.ts
+++ b/packages/drive/src/instance/process.ts
@@ -10,7 +10,7 @@ import * as Schema from "effect/Schema"
 import * as Stream from "effect/Stream"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
-export class ProcessError extends Schema.TaggedErrorClass<ProcessError>()(
+export class ProcessError extends Schema.TaggedError<ProcessError>()(
   "ProcessError",
   {
     operation: Schema.String,

--- a/packages/drive/src/project.ts
+++ b/packages/drive/src/project.ts
@@ -17,7 +17,7 @@ export interface OpenCodeConfig extends JsonObject {}
 /** OpenCode's semantic TUI configuration, written to tui.jsonc. */
 export interface OpenCodeTuiConfig extends JsonObject {}
 
-export class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
+export class FileSystemError extends Schema.TaggedError<FileSystemError>()(
   "FileSystemError",
   {
     path: Schema.String,

--- a/packages/drive/src/simulation/connector.ts
+++ b/packages/drive/src/simulation/connector.ts
@@ -17,7 +17,7 @@ import {
 } from "./protocol.js"
 import { BackendRpcs, SimulationRequestError, UiRpcs } from "./rpc.js"
 
-export class SimulationConnectionError extends Schema.TaggedErrorClass<SimulationConnectionError>()(
+export class SimulationConnectionError extends Schema.TaggedError<SimulationConnectionError>()(
   "SimulationConnectionError",
   {
     endpoint: Schema.String,
@@ -26,7 +26,7 @@ export class SimulationConnectionError extends Schema.TaggedErrorClass<Simulatio
   },
 ) {}
 
-export class SimulationCompatibilityError extends Schema.TaggedErrorClass<SimulationCompatibilityError>()(
+export class SimulationCompatibilityError extends Schema.TaggedError<SimulationCompatibilityError>()(
   "SimulationCompatibilityError",
   {
     endpoint: Schema.String,
@@ -35,7 +35,7 @@ export class SimulationCompatibilityError extends Schema.TaggedErrorClass<Simula
   },
 ) {}
 
-export class SimulationEventStreamError extends Schema.TaggedErrorClass<SimulationEventStreamError>()(
+export class SimulationEventStreamError extends Schema.TaggedError<SimulationEventStreamError>()(
   "SimulationEventStreamError",
   {
     endpoint: Schema.String,

--- a/packages/drive/src/simulation/opencode-protocol.ts
+++ b/packages/drive/src/simulation/opencode-protocol.ts
@@ -273,6 +273,7 @@ export const make = Effect.fn("OpenCodeRpcProtocol.make")(function* (
         send,
         supportsAck: false,
         supportsTransferables: false,
+        codecFor: Schema.toCodecJson,
       }
     }),
   )

--- a/packages/drive/src/simulation/protocol.ts
+++ b/packages/drive/src/simulation/protocol.ts
@@ -23,13 +23,24 @@ export namespace JsonRpc {
     data: Schema.optional(Schema.Json),
   })
 
-  export const Response = Schema.Struct({
-    jsonrpc: Schema.Literal("2.0"),
-    id: JsonRpcID,
-    result: Schema.optional(Schema.Json),
-    error: Schema.optional(ErrorObject),
-  })
-  export interface Response extends Schema.Schema.Type<typeof Response> {}
+  export const Response = Schema.Union(
+    [
+      Schema.Struct({
+        jsonrpc: Schema.Literal("2.0"),
+        id: JsonRpcID,
+        result: Schema.Json,
+        error: Schema.optionalKey(Schema.Never),
+      }),
+      Schema.Struct({
+        jsonrpc: Schema.Literal("2.0"),
+        id: JsonRpcID,
+        result: Schema.optionalKey(Schema.Never),
+        error: ErrorObject,
+      }),
+    ],
+    { mode: "oneOf" },
+  )
+  export type Response = Schema.Schema.Type<typeof Response>
 
   export const decodeRequest = Schema.decodeUnknownSync(Request)
 
@@ -84,7 +95,7 @@ export namespace Handshake {
     protocolVersion: ProtocolVersion,
     role: EndpointRole,
     server: Identity,
-    capabilities: Schema.Array(Capability),
+    capabilities: Schema.Array(Capability).check(Schema.isUnique()),
   })
   export interface Response extends Schema.Schema.Type<typeof Response> {}
 
@@ -475,10 +486,7 @@ export namespace Backend {
       : `${registration.options.namespace.replaceAll(".", "_")}_${registration.name}`
   }
 
-  export const ToolProgress = Schema.Struct({
-    structured: Schema.Record(Schema.String, Schema.Json),
-    content: Schema.optionalKey(Schema.Array(ToolContent)),
-  })
+  export const ToolProgress = Schema.Record(Schema.String, Schema.Json)
   export interface ToolProgress extends Schema.Schema.Type<typeof ToolProgress> {}
 
   export const ToolOutput = Schema.Struct({
@@ -514,7 +522,7 @@ export namespace Backend {
       sessionID: Schema.String,
       agent: Schema.String,
       messageID: Schema.String,
-      callID: Schema.String,
+      id: Schema.String,
     }),
   })
   export interface ToolInvocation extends Schema.Schema.Type<typeof ToolInvocation> {}

--- a/packages/drive/src/simulation/rpc.ts
+++ b/packages/drive/src/simulation/rpc.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema"
 import { Rpc, RpcClientError, RpcGroup } from "effect/unstable/rpc"
 import { Backend, Frontend, Handshake } from "./protocol.js"
 
-export class SimulationRequestError extends Schema.TaggedErrorClass<SimulationRequestError>()(
+export class SimulationRequestError extends Schema.TaggedError<SimulationRequestError>()(
   "SimulationRequestError",
   {
     method: Schema.String,

--- a/packages/drive/src/tool/plugin.js
+++ b/packages/drive/src/tool/plugin.js
@@ -10,7 +10,7 @@ const descriptions = {
   write: "Writes a file to the local filesystem, overwriting if one exists.",
 }
 
-class ToolFailure extends Schema.TaggedErrorClass()("LLM.ToolFailure", {
+class ToolFailure extends Schema.TaggedError()("Tool.Error", {
   message: Schema.String,
 }) {}
 
@@ -23,11 +23,7 @@ const content = (result) => [
 // `output` value: opencode's tool runtime dies on undeclared structured output.
 const output = (result) => ({
   content: content(result),
-})
-
-const progress = (result) => ({
-  structured: result,
-  content: content(result),
+  metadata: result,
 })
 
 const failure = (cause) =>
@@ -134,7 +130,7 @@ const execute = (ctx, scope, options, name, input, context) =>
               buffer = buffer.slice(newline + 1)
               if (!line) continue
               const event = yield* parse(line)
-              if (event.type === "progress") yield* context.progress(progress(event.result))
+              if (event.type === "progress") yield* context.progress(event.result)
               if (event.type === "success") result = event.result
               if (event.type === "failure")
                 return yield* new ToolFailure({ message: event.message })

--- a/packages/drive/src/tool/producer.ts
+++ b/packages/drive/src/tool/producer.ts
@@ -159,7 +159,7 @@ export const make = Effect.fn("ToolProducer.make")(function* (
   }
 
   const deliver = (record: Active) => {
-    const callID = record.call.context.callID
+    const callID = record.call.context.id
     const exact = waiters.findIndex((waiter) => waiter.callID === callID)
     const index =
       exact >= 0
@@ -284,9 +284,9 @@ export const make = Effect.fn("ToolProducer.make")(function* (
           operation,
           record.state === "settled" ? "already-settled" : "cancelled",
           record.state === "settled"
-            ? `dynamic tool call ${record.call.context.callID} is settled`
-            : `dynamic tool call ${record.call.context.callID} was cancelled`,
-          record.call.context.callID,
+            ? `dynamic tool call ${record.call.context.id} is settled`
+            : `dynamic tool call ${record.call.context.id} was cancelled`,
+          record.call.context.id,
         )
 
   const operate = <A>(
@@ -306,8 +306,8 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 lifecycleError(
                   operation,
                   "cancelled",
-                  `dynamic tool call ${record.call.context.callID} was cancelled`,
-                  record.call.context.callID,
+                  `dynamic tool call ${record.call.context.id} was cancelled`,
+                  record.call.context.id,
                 ),
               ),
             ),
@@ -357,11 +357,11 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 "progress",
                 "rejected",
                 error.message,
-                invocation.context.callID,
+                invocation.context.id,
               ),
             ),
             Effect.flatMap((decoded) =>
-              request("progress", invocation.context.callID, (backend) =>
+              request("progress", invocation.context.id, (backend) =>
                 backend.updateTool({
                   id: invocation.id,
                   sequence: record.sequence,
@@ -386,11 +386,11 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 "finish",
                 "rejected",
                 error.message,
-                invocation.context.callID,
+                invocation.context.id,
               ),
             ),
             Effect.flatMap((decoded) =>
-              request("finish", invocation.context.callID, (backend) =>
+              request("finish", invocation.context.id, (backend) =>
                 backend.finishTool({ id: invocation.id, output: decoded }),
               ),
             ),
@@ -406,11 +406,11 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 "fail",
                 "rejected",
                 error.message,
-                invocation.context.callID,
+                invocation.context.id,
               ),
             ),
             Effect.flatMap((decoded) =>
-              request("fail", invocation.context.callID, (backend) =>
+              request("fail", invocation.context.id, (backend) =>
                 backend.failTool({ id: invocation.id, message: decoded }),
               ),
             ),
@@ -442,7 +442,7 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 "take",
                 "rejected",
                 `dynamic tool invocation ${invocation.id} was replayed with different input`,
-                invocation.context.callID,
+                invocation.context.id,
               ),
             )
           return
@@ -455,7 +455,7 @@ export const make = Effect.fn("ToolProducer.make")(function* (
                 "take",
                 "rejected",
                 `dynamic tool invocation ${invocation.id} was reused with different input`,
-                invocation.context.callID,
+                invocation.context.id,
               ),
             )
           return
@@ -738,7 +738,7 @@ export const make = Effect.fn("ToolProducer.make")(function* (
             callID !== undefined &&
             (Array.from(records.values()).some(
               (record) =>
-                record.call.context.callID === callID && record.claimed,
+                record.call.context.id === callID && record.claimed,
             ) ||
               waiters.some((waiter) => waiter.callID === callID))
           ) {
@@ -758,7 +758,7 @@ export const make = Effect.fn("ToolProducer.make")(function* (
             (candidate) =>
               !candidate.claimed &&
               (callID === undefined ||
-                candidate.call.context.callID === callID),
+                candidate.call.context.id === callID),
           )
           if (record !== undefined) {
             record.claimed = true

--- a/packages/drive/src/tool/types.ts
+++ b/packages/drive/src/tool/types.ts
@@ -72,7 +72,7 @@ export const WriteResult = Schema.Struct({
 })
 export interface WriteResult extends Schema.Schema.Type<typeof WriteResult> {}
 
-export class Failure extends Schema.TaggedErrorClass<Failure>()(
+export class Failure extends Schema.TaggedError<Failure>()(
   "OpenCodeDrive.ToolFailure",
   { message: Schema.String },
 ) {}
@@ -81,7 +81,7 @@ export const Name = Schema.Literals(["shell", "webfetch", "websearch", "write"])
 export type Name = typeof Name.Type
 export const Names = Schema.Array(Name)
 
-export class ControlError extends Schema.TaggedErrorClass<ControlError>()(
+export class ControlError extends Schema.TaggedError<ControlError>()(
   "OpenCodeDrive.ToolControlError",
   {
     operation: Schema.Literals(["control", "take", "progress", "succeed", "fail"]),
@@ -172,7 +172,7 @@ export type Progress = Backend.ToolProgress
 export type Output = Backend.ToolOutput
 export type Cancellation = Backend.ToolCancellation
 
-export class LifecycleError extends Schema.TaggedErrorClass<LifecycleError>()(
+export class LifecycleError extends Schema.TaggedError<LifecycleError>()(
   "OpenCodeDrive.ToolLifecycleError",
   {
     operation: Schema.Literals(["attach", "take", "progress", "finish", "fail"]),

--- a/packages/drive/test/driver/index.test.ts
+++ b/packages/drive/test/driver/index.test.ts
@@ -305,11 +305,11 @@ it.live("controls arbitrary provider-backed tools through the runtime lifecycle"
           expect(call).toMatchObject({
             name: "lookup",
             input: { query: "meaning" },
-            context: { sessionID: "ses_dynamic", callID: "call_lookup" },
+            context: { sessionID: "ses_dynamic", id: "call_lookup" },
           })
           yield* call.progress({
-            structured: { phase: "searching" },
-            content: [{ type: "text", text: "Searching" }],
+            phase: "searching",
+            output: "Searching",
           })
           yield* call.finish({
             structured: { answer: 42 },
@@ -333,8 +333,8 @@ it.live("controls arbitrary provider-backed tools through the runtime lifecycle"
           id: "tool_1",
           sequence: 0,
           update: {
-            structured: { phase: "searching" },
-            content: [{ type: "text", text: "Searching" }],
+            phase: "searching",
+            output: "Searching",
           },
         },
       },

--- a/packages/drive/test/fixtures/fake-opencode.ts
+++ b/packages/drive/test/fixtures/fake-opencode.ts
@@ -188,7 +188,7 @@ const backend = role === "client" ? undefined : Bun.serve({
                   sessionID: "ses_dynamic",
                   agent: "build",
                   messageID: "msg_dynamic",
-                  callID: "call_lookup",
+                  id: "call_lookup",
                 },
               },
             }),

--- a/packages/drive/test/manual/current-v2.ts
+++ b/packages/drive/test/manual/current-v2.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict"
+import { Effect, Option, Queue, Stream } from "effect"
+import { Llm, OpenCodeDriver } from "opencode-drive"
+
+// Run through `drive run` with OPENCODE_DRIVE_DEV pointing to an installed V2 checkout.
+const dev = process.env.OPENCODE_DRIVE_DEV
+if (dev === undefined) throw new Error("OPENCODE_DRIVE_DEV must point to an isolated V2 checkout")
+
+export default OpenCodeDriver.useReport(
+  {
+    opencode: { dev, compatibility: "required" },
+    config: { autoupdate: false },
+    tools: ["shell"],
+    tui: { viewport: { cols: 100, rows: 35 } },
+  },
+  ({ llm, ui, opencode, tools }) =>
+    Effect.gen(function* () {
+      yield* llm.title(() => Effect.succeed("Drive compatibility"))
+      yield* llm.queue(Llm.text("QUEUED_REPLY_OK", { delay: 0 }))
+      yield* ui.waitFor((state) => state.focused.editor)
+      yield* ui.submit("Reply to the fixture prompt")
+      yield* ui.waitFor("QUEUED_REPLY_OK")
+
+      const sessionID = (yield* opencode.session.list({ limit: 1, order: "desc" })).data[0]?.id
+      assert(sessionID)
+      const messages = yield* opencode.message.list({ sessionID, limit: 20 })
+      assert(messages.data.some((message) => message.type === "user" && message.text === "Reply to the fixture prompt"))
+      assert.deepEqual(yield* opencode.session.inbox.list({ sessionID }), [])
+
+      const events = yield* opencode.event.subscribe().pipe(Stream.toQueue({ capacity: "unbounded" }))
+      assert.equal((yield* Queue.take(events)).type, "server.connected")
+      const progress = (id: string) =>
+        Stream.fromQueue(events).pipe(
+          Stream.filter((event) => event.type === "session.tool.progress"),
+          Stream.filter((event) => event.data.sessionID === sessionID && event.data.id === id),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+          Effect.timeout("5 seconds"),
+        )
+
+      const shells = yield* tools.control("shell")
+      yield* llm.queue(
+        Llm.toolCall({ index: 0, id: "call_shell", name: "shell", input: { command: "fixture-only" } }, { delay: 0 }),
+        Llm.finish("tool-calls"),
+      )
+      yield* llm.queue(Llm.text("SHELL_REPLY_OK", { delay: 0 }))
+      yield* ui.submit("Run the controlled shell")
+      const shell = yield* shells.take("call_shell")
+      yield* shell.progress("SHELL_PROGRESS_OK")
+      assert.deepEqual((yield* progress("call_shell")).data.metadata, { output: "SHELL_PROGRESS_OK" })
+      yield* shell.succeed({ output: "SHELL_OUTPUT_OK", exit: 0 })
+      yield* ui.waitFor("SHELL_REPLY_OK")
+
+      yield* tools.attach({
+        tools: [
+          {
+            name: "lookup",
+            description: "Look up the fixture",
+            inputSchema: { type: "object", properties: {} },
+            options: { codemode: false },
+          },
+        ],
+      })
+      yield* llm.queue(
+        Llm.toolCall({ index: 0, id: "call_lookup", name: "lookup", input: {} }, { delay: 0 }),
+        Llm.finish("tool-calls"),
+      )
+      yield* llm.queue(Llm.text("DYNAMIC_REPLY_OK", { delay: 0 }))
+      yield* ui.submit("Look up the fixture")
+      const lookup = yield* tools.take("call_lookup")
+      assert.equal(lookup.context.id, "call_lookup")
+      yield* lookup.progress({ phase: "searching", output: "DYNAMIC_PROGRESS_OK" })
+      assert.deepEqual((yield* progress("call_lookup")).data.metadata, {
+        phase: "searching",
+        output: "DYNAMIC_PROGRESS_OK",
+      })
+      yield* lookup.finish({ structured: null, content: [{ type: "text", text: "DYNAMIC_OUTPUT_OK" }] })
+      yield* ui.waitFor("DYNAMIC_REPLY_OK")
+      yield* opencode.session.wait({ sessionID })
+      yield* ui.waitFor(() =>
+        opencode.session.get({ sessionID }).pipe(Effect.map((session) => session.title === "Drive compatibility")),
+      )
+
+      const frame = yield* ui.capture()
+      assert.equal(frame.cols, 100)
+      assert.equal(frame.rows, 35)
+      yield* ui.screenshot("current-v2")
+    }),
+).pipe(
+  Effect.tap(({ report }) =>
+    Effect.sync(() => {
+      assert(report.compatibility.every((endpoint) => endpoint._tag === "Negotiated"))
+      console.log(JSON.stringify(report, undefined, 2))
+    }),
+  ),
+  Effect.timeout("90 seconds"),
+)

--- a/packages/drive/test/manual/tui-regressions/lifecycle-properties.ts
+++ b/packages/drive/test/manual/tui-regressions/lifecycle-properties.ts
@@ -164,14 +164,14 @@ export default defineScript({
       ) {
         const [messages, pending] = yield* Effect.all([
           opencode.message.list({ sessionID, limit: 20, order: "desc" }),
-          opencode.session.pending.list({ sessionID }),
+          opencode.session.inbox.list({ sessionID }),
         ], { concurrency: "unbounded" })
         return {
           projected: messages.data.filter(
             (message) => message.type === "user" && message.text === prompt,
           ).length,
           pending: pending.filter(
-            (input) => input.type === "user" && input.data.text === prompt,
+            (input) => input.type === "user" && input.payload.text === prompt,
           ).length,
         }
       })
@@ -590,7 +590,7 @@ export default defineScript({
                 : Effect.gen(function* () {
                     const sessionID = state.sessionID
                     if (sessionID === undefined) return
-                    const pending = yield* opencode.session.pending.list({ sessionID })
+                    const pending = yield* opencode.session.inbox.list({ sessionID })
                     if (pending.length === 0) return
                     return yield* Effect.fail(new Error(`settled session retained ${pending.length} pending input(s)`))
                   }),

--- a/packages/drive/test/simulation/backend.test.ts
+++ b/packages/drive/test/simulation/backend.test.ts
@@ -203,7 +203,7 @@ describe("OpenCode backend simulation transport", () => {
           sessionID: "ses_tools",
           agent: "build",
           messageID: "msg_tools",
-          callID: "call_lookup",
+          id: "call_lookup",
         },
       }
       const peer = startTransportPeer(({ request, socket }) => {
@@ -240,7 +240,7 @@ describe("OpenCode backend simulation transport", () => {
       yield* connection.updateTool({
         id: "tool_1",
         sequence: 0,
-        update: { structured: { phase: "searching" } },
+        update: { phase: "searching" },
       })
       yield* connection.finishTool({
         id: "tool_1",
@@ -269,7 +269,7 @@ describe("OpenCode backend simulation transport", () => {
           params: {
             id: "tool_1",
             sequence: 0,
-            update: { structured: { phase: "searching" } },
+            update: { phase: "searching" },
           },
         },
         {

--- a/packages/drive/test/simulation/direct-cli.test.ts
+++ b/packages/drive/test/simulation/direct-cli.test.ts
@@ -95,7 +95,7 @@ test.sequential("CLI drives an externally owned OpenCode endpoint on the default
     ])
     expect(invalidAlt.status).toBe(1)
     expect(invalidAlt.stderr).toContain("alt")
-    expect(invalidAlt.stderr).toContain("Unexpected key with value true")
+    expect(invalidAlt.stderr).toContain("Expected no excess property")
 
     expect(requests).toEqual([
       { jsonrpc: "2.0", id: 1, method: "ui.state" },

--- a/packages/drive/test/simulation/protocol.test.ts
+++ b/packages/drive/test/simulation/protocol.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "@effect/vitest"
-import { Backend } from "../../src/simulation/protocol.js"
+import { Schema } from "effect"
+import { Backend, Handshake, JsonRpc } from "../../src/simulation/protocol.js"
 
 it("decodes the canonical dynamic tool lifecycle", () => {
   expect(
@@ -30,12 +31,31 @@ it("decodes the canonical dynamic tool lifecycle", () => {
         id: "tool_1",
         sequence: 0,
         update: {
-          structured: { phase: "searching" },
-          content: [{ type: "text", text: "Searching" }],
+          phase: "searching",
+          output: "Searching",
         },
       },
     }),
   ).toMatchObject({ method: "tool.update" })
+})
+
+it("requires exactly one JSON-RPC result or error", () => {
+  const decode = Schema.decodeUnknownSync(JsonRpc.Response)
+  const response = { jsonrpc: "2.0", id: 1 }
+  const error = { code: -32000, message: "failed" }
+  expect(decode({ ...response, result: null })).toEqual({ ...response, result: null })
+  expect(decode({ ...response, error })).toEqual({ ...response, error })
+  expect(() => decode(response)).toThrow()
+  expect(() => decode({ ...response, result: null, error })).toThrow()
+})
+
+it("rejects duplicated negotiated capabilities", () => {
+  expect(() => Schema.decodeUnknownSync(Handshake.Response)({
+    protocolVersion: 1,
+    role: "backend",
+    server: { name: "OpenCode", version: "test" },
+    capabilities: ["llm.attach", "llm.attach"],
+  })).toThrow()
 })
 
 it("rejects unsafe, colliding, and reserved exposed names", () => {

--- a/packages/drive/test/tool/controller.test.ts
+++ b/packages/drive/test/tool/controller.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest"
-import { Deferred, Effect } from "effect"
+import { Deferred, Effect, Schema } from "effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
@@ -12,9 +12,13 @@ interface RegisteredTool {
   readonly name: string
   readonly execute: (
     input: unknown,
-    context: { readonly sessionID: string; readonly id: string },
+    context: {
+      readonly sessionID: string
+      readonly id: string
+      readonly progress?: (update: Readonly<Record<string, unknown>>) => Effect.Effect<void>
+    },
   ) => Effect.Effect<{
-    readonly structured: unknown
+    readonly metadata?: Readonly<Record<string, unknown>>
     readonly content: ReadonlyArray<{ readonly type: string; readonly text: string }>
   }, unknown>
 }
@@ -705,6 +709,11 @@ it.effect("notifies OpenCode when a registered background shell completes", () =
       // No `output` value: drive tools declare no output schema, and opencode's
       // tool runtime rejects undeclared structured output.
       expect(started).toEqual({
+        metadata: {
+          output: "The command was moved to the background.",
+          shellID: "call_plugin",
+          status: "running",
+        },
         content: [
           { type: "text", text: "The command was moved to the background." },
           {
@@ -900,4 +909,44 @@ it.effect("interrupts a handler with its plugin execution", () =>
       yield* Effect.promise(() => interrupted.promise)
     }),
   ),
+)
+
+it.live("uses native V2 tool progress, result metadata, and failure tags", () =>
+  Effect.gen(function* () {
+    const controller = yield* ToolController.make((tools) => {
+      tools.handle("shell", ({ input, progress }) => Effect.gen(function* () {
+        yield* progress("working")
+        if (input.command === "fail") return yield* new Failure({ message: "controlled failure" })
+        return { output: "done", exit: 7 }
+      }))
+    })
+    const config: OpenCodeConfig = {}
+    controller.configure(config)
+    const injected = Schema.decodeUnknownSync(Schema.Array(Schema.Struct({ options: Schema.Unknown })))(config.plugins)[0]
+    const registered: RegisteredTool[] = []
+    yield* plugin.effect({
+      options: injected?.options,
+      tool: {
+        transform: (register: (tools: { add: (tool: RegisteredTool) => void }) => void) =>
+          Effect.sync(() => register({ add: (tool) => registered.push(tool) })),
+      },
+    })
+    const shell = registered.find((tool) => tool.name === "shell")
+    if (shell === undefined) return yield* Effect.dieMessage("shell tool was not registered")
+    const updates: Readonly<Record<string, unknown>>[] = []
+    const context = {
+      sessionID: "ses_plugin",
+      id: "call_plugin",
+      progress: (update: Readonly<Record<string, unknown>>) => Effect.sync(() => { updates.push(update) }),
+    }
+    expect(yield* shell.execute({ command: "succeed" }, context)).toEqual({
+      content: [{ type: "text", text: "done" }],
+      metadata: { output: "done", exit: 7 },
+    })
+    expect(yield* shell.execute({ command: "fail" }, context).pipe(Effect.flip)).toMatchObject({
+      _tag: "Tool.Error",
+      message: "controlled failure",
+    })
+    expect(updates).toEqual([{ output: "working" }, { output: "working" }])
+  }),
 )

--- a/packages/drive/test/tool/producer.test.ts
+++ b/packages/drive/test/tool/producer.test.ts
@@ -30,7 +30,7 @@ const invocation = {
     sessionID: "ses_tools",
     agent: "build",
     messageID: "msg_tools",
-    callID: "call_lookup",
+    id: "call_lookup",
   },
 } as const
 
@@ -58,10 +58,10 @@ it.live("attaches, sequences progress, and settles one dynamic invocation", () =
 
       expect(call).toMatchObject(invocation)
       yield* call.progress({
-        structured: { phase: "searching" },
-        content: [{ type: "text", text: "Searching" }],
+        phase: "searching",
+        output: "Searching",
       })
-      yield* call.progress({ structured: { phase: "done" } })
+      yield* call.progress({ phase: "done" })
       yield* call.finish({
         structured: { answer: 42 },
         content: [{ type: "text", text: "42" }],
@@ -82,8 +82,8 @@ it.live("attaches, sequences progress, and settles one dynamic invocation", () =
             id: "tool_1",
             sequence: 0,
             update: {
-              structured: { phase: "searching" },
-              content: [{ type: "text", text: "Searching" }],
+              phase: "searching",
+              output: "Searching",
             },
           },
         },
@@ -94,7 +94,7 @@ it.live("attaches, sequences progress, and settles one dynamic invocation", () =
           params: {
             id: "tool_1",
             sequence: 1,
-            update: { structured: { phase: "done" } },
+            update: { phase: "done" },
           },
         },
         {
@@ -211,7 +211,7 @@ it.live("bounds retained unclaimed cancellations", () =>
         notify(socket, "tool.invocation", {
           ...invocation,
           id: `tool_${index}`,
-          context: { ...invocation.context, callID: `call_${index}` },
+          context: { ...invocation.context, id: `call_${index}` },
         })
         notify(socket, "tool.cancel", {
           id: `tool_${index}`,
@@ -251,7 +251,7 @@ it.live("settles concurrent invocations in controlled reverse order", () =>
         ...invocation,
         id: "tool_2",
         input: { query: "second" },
-        context: { ...invocation.context, callID: "call_second" },
+        context: { ...invocation.context, id: "call_second" },
       })
 
       const second = yield* controller.controls.take("call_second")
@@ -401,7 +401,7 @@ it.live("preserves a replacement intent when its acknowledgement is lost", () =>
         ...invocation,
         id: "tool_2",
         name: "search",
-        context: { ...invocation.context, callID: "call_search" },
+        context: { ...invocation.context, id: "call_search" },
       }
       const firstReplacement = yield* Deferred.make<void>()
       const peer = startTransportPeer(({ request, socket }) => {
@@ -1109,7 +1109,7 @@ it.live("drains a reconnect that finishes during settlement commit", () =>
       const staleInvocation = {
         ...invocation,
         id: "tool_stale",
-        context: { ...invocation.context, callID: "call_stale" },
+        context: { ...invocation.context, id: "call_stale" },
       }
       const peer = startTransportPeer(({ request, socket }) => {
         if (request.method === "tool.attach") {
@@ -1302,7 +1302,7 @@ it.live("retries in-flight progress after reconnect without advancing its sequen
       const call = yield* controller.controls.take("call_lookup")
 
       const progress = yield* call
-        .progress({ structured: { phase: "searching" } })
+        .progress({ phase: "searching" })
         .pipe(Effect.forkScoped)
       yield* Deferred.await(firstUpdate)
       yield* first.closed
@@ -1322,12 +1322,12 @@ it.live("retries in-flight progress after reconnect without advancing its sequen
         {
           id: "tool_1",
           sequence: 0,
-          update: { structured: { phase: "searching" } },
+          update: { phase: "searching" },
         },
         {
           id: "tool_1",
           sequence: 0,
-          update: { structured: { phase: "searching" } },
+          update: { phase: "searching" },
         },
       ])
       yield* secondAttachment.detach()
@@ -1360,7 +1360,7 @@ it.live("does not retry progress interrupted by its caller", () =>
       const call = yield* controller.controls.take("call_lookup")
 
       const progress = yield* call
-        .progress({ structured: { phase: "searching" } })
+        .progress({ phase: "searching" })
         .pipe(Effect.forkScoped)
       yield* Deferred.await(updateReceived)
       yield* Fiber.interrupt(progress)
@@ -1387,13 +1387,13 @@ it.live("rejects malformed progress without advancing its sequence", () =>
       notify(peer.received[0].socket, "tool.invocation", invocation)
       const call = yield* controller.controls.take("call_lookup")
 
-      const malformed = { structured: [] } as unknown as Progress
+      const malformed = [] as unknown as Progress
       expect(yield* call.progress(malformed).pipe(Effect.flip)).toMatchObject({
         operation: "progress",
         reason: "rejected",
         callID: "call_lookup",
       })
-      yield* call.progress({ structured: { phase: "valid" } })
+      yield* call.progress({ phase: "valid" })
       yield* call.fail("finished")
 
       expect(
@@ -1402,7 +1402,7 @@ it.live("rejects malformed progress without advancing its sequence", () =>
         {
           id: "tool_1",
           sequence: 0,
-          update: { structured: { phase: "valid" } },
+          update: { phase: "valid" },
         },
       ])
     }),

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -282,7 +282,7 @@ yield* tools.attach({
 })
 
 const lookup = yield* tools.take("call_lookup")
-yield* lookup.progress({ structured: { phase: "searching" } })
+yield* lookup.progress({ phase: "searching" })
 yield* lookup.finish({
   structured: { answer: 42 },
   content: [{ type: "text", text: "42" }],


### PR DESCRIPTION
## Why

Drive 1.4.5 still pins Effect beta.101 and an older V2 client. Current V2 dynamic-tool notifications use `context.id`, which the old Drive protocol cannot decode; updating dependencies alone also breaks schema-backed errors, RPC codecs, and omitted CLI boolean flags.

## What Changes

| Dependency | Before | After |
| --- | --- | --- |
| `effect` | `4.0.0-beta.101` | `4.0.0-rc.111` (exact peer) |
| `@effect/platform-node` | `4.0.0-beta.101` | `4.0.0-rc.111` |
| `@effect/platform-node-shared` | `4.0.0-beta.101` | `4.0.0-rc.111` |
| `@effect/vitest` | `4.0.0-beta.101` | `4.0.0-rc.111` |
| `@opencode-ai/client` | `0.0.0-next-17010` | `0.0.0-dev-18516` |

- Use `Schema.TaggedError` and provide the JSON codec required by Effect RPC.
- Preserve `start --name demo` and other CLI behavior with explicit false defaults for optional boolean flags.
- Copy current V2 JSON-RPC response exclusivity, unique negotiated capabilities, dynamic-tool progress records, and invocation context fields.
- Static tool adapters emit native progress metadata, terminal result metadata, and `Tool.Error` failures while retaining their public controlled-call API.
- Update affected catalog schemas, fixtures, documentation, and the lifecycle probe's `session.inbox.list` integration.

Dynamic controls now match the canonical V2 protocol:

```ts
// Before
yield* invocation.progress({ structured: { phase: "searching" } })
invocation.context.callID

// After
yield* invocation.progress({ phase: "searching" })
invocation.context.id

// Unchanged: terminal output and producer identity
yield* invocation.finish({ structured: { answer: 42 }, content: [{ type: "text", text: "42" }] })
invocation.id
```

## Effect Alignment

Registry checks found Effect `rc.112` is newer, but the newest V2 client (`dev-18516`) and its protocol/schema packages still require exactly `rc.111`. This PR uses the latest coherent V2 dependency set instead of overriding the published client's contract or accidentally selecting Effect V3 through `latest`.

Effect is an exact peer because Drive exposes Effect values in its public API. A workspace override prevents Bun's isolated linker from selecting a newer `platform-node-shared` through the platform package's caret dependency. The clean packed consumer resolved one Effect `rc.111` runtime without overrides.

## Scope

Compatibility update only: LLM queue/send/serve/title sequencing, two-sided waiting, mode exclusivity, cancellation, reconnection, run-wide supervision, and settlement retain their contracts. No shared response language or controller redesign.

The major changeset records the public dynamic-tool shape migration. The package version remains `1.4.5` pending the normal approved Changesets release; this PR does not publish npm or change an installed CLI.

## Verification

```sh
# packages/drive
bun run check
bun typecheck
bun run release:validate
bun run drive run ./test/manual/current-v2.ts
bun pm pack --destination ../../.tmp

# apps/catalog
bun run check

# isolated OpenCode checkout, packages/simulation, private HOME/XDG/config
bun run test

# fresh packed consumer
bun typecheck
bun node_modules/opencode-drive/bin/opencode-drive run ./consumer.ts
bun node_modules/opencode-drive/bin/opencode-drive run ../../packages/drive/test/manual/current-v2.ts
```

- Final release validation: 244 Effect tests and 58 CLI integration tests pass.
- Catalog check: lint, types, generation consistency, 40 tests, and browser/Bun builds pass.
- OpenCode simulation: 42 tests pass against `6fad330efceb5af8e49d558394ddb492fca259db` from `origin/v2` with isolated HOME/XDG/config.
- Both source and packed CLI smoke runs use `OPENCODE_DRIVE_DEV` pointing to that isolated checkout, negotiate both endpoint roles at protocol V1 with compatibility required, and verify queued replies, title handling, SDK inbox/event APIs, static/dynamic tool progress and completion, capture, PNG, and settlement.
- A temporary checked `defineScript` fixture also passes two explicit server/TUI generations with queued replies and backend relaunch.
- Inspected the 102-file tarball (1.62 MB, SHA-1 `5622f14b8d63257a5824c1f64b705e6f334dba75`): all seven public entry points, CLI, runtime config/plugin, and fonts are included; tests, catalog, and node_modules are excluded. A fresh consumer typechecks and imports all entry points with client/protocol/schema `dev-18516` and a single Effect `rc.111`.
- One pre-existing lint warning remains in `recording/marks.ts`. An earlier overlapping validation run failed once on a missing detached-owner log; two focused reruns and final full validation pass. No live user sessions, real providers, or elected OpenCode server replacement were used.
