### PR TITLE
fix(drive): repair V2 configuration and lifecycle ownership

### DIFF
--- a/.changeset/drive-v2-cli-config.md
+++ b/.changeset/drive-v2-cli-config.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Write `tuiConfig` to the isolated OpenCode V2 `cli.json` configuration file so terminal settings take effect. Merge `.opencode/cli.json` fixture values before declared options and setup mutations, without generating a legacy `tui.jsonc` file.

--- a/.changeset/owned-script-endpoint.md
+++ b/.changeset/owned-script-endpoint.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Pin scripted TUIs to the script-owned server and retain its HTTP endpoint across restarts, preventing TUI reconnects from electing a competing managed service. Existing SDK clients also remain connected to the replacement server; network-chaos TUIs continue to use the proxy.

--- a/.changeset/tool-interruption-delivery.md
+++ b/.changeset/tool-interruption-delivery.md
@@ -1,0 +1,5 @@
+---
+"opencode-drive": patch
+---
+
+Keep static tool requests cancellable after progress arrives so session interruption promptly notifies held calls and interrupts foreground callback handlers, while detached background shells continue running.

--- a/packages/drive/README.md
+++ b/packages/drive/README.md
@@ -270,14 +270,15 @@ generated script is ready for `opencode-drive check ./drive.ts` and
 `start --script ./drive.ts`.
 
 ```ts
-import { defineScript, Effect, Llm } from "opencode-drive"
+import { Effect } from "effect"
+import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
   config: {
     autoupdate: false,
   },
   tuiConfig: {
-    theme: "system",
+    theme: { name: "opencode", mode: "dark" },
   },
   project: {
     git: true,
@@ -288,7 +289,7 @@ export default defineScript({
   setup: ({ config, tuiConfig }) =>
     Effect.sync(() => {
       config.username = "Drive"
-      tuiConfig.scroll_speed = 1
+      tuiConfig.scroll = { speed: 1 }
     }),
   run: ({ ui, llm }) =>
     Effect.gen(function* () {
@@ -304,8 +305,19 @@ export default defineScript({
 pre-launch state, including files written in `setup`. A prepared repository is
 never replaced; omit `project.git` when an `init` step supplies Git history.
 Declared `config` and `tuiConfig` values are deeply merged over fixture
-`.opencode/opencode.jsonc` and `.opencode/tui.jsonc` files. Arrays replace
+`.opencode/opencode.jsonc` and `.opencode/cli.json` files. Arrays replace
 instead of merging, and mutations made in `setup` take final precedence.
+
+`tuiConfig` retains its public option name and contains current V2 CLI settings.
+Drive's isolated `OPENCODE_CONFIG_DIR` points to the fixture's `.opencode`
+directory, so `cli.json` is consumed as global terminal configuration without
+changing the installed client's files. Legacy `tui.jsonc` is not emitted.
+
+Scripted TUIs connect explicitly to Drive's owned server endpoint. The endpoint
+and existing registered credential remain usable across manual server restarts;
+the TUI does not elect a competing managed service during an outage. Network
+chaos routes this same explicit connection through the proxy. Non-scripted live
+launches keep their existing managed-service behavior.
 
 Attach arbitrary provider-backed tools at runtime with their JSON schemas, then
 take and settle native OpenCode invocations by model call ID. `attach` replaces

--- a/packages/drive/docs/driver-consolidation-plan.md
+++ b/packages/drive/docs/driver-consolidation-plan.md
@@ -16,7 +16,7 @@ Phases 0 through 5 are complete. The consolidated Effect lifecycle, typed OpenCo
 - Script cancellation is Effect interruption and runs scoped finalizers.
 - Manual scripts retain server kill/relaunch and named multi-TUI behavior.
 - CLI `--command.ui.*` names and payloads remain identical to OpenCode's canonical frontend protocol.
-- OpenCode configuration is expressed through normal `opencode.jsonc` and `tui.jsonc` files, not Drive-specific runtime flags.
+- OpenCode configuration is expressed through normal `opencode.jsonc` and V2 `cli.json` files, not Drive-specific runtime flags.
 - Backend simulation control remains in programs, not CLI commands.
 - Every process, socket, worker, timeline, and temporary project has one lifecycle owner.
 - Protocol compatibility is reported truthfully; legacy fallback is never described as negotiated compatibility.
@@ -36,7 +36,7 @@ Phases 0 through 5 are complete. The consolidated Effect lifecycle, typed OpenCo
 3. Expose mutable `config` and `tui` objects to `setup`.
 4. Deep-merge declared configuration over project fixture files, with arrays replacing and setup mutations taking final precedence.
 5. Parse existing JSONC rather than assuming strict JSON.
-6. Write normalized `.opencode/opencode.jsonc` and `.opencode/tui.jsonc` before creating the optional Git baseline.
+6. Write normalized `.opencode/opencode.jsonc` and `.opencode/cli.json` before creating the optional Git baseline.
 7. Verify the same behavior through Effect scripts and the Effect driver.
 
 ## Phase 2: Effect Program Runner (Completed)

--- a/packages/drive/docs/open-code-driver-architecture.md
+++ b/packages/drive/docs/open-code-driver-architecture.md
@@ -199,7 +199,7 @@ OpenCodeTuiConfig
 Configuration is applied in this order:
 
 1. Write declared project files.
-2. Read fixture `opencode.jsonc` and `tui.jsonc` values.
+2. Read fixture `opencode.jsonc` and V2 `cli.json` values from the isolated config directory.
 3. Deep-merge `config` and `tuiConfig`; arrays replace existing arrays.
 4. Run Effect-only `setup`, which may mutate both merged objects.
 5. Write normalized JSON and optionally commit the Git baseline.

--- a/packages/drive/src/instance/instance.ts
+++ b/packages/drive/src/instance/instance.ts
@@ -62,13 +62,13 @@ export const prepareInstanceProject = Effect.fn("OpenCodeInstance.prepareProject
 }) {
   const files = join(resolve(options.artifacts), "files")
   const configPath = join(files, ".opencode", "opencode.jsonc")
-  const tuiPath = join(files, ".opencode", "tui.jsonc")
+  const tuiPath = join(files, ".opencode", "cli.json")
   const project = options.project
   if (project)
     yield* promise(() => initializeScriptProject(files, project))
   const [config, tui] = yield* Effect.all([
     promise(() => readConfig(configPath, "opencode.jsonc")),
-    promise(() => readConfig(tuiPath, "tui.jsonc", {})),
+    promise(() => readConfig(tuiPath, "cli.json", {})),
   ], { concurrency: "unbounded" })
   deepMerge(config, options.config)
   deepMerge(tui, options.tui)

--- a/packages/drive/src/instance/runtime.ts
+++ b/packages/drive/src/instance/runtime.ts
@@ -45,9 +45,8 @@ export interface Options {
   readonly viewport?: Viewport
   readonly env?: Readonly<Record<string, string>>
   /**
-   * Routes every launched TUI through a chaos network proxy. TUIs connect
-   * with an explicit `--server` pointing at the proxy instead of managed
-   * service discovery.
+   * Routes scripted TUIs through a chaos network proxy instead of connecting
+   * directly to the script-owned server.
    */
   readonly network?: boolean
   readonly project?: Project
@@ -130,6 +129,8 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
     ui: `ws://127.0.0.1:${yield* freePort}`,
     backend: `ws://127.0.0.1:${yield* freePort}`,
   }
+  // Retained TUIs and SDK clients keep their endpoint across server generations.
+  const serverPort = options.scripted ? yield* freePort : undefined
   const toolController = configuredTools ?? (yield* ToolController.make(options.tools))
   const database = yield* Config.string("OPENCODE_DRIVE_DB").pipe(
     Config.withDefault(":memory:"),
@@ -307,7 +308,7 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
           "serve",
           dev?.serviceFlag ?? "--service",
           "--port",
-          String(yield* freePort),
+          String(serverPort),
         ]
         yield* writeManifest(name, {
           ui: `ws://127.0.0.1:${yield* freePort}`,
@@ -422,23 +423,18 @@ export const make = Effect.fn("OpenCodeInstance.make")(function* (
           recording,
           tuiOptions.viewport ?? options.viewport,
         )
-        // With the chaos proxy, TUIs pin to the proxy URL: reconnects always
-        // cross the proxy and the TUI never elects a replacement server. The
-        // registered password rides OPENCODE_PASSWORD because explicit
-        // --server connections skip registration-based credentials.
-        const registration = network === undefined
-          ? undefined
-          : yield* awaitRegistration
-        const tuiCommand = network === undefined
-          ? scriptedCommand
-          : [...scriptedCommand, "--server", network.url]
+        // Scripts own server replacement. Managed TUI discovery would elect a
+        // competing server during an outage. Explicit connections also need
+        // the registered credential, which remains valid across generations.
+        const registration = yield* awaitRegistration
+        const tuiCommand = [...scriptedCommand, "--server", network?.url ?? registration.url]
         options.log?.(`launching TUI ${name}`)
         const tui = yield* spawn(
           driveName,
           tuiCommand,
           `tui-${name}`,
           options.visible ?? false,
-          registration?.password === undefined
+          registration.password === undefined
             ? undefined
             : { OPENCODE_PASSWORD: registration.password },
         )

--- a/packages/drive/src/project.ts
+++ b/packages/drive/src/project.ts
@@ -14,7 +14,7 @@ export type JsonObject = { [key: string]: JsonValue }
 /** OpenCode's semantic project configuration, written to opencode.jsonc. */
 export interface OpenCodeConfig extends JsonObject {}
 
-/** OpenCode's semantic TUI configuration, written to tui.jsonc. */
+/** OpenCode V2 CLI configuration, written to .opencode/cli.json in the isolated config directory. */
 export interface OpenCodeTuiConfig extends JsonObject {}
 
 export class FileSystemError extends Schema.TaggedError<FileSystemError>()(
@@ -38,7 +38,7 @@ export interface SetupContext {
   readonly fs: ProjectFileSystem
   /** The current OpenCode config object. Mutate it to customize the run. */
   readonly config: OpenCodeConfig
-  /** The current OpenCode TUI config object. Mutate it to customize the run. */
+  /** The current OpenCode V2 CLI config object. Mutate it to customize the run. */
   readonly tuiConfig: OpenCodeTuiConfig
 }
 

--- a/packages/drive/src/tool/plugin.js
+++ b/packages/drive/src/tool/plugin.js
@@ -87,8 +87,11 @@ const notifyWhenDone = (ctx, options, sessionID, shellID) =>
 
 const execute = (ctx, scope, options, name, input, context) =>
   Effect.gen(function* () {
+    // Fetch resolves at headers; its signal must outlive that Effect and cover
+    // the response body. Cancelling Bun's reader alone leaves the socket open.
+    const signal = yield* Effect.abortSignal
     const response = yield* Effect.tryPromise({
-      try: (signal) =>
+      try: () =>
         fetch(`${options.endpoint}/execute/${name}`, {
           method: "POST",
           headers: {
@@ -147,7 +150,7 @@ const execute = (ctx, scope, options, name, input, context) =>
         }),
       (reader) => Effect.promise(() => reader.cancel().catch(() => undefined)),
     )
-  })
+  }).pipe(Effect.scoped)
 
 export default {
   id: "opencode-drive.tool-handlers",

--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -821,8 +821,10 @@ describe("opencode-drive", () => {
       providers: { simulation: { models: { "gpt-sim-model": {} } } },
       test: { declared: true, setup: true },
     })
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "tui.jsonc")).json()).toEqual({
-      test: { declared: true, setup: true },
+    expect(await Bun.file(join(artifacts, "files", ".opencode", "cli.json")).json()).toEqual({
+      session: { new_location: "inherit" },
+      keybinds: { "session.new": "ctrl+n" },
+      theme: { name: "opencode", mode: "light" },
     })
     const backendEvents = (await Bun.file(join(artifacts, "backend-events.jsonl")).text())
       .trim()

--- a/packages/drive/test/driver/index.test.ts
+++ b/packages/drive/test/driver/index.test.ts
@@ -18,6 +18,7 @@ it.live("runs and settles a complete scoped driver", () =>
           git: true,
           files: {
             "src/seeded.ts": "export const seeded = true\n",
+            ".opencode/cli.json": '{ "theme": { "name": "tokyonight", "mode": "dark" } }',
           },
         },
         config: {
@@ -25,17 +26,15 @@ it.live("runs and settles a complete scoped driver", () =>
           nested: { declared: true, winner: "declared" },
           items: ["declared"],
         },
-        tuiConfig: { theme: { declared: true } },
+        tuiConfig: { theme: { name: "catppuccin" } },
         setup: ({ config, tuiConfig }) =>
           Effect.sync(() => {
             config.nested = {
               ...config.nested as Record<string, boolean | string>,
               winner: "setup",
             }
-            tuiConfig.theme = {
-              ...tuiConfig.theme as Record<string, boolean>,
-              setup: true,
-            }
+            expect(tuiConfig.theme).toEqual({ name: "catppuccin", mode: "dark" })
+            tuiConfig.theme = { name: "opencode", mode: "light" }
           }),
         tui: {
           recording: true,
@@ -99,11 +98,11 @@ it.live("runs and settles a complete scoped driver", () =>
     expect(
       yield* Effect.promise(() =>
         readFile(
-          `${result.artifacts}/files/.opencode/tui.jsonc`,
+          `${result.artifacts}/files/.opencode/cli.json`,
           "utf8",
         ).then(JSON.parse),
       ),
-    ).toEqual({ theme: { declared: true, setup: true } })
+    ).toEqual({ theme: { name: "opencode", mode: "light" } })
     expect(
       yield* Effect.promise(() =>
         readFile(`${result.artifacts}/backend-events.jsonl`, "utf8"),

--- a/packages/drive/test/fixtures/fake-opencode.ts
+++ b/packages/drive/test/fixtures/fake-opencode.ts
@@ -29,7 +29,7 @@ const servicePassword = "drive-test-password"
 const api = role === "service"
   ? Bun.serve({
       hostname: "127.0.0.1",
-      port: 0,
+      port: Number(process.argv[process.argv.indexOf("--port") + 1]) || 0,
       fetch(request) {
         if (
           request.headers.get("authorization") !==
@@ -75,6 +75,13 @@ if (drive.recording && role !== "service")
     `${JSON.stringify({ type: "header", version: 1, cols: 100, rows: 40, encoding: "base64" })}\n${JSON.stringify({ type: "output", at_ms: 0, data: Buffer.from("Fake OpenCode").toString("base64") })}\n`,
   )
 if (process.env.OPENCODE_TEST_HOME && role !== "service") {
+  await Bun.write(
+    `${process.env.OPENCODE_TEST_HOME}/client-connection.json`,
+    JSON.stringify({
+      argv: process.argv.slice(2),
+      authenticated: process.env.OPENCODE_PASSWORD === servicePassword,
+    }),
+  )
   await Bun.write(
     `${process.env.OPENCODE_TEST_HOME}/child.pid`,
     String(process.pid),

--- a/packages/drive/test/fixtures/script.ts
+++ b/packages/drive/test/fixtures/script.ts
@@ -7,7 +7,8 @@ export default defineScript({
     test: { declared: true },
   },
   tuiConfig: {
-    test: { declared: true },
+    session: { new_location: "inherit" },
+    keybinds: { "session.new": "ctrl+n" },
   },
   project: {
     git: true,
@@ -19,7 +20,7 @@ export default defineScript({
     Effect.gen(function* () {
       config.autoupdate = false
       config.test = { ...config.test as Record<string, boolean>, setup: true }
-      tuiConfig.test = { ...tuiConfig.test as Record<string, boolean>, setup: true }
+      tuiConfig.theme = { name: "opencode", mode: "light" }
       yield* fs.writeFile("setup-seeded.txt", "included in baseline\n")
     }),
 

--- a/packages/drive/test/instance/config.test.ts
+++ b/packages/drive/test/instance/config.test.ts
@@ -33,7 +33,7 @@ describe("instance configuration", () => {
     })
   })
 
-  test("merges JSONC fixtures, replaces arrays, applies setup last, and commits normalized files", async () => {
+  test("merges V2 CLI JSONC fixtures, replaces arrays, applies setup last, and commits normalized files", async () => {
     const root = await initializeInstance()
     artifacts.push(root)
     await Effect.runPromise(prepareInstanceProject({
@@ -46,9 +46,12 @@ describe("instance configuration", () => {
             "nested": { "fixture": true, "winner": "fixture" },
             "items": ["fixture"],
           }`,
-          ".opencode/tui.jsonc": `{
-            "theme": { "fixture": true },
-            "items": ["fixture"],
+          ".opencode/cli.json": `{
+            // CLI fixtures also accept comments and trailing commas
+            "$schema": "https://opencode.ai/v2/cli.json",
+            "theme": { "name": "tokyonight", "mode": "light" },
+            "session": { "new_location": "launch" },
+            "keybinds": { "app.exit": ["ctrl+c", "ctrl+d"] },
           }`,
         },
       },
@@ -57,8 +60,9 @@ describe("instance configuration", () => {
         items: ["declared"],
       },
       tui: {
-        theme: { declared: true },
-        items: ["declared"],
+        theme: { name: "catppuccin" },
+        session: { new_location: "inherit" },
+        keybinds: { "app.exit": ["ctrl+q"] },
       },
       setup({ config, tuiConfig }) {
         return Effect.sync(() => {
@@ -66,7 +70,10 @@ describe("instance configuration", () => {
             ...(config.nested as Record<string, boolean | string>),
             winner: "setup",
           }
-          tuiConfig.items = ["setup"]
+          expect(tuiConfig.theme).toEqual({ name: "catppuccin", mode: "light" })
+          expect(tuiConfig.keybinds).toEqual({ "app.exit": ["ctrl+q"] })
+          tuiConfig.theme = { name: "opencode", mode: "light" }
+          tuiConfig.keybinds = { "app.exit": ["ctrl+x"], "session.new": "ctrl+n" }
         })
       },
     }))
@@ -75,40 +82,54 @@ describe("instance configuration", () => {
     const configText = await Bun.file(
       join(files, ".opencode", "opencode.jsonc"),
     ).text()
-    const tuiText = await Bun.file(
-      join(files, ".opencode", "tui.jsonc"),
+    const cliText = await Bun.file(
+      join(files, ".opencode", "cli.json"),
     ).text()
     expect(JSON.parse(configText)).toEqual({
       nested: { fixture: true, declared: true, winner: "setup" },
       items: ["declared"],
     })
-    expect(JSON.parse(tuiText)).toEqual({
-      theme: { fixture: true, declared: true },
-      items: ["setup"],
-    })
+    const cli = {
+      $schema: "https://opencode.ai/v2/cli.json",
+      theme: { name: "opencode", mode: "light" },
+      session: { new_location: "inherit" },
+      keybinds: { "app.exit": ["ctrl+x"], "session.new": "ctrl+n" },
+    }
+    expect(cliText).toBe(`${JSON.stringify(cli, undefined, 2)}\n`)
+    expect(await Bun.file(join(files, ".opencode", "tui.jsonc")).exists()).toBe(false)
     expect(configText).not.toContain("//")
     expect(await git(files, ["status", "--porcelain"])).toBe("")
-    expect(await git(files, ["show", "HEAD:.opencode/tui.jsonc"])).toBe(tuiText)
+    expect(await git(files, ["show", "HEAD:.opencode/cli.json"])).toBe(cliText)
   })
 
-  test("rejects invalid JSONC configuration", async () => {
+  test("prepares only the isolated V2 CLI configuration when no overrides are supplied", async () => {
+    const root = await initializeInstance()
+    artifacts.push(root)
+    await Effect.runPromise(prepareInstanceProject({ artifacts: root }))
+
+    expect(await Bun.file(join(root, "files", ".opencode", "cli.json")).text()).toBe("{}\n")
+    expect(await Bun.file(join(root, "files", ".opencode", "tui.jsonc")).exists()).toBe(false)
+    expect(await Bun.file(join(root, "home", ".config", "opencode", "cli.json")).exists()).toBe(false)
+  })
+
+  test.each(["{ invalid", "null", "[]"])("rejects invalid CLI JSONC configuration: %s", async (contents) => {
     const root = await initializeInstance()
     artifacts.push(root)
     await expect(
       Effect.runPromise(prepareInstanceProject({
         artifacts: root,
         project: {
-          files: { ".opencode/tui.jsonc": "{ invalid" },
+          files: { ".opencode/cli.json": contents },
         },
       })),
-    ).rejects.toThrow("invalid .opencode/tui.jsonc")
+    ).rejects.toThrow("invalid .opencode/cli.json")
   })
 
   test("does not let setup mutate declarative configuration inputs", async () => {
     const root = await initializeInstance()
     artifacts.push(root)
     const config = { nested: { value: "declared" }, items: ["declared"] }
-    const tui = { keybinds: { app_exit: "ctrl+q" } }
+    const tui = { keybinds: { "app.exit": "ctrl+q" } }
 
     await Effect.runPromise(prepareInstanceProject({
       artifacts: root,
@@ -121,7 +142,7 @@ describe("instance configuration", () => {
           const keybinds = tuiConfig.keybinds as Record<string, string>
           nested.value = "setup"
           items.push("setup")
-          keybinds.app_exit = "ctrl+x"
+          keybinds["app.exit"] = "ctrl+x"
         })
       },
     }))
@@ -130,7 +151,7 @@ describe("instance configuration", () => {
       nested: { value: "declared" },
       items: ["declared"],
     })
-    expect(tui).toEqual({ keybinds: { app_exit: "ctrl+q" } })
+    expect(tui).toEqual({ keybinds: { "app.exit": "ctrl+q" } })
   })
 
   test("interrupts setup with project preparation", async () => {

--- a/packages/drive/test/instance/runtime.test.ts
+++ b/packages/drive/test/instance/runtime.test.ts
@@ -2,22 +2,93 @@ import { rm } from "node:fs/promises"
 import { resolve } from "node:path"
 import { NodeServices } from "@effect/platform-node"
 import { expect, it } from "@effect/vitest"
-import { ConfigProvider, Effect, Exit, Fiber } from "effect"
+import { ConfigProvider, Effect, Exit, Fiber, Schema } from "effect"
 import { initializeInstance } from "../../src/instance/instance.js"
-import * as OpenCodeInstance from "../../src/instance/runtime.js"
+import { OpenCodeInstance } from "../../src/instance/runtime.js"
+import { make } from "../../src/driver/opencode.js"
+import { discoverRegistration } from "../../src/instance/discovery.js"
 
 const fakeOpenCode = [
   process.execPath,
   resolve("test", "fixtures", "fake-opencode.ts"),
 ]
+const decodeConnection = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Struct({
+  argv: Schema.Array(Schema.String),
+  authenticated: Schema.Boolean,
+})))
+
+it.live("pins scripted TUIs and existing SDKs to the owned server across replacement", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const artifacts = yield* Effect.promise(() => initializeInstance())
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(artifacts, { recursive: true, force: true })))
+      const instance = yield* OpenCodeInstance.make({
+        artifacts,
+        name: "owned-server-test",
+        scripted: true,
+        command: fakeOpenCode,
+      })
+      yield* instance.launchServer
+      const sdk = yield* make(artifacts)
+      const before = yield* sdk.health.get()
+      const registration = yield* Effect.promise(() => discoverRegistration(`${artifacts}/home/.local/state`))
+      yield* instance.launchTui("retained")
+      const connection = yield* Effect.promise(() => Bun.file(`${artifacts}/client-connection.json`).text()).pipe(
+        Effect.flatMap(decodeConnection),
+      )
+      expect(connection.argv.slice(-2)).toEqual(["--server", registration?.url])
+      expect(connection.authenticated).toBe(true)
+      yield* instance.killServer
+      yield* instance.launchServer
+      const after = yield* sdk.health.get()
+      expect(after.healthy).toBe(true)
+      expect(after.pid).not.toBe(before.pid)
+      const replacement = yield* Effect.promise(() => discoverRegistration(`${artifacts}/home/.local/state`))
+      expect(replacement?.url).toBe(registration?.url)
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
+)
+
+it.live("preserves owned-port boot failures and permits launch after the overlap ends", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const artifacts = yield* Effect.promise(() => initializeInstance())
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(artifacts, { recursive: true, force: true })))
+      const instance = yield* OpenCodeInstance.make({
+        artifacts,
+        name: "occupied-server-test",
+        scripted: true,
+        command: fakeOpenCode,
+      })
+      yield* instance.launchServer
+      const sdk = yield* make(artifacts)
+      const registration = yield* Effect.promise(() => discoverRegistration(`${artifacts}/home/.local/state`))
+      if (registration === undefined) return yield* Effect.dieMessage("service registration missing")
+      yield* instance.killServer
+      const blocker = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            hostname: "127.0.0.1",
+            port: Number(new URL(registration.url).port),
+            fetch: () => new Response("occupied"),
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const failed = yield* instance.launchServer.pipe(Effect.exit)
+      expect(Exit.isFailure(failed)).toBe(true)
+      yield* Effect.promise(() => blocker.stop(true))
+      yield* instance.launchServer
+      expect((yield* sdk.health.get()).healthy).toBe(true)
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
+)
 
 it.live("stops a TUI while its readiness check is pending", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const artifacts = yield* Effect.promise(() => initializeInstance())
-      yield* Effect.addFinalizer(() =>
-        Effect.promise(() => rm(artifacts, { recursive: true, force: true })),
-      )
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(artifacts, { recursive: true, force: true })))
       const instance = yield* OpenCodeInstance.make({
         artifacts,
         name: "pending-client-test",
@@ -26,10 +97,7 @@ it.live("stops a TUI while its readiness check is pending", () =>
       })
 
       yield* instance.launchServer
-      const launch = yield* instance.launchTui("pending").pipe(
-        Effect.exit,
-        Effect.forkChild,
-      )
+      const launch = yield* instance.launchTui("pending").pipe(Effect.exit, Effect.forkChild)
       yield* Effect.sleep(100)
 
       const started = Date.now()
@@ -40,13 +108,48 @@ it.live("stops a TUI while its readiness check is pending", () =>
   ).pipe(Effect.provide(NodeServices.layer)),
 )
 
+it.live("keeps chaos TUIs on the proxy and non-scripted launches managed", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const artifacts = yield* Effect.promise(() => initializeInstance())
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(artifacts, { recursive: true, force: true })))
+      const instance = yield* OpenCodeInstance.make({
+        artifacts,
+        name: "proxy-server-test",
+        scripted: true,
+        command: fakeOpenCode,
+        network: true,
+      })
+      yield* instance.launchServer
+      yield* instance.launchTui("proxy")
+      const connection = yield* Effect.promise(() => Bun.file(`${artifacts}/client-connection.json`).text()).pipe(
+        Effect.flatMap(decodeConnection),
+      )
+      expect(connection.argv.slice(-2)).toEqual(["--server", instance.network?.url])
+      expect(connection.authenticated).toBe(true)
+      yield* instance.stop
+
+      const managedArtifacts = yield* Effect.promise(() => initializeInstance())
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(managedArtifacts, { recursive: true, force: true })))
+      const managed = yield* OpenCodeInstance.make({
+        artifacts: managedArtifacts,
+        name: "managed-server-test",
+        command: fakeOpenCode,
+      })
+      yield* managed.waitForDrive()
+      const managedConnection = yield* Effect.promise(() =>
+        Bun.file(`${managedArtifacts}/client-connection.json`).text(),
+      ).pipe(Effect.flatMap(decodeConnection))
+      expect(managedConnection.argv).not.toContain("--server")
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
+)
+
 it.live("reads the database target from Effect config", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const artifacts = yield* Effect.promise(() => initializeInstance())
-      yield* Effect.addFinalizer(() =>
-        Effect.promise(() => rm(artifacts, { recursive: true, force: true })),
-      )
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(artifacts, { recursive: true, force: true })))
       const instance = yield* OpenCodeInstance.make({
         artifacts,
         name: "database-config-test",

--- a/packages/drive/test/manual/probe-success-guards.ts
+++ b/packages/drive/test/manual/probe-success-guards.ts
@@ -1,0 +1,42 @@
+import { Effect, Stream } from "effect"
+import { defineScript, Llm } from "../../src/index.js"
+import type { ScriptContext } from "../../src/script/types.js"
+import pending from "./tui-regressions/pending-form-restart.js"
+import reconnect from "./tui-regressions/reconnect-modal-submit.js"
+
+// Expected failure: run the actual recovery/resend probes, but make their
+// model emit the visible completion marker followed by a terminal filter.
+// Idleness and a stable screen must not let this become a passing probe.
+const scenario = process.env.OPENCODE_DRIVE_GUARD_CASE ?? "form"
+if (scenario !== "form" && scenario !== "reconnect") throw new Error("unknown guard case")
+
+export default scenario === "form"
+  ? defineScript({
+      ...pending,
+      run: (context) =>
+        pending.run({ ...context, llm: failAfterMarker(context.llm, "restart-form-recovery-complete") }),
+    })
+  : defineScript({
+      ...reconnect,
+      run: (context) => reconnect.run({ ...context, llm: failAfterMarker(context.llm, "SECOND_DONE") }),
+    })
+
+function failAfterMarker(llm: ScriptContext["llm"], marker: string): ScriptContext["llm"] {
+  return {
+    ...llm,
+    serve: (handler) =>
+      llm.serve((request, index) => {
+        let emitted = false
+        return handler(request, index).pipe(
+          Stream.tap((output) =>
+            Effect.sync(() => {
+              if (output.type === "text" && output.text === marker) emitted = true
+            }),
+          ),
+          Stream.concat(
+            Stream.unwrap(Effect.sync(() => (emitted ? Stream.make(Llm.finish("content-filter")) : Stream.empty))),
+          ),
+        )
+      }),
+  }
+}

--- a/packages/drive/test/manual/service-restart-ownership.ts
+++ b/packages/drive/test/manual/service-restart-ownership.ts
@@ -1,0 +1,87 @@
+import { defineScript, Llm } from "../../src/index.js"
+import { Config, Effect, Option, Schedule, Schema, Stream } from "effect"
+
+const Registration = Schema.Struct({ pid: Schema.Number, url: Schema.String })
+const decodeRegistration = Schema.decodeUnknownEffect(Schema.fromJsonString(Registration))
+
+export default defineScript({
+  launch: "manual",
+  run: ({ server, tuis, llm, artifacts }) =>
+    Effect.gen(function* () {
+      const cycles = yield* Config.int("OPENCODE_DRIVE_RESTART_CYCLES").pipe(Config.withDefault(1))
+      const outage = yield* Config.int("OPENCODE_DRIVE_RESTART_GATE_MS").pipe(Config.withDefault(10_000))
+      const registration = Effect.tryPromise(() =>
+        Bun.file(`${artifacts}/home/.local/state/opencode/service-local.json`).text(),
+      ).pipe(Effect.flatMap(decodeRegistration), Effect.option)
+      const evidence: Array<unknown> = []
+      const save = () =>
+        Effect.promise(() => Bun.write(`${artifacts}/restart-ownership.json`, JSON.stringify(evidence, null, 2)))
+      const original = yield* server.launch()
+      const initial = yield* original.health.get()
+      let response = "restart-ownership-ready"
+      yield* llm.serve(() => Stream.make(Llm.text(response)))
+      const tui = yield* tuis.launch("ownership")
+      yield* tui.ui.submit("Establish the restart ownership fixture")
+      yield* tui.ui.waitFor("restart-ownership-ready")
+
+      yield* Effect.forEach(
+        Array.from({ length: cycles }, (_, index) => index),
+        (cycle) =>
+          Effect.gen(function* () {
+            const before = yield* original.health.get()
+            const registered = yield* registration
+            yield* server.kill()
+            yield* tui.ui.waitFor("Connection lost", { timeout: 5_000 })
+            // Hold the Drive replacement at a known boundary while reconnects run.
+            const elected = yield* registration.pipe(
+              Effect.filterOrFail((value) => Option.isSome(value) && value.value.pid !== before.pid),
+              Effect.retry(Schedule.spaced(50)),
+              Effect.timeoutOption(outage),
+            )
+            if (Option.isSome(elected)) {
+              evidence.push({
+                cycle,
+                phase: "owned-server-down",
+                before,
+                registered,
+                elected: elected.value,
+              })
+              yield* save()
+              return yield* Effect.fail(new Error("TUI elected a replacement while the script server was stopped"))
+            }
+            const replacement = yield* server.launch()
+            const current = yield* replacement.health.get()
+            const oldClient = yield* original.health.get()
+            const after = yield* registration
+            evidence.push({
+              cycle,
+              before,
+              registered,
+              current,
+              oldClient,
+              after,
+            })
+            yield* save()
+            if (current.pid === before.pid || oldClient.pid !== current.pid)
+              return yield* Effect.fail(new Error("SDK did not reach the owned replacement server"))
+            if (Option.isNone(registered) || Option.isNone(after) || registered.value.url !== after.value.url)
+              return yield* Effect.fail(new Error("script server endpoint changed across restart"))
+            yield* tui.ui.waitFor((state) => state.focused.editor, {
+              timeout: 20_000,
+            })
+            response = `owned-replacement-${cycle}`
+            yield* tui.ui.submit(`Verify owned replacement ${cycle}`)
+            yield* tui.ui.waitFor(response)
+          }),
+      )
+      console.log(
+        JSON.stringify({
+          verdict: "pass",
+          cycles,
+          outage,
+          initialPID: initial.pid,
+          evidence,
+        }),
+      )
+    }),
+})

--- a/packages/drive/test/manual/tui-regressions/README.md
+++ b/packages/drive/test/manual/tui-regressions/README.md
@@ -47,12 +47,22 @@ Relative database paths resolve under the isolated run's OpenCode data directory
 
 ```sh
 bun run --cwd packages/drive drive check test/manual/tui-regressions/pending-form-restart.ts
-bun run --cwd packages/drive drive start --name tui-pending-form-restart \
+OPENCODE_DRIVE_DB=form-restart.sqlite bun run --cwd packages/drive drive start --name tui-pending-form-restart \
   --script test/manual/tui-regressions/pending-form-restart.ts \
   --dev "$OPENCODE_DEV"
 ```
 
-The desired invariant is that the form either remains answerable or is dismissed as stale. If a retained form accepts local input but submission returns `Form not found`, the probe fails and preserves `stale-form.frame.json`. Current V2 dismisses the stale form and passes this probe.
+Form state is process-local in current V2. This probe requires a file-backed
+`OPENCODE_DRIVE_DB`, serves the model request made by durable restart recovery,
+and verifies that the old question settles as interrupted, the stale form is
+dismissed, the recovery continuation is projected, and the composer and terminal
+settle without another user admission. It does not silently return as soon as the
+old form disappears, leaving an unexpected recovery request unserved. Failures
+retain the frame and projected messages in `state-machine-failure.json`.
+
+Idle is not successful settlement: `Session.wait` waits for idleness even after a
+failure. This probe also requires `Session.outcome` to be `succeeded` and the
+recovery output to exist in durable assistant content.
 
 ## Reconnect outage
 
@@ -67,6 +77,54 @@ OPENCODE_DRIVE_OUTAGE_MS=20000 bun run --cwd packages/drive drive start \
 
 The desired invariant is that the TUI remains alive and returns to an actionable composer after the service relaunches. Current V2 passes with both 20-second and 60-second isolated outages. Increase the outage to model slower update election and cold location startup.
 
+## Script-owned restart
+
+Scripted TUIs connect explicitly to Drive's owned server endpoint, even without
+network chaos. A retained TUI must not elect an unowned managed service while
+`server.kill()` and `server.launch()` control replacement. The owned HTTP URL and
+existing credential remain stable across generations; non-scripted live
+launches keep their managed behavior.
+
+The ownership probe holds replacement at a known ten-second boundary and
+inspects registration without reading or printing credentials:
+
+```sh
+OPENCODE_DRIVE_RESTART_CYCLES=3 OPENCODE_DRIVE_RESTART_GATE_MS=10000 \
+  bun run --cwd packages/drive drive start --daemon --name restart-ownership \
+    --script test/manual/service-restart-ownership.ts \
+    --dev "$OPENCODE_DEV"
+```
+
+It requires no competing registration while stopped, the retained SDK reaching
+the explicitly launched replacement PID at the same URL, and a subsequent real
+TUI reply. `quiescence-restart.ts` separately covers file-backed recovery and
+terminal stability. An occupied owned port remains a visible boot failure; this
+is not a generic port-retry policy.
+
+## Tool transport death
+
+`tool-transport-death.ts` is a one-shot Effect program, not a `defineScript`
+module. `run` typechecks its fully provided program contract before execution:
+
+```sh
+OPENCODE_DEV="$OPENCODE_DEV" OPENCODE_DRIVE_MEDIA_DIR="$PWD/.drive-output" \
+  bun run --cwd packages/drive drive run \
+    test/manual/tui-regressions/tool-transport-death.ts
+```
+
+The internal scoped fixture routes one real static-tool HTTP connection through
+Drive's existing TCP proxy. It establishes Core's event subscription before
+progress, verifies the exact ephemeral `session.tool.progress` payload, and
+drops the established connection. Running progress is not durable
+`message.list` metadata. The native held-call interruption must arrive, a late
+success must be rejected, exactly one tool part must settle in error, the model
+must continue, and the terminal must become stable without another user prompt.
+
+The probe no longer requires manually lowering controller idle timeouts or
+removing the long-running `/execute` exemption. It does not synthesize a
+cancellation result or change the public tool API. The invocation requires an
+explicit `OPENCODE_DEV` so it cannot fall back to an installed service.
+
 ## Seeded lifecycle simulation
 
 `lifecycle-properties.ts` uses the live OpenCode event stream and a queue-backed simulated response to select deterministic mid-flight actions. Submit, queued submit, text emission, reasoning emission, tool-input streaming, tool execution, completion, interruption, and provider disconnect are separate model transitions. A failure preserves its seed, action trace, model state, recent session events, and terminal frame in `state-machine-failure.json`:
@@ -78,7 +136,32 @@ OPENCODE_DRIVE_SEED=42 OPENCODE_DRIVE_STEPS=20 \
   --dev "$OPENCODE_DEV"
 ```
 
-Re-run a failure with the same seed and step count. Transition preconditions constrain actions to valid idle, pending, streaming, tool-input, and running-tool states. Tool input is chunked so interruption can occur before parsing completes; advancing the tool response dispatches a blocking question tool so interruption can also occur during execution. Interrupted tool parts must settle with an aborted error in the server projection. A queued prompt must have exactly one owner across pending input and projected history. Completion can promote it into the next model step, interruption can leave it awaiting resume, and provider failure can promote it into a replacement execution. Shared invariants also require the latest prompt and settled output to remain visible, the server projection to retain the active prompt, the composer to become actionable after terminal execution, and internal transport defects to stay out of the UI.
+Re-run a failure with the same seed and step count. Transition preconditions
+constrain actions to valid idle, pending, streaming, tool-input, and running-tool
+states. Tool input is chunked so interruption can occur before parsing completes;
+advancing the response dispatches a blocking question tool so interruption can
+also occur during execution. Interrupted tool parts must settle with an aborted
+error in the server projection. A queued prompt must have exactly one owner
+across pending input and projected history. Completion can promote it into the
+next model Step; interruption can leave it awaiting resume.
+
+`provider-disconnect-and-retry` injects one failure per logical Step, waits for
+the actual `session.retry.scheduled` fact, and drives the replacement physical
+attempt instead of waiting for terminal failure. Pre-output retry retains the
+logical Step; incomplete-stream continuation may persist partial output across
+assistant messages, so content assertions search the projected parts rather than
+assuming one physical message. Queued input remains owned while recovery runs.
+This case tests recovery, not retry-budget exhaustion, and its precondition makes
+that limit explicit. Core's retry-policy tests cover exhaustion separately.
+
+Text and reasoning emission now require a live delta from a complete single
+burst while the stream remains open. They do not inject a later sentinel to
+mask unbounded batching. Run against a V2 revision with the bounded stream-flush
+fix; an older revision can correctly fail at this desired-behavior checkpoint.
+Shared invariants also require the latest prompt and settled output to remain
+visible, the server projection to retain the active prompt, the composer to
+become actionable after terminal execution, and internal transport defects to
+stay out of the UI.
 
 Interruption uses the existing `llm.pending` simulation capability. If OpenCode rejects a response write after terminating the invocation, Drive confirms that the invocation is no longer pending and settles the response as externally terminated. If the invocation remains pending or the query fails, Drive preserves the original write failure.
 
@@ -130,8 +213,17 @@ bun run --cwd packages/drive drive start --name tui-type-during-submit \
 Companion probes that ruled out the other hypotheses: `steer-enter-drop.ts`
 (steers at 0-1800ms into a clean-network stream are never dropped),
 `heal-submit-drop.ts` (blackhole-heal-submit alone does not drop the prompt),
-and `reconnect-modal-submit.ts` (classifies submits into the reconnect
-overlay).
+and `reconnect-modal-submit.ts` (asserts transport rejection in the current
+`Connection lost` overlay, draft restoration in the actual composer, zero pending
+and projected owners at a healed observation checkpoint, and exactly-once
+successful settlement after explicit resend).
+
+A refused connection can reject model preparation before any prompt POST is
+attempted; this proves send-path rejection, not prompt-POST arrival. The TCP
+probe samples both owners in the captured Session before Enter, and requires a
+successful execution outcome afterward. It does not prove the absence of
+arbitrarily delayed automatic resends beyond that checkpoint; causal retry
+ordering belongs at the focused client/prompt admission seam.
 
 With optimistic session creation (opencode PR #43687) the contract changed:
 enter navigates immediately, the mid-flight typing lands in the live session
@@ -140,6 +232,27 @@ asserts both prompts are admitted exactly once and in submission order. When
 both are admitted before the run starts, opencode batches them into a single
 turn, so only the LAST marker's reply appears on screen — admissions are the
 ground truth, not done markers.
+
+## Successful Outcome Guards
+
+The recovery and resend probes require a successful execution outcome, not just
+an idle Session with a visible completion marker. The pressure fixture runs those
+actual probes with their model output followed by a terminal content filter:
+
+```sh
+OPENCODE_DRIVE_DB=guard-pressure.sqlite OPENCODE_DRIVE_GUARD_CASE=form \
+  bun run --cwd packages/drive drive start --daemon --name form-outcome-guard \
+    --script test/manual/probe-success-guards.ts --dev "$OPENCODE_DEV"
+OPENCODE_DRIVE_GUARD_CASE=reconnect \
+  bun run --cwd packages/drive drive start --daemon --name resend-outcome-guard \
+    --script test/manual/probe-success-guards.ts --dev "$OPENCODE_DEV"
+```
+
+Both are **expected failures** at the successful-outcome assertion: the marker
+can render and the terminal can settle even though `Session.outcome` is `failed`.
+Keep these negative controls separate from ordinary gauntlet passes. The fixture
+decorates only the model stream; it does not replace the production probe's
+submission, recovery, or validation logic.
 
 ## Optimistic session creation
 
@@ -157,6 +270,116 @@ tab (a closed tab resurrected by a late lock-serialized registration write).
 Both probes sleep 1.5s after ready before degrading the network: startup
 catalog loads racing the chaos proxy trip the model-readiness guard and the
 submit never reaches session creation.
+
+## Compaction admission
+
+`compact-admission.ts` exercises OpenCode PR #45973 through the production TUI
+and real isolated server. A blackhole gates the TUI's model setup and admission
+traffic; the clean SDK inspects durable history and can advance or cancel an
+existing control item independently. Run each case separately at narrow and wide
+sizes:
+
+```sh
+bun run --cwd packages/drive drive check test/manual/tui-regressions/compact-admission.ts
+for scenario in ordered coalesce consumed cancelled rollback; do
+  for cols in 70 120; do
+    OPENCODE_DRIVE_MEDIA_DIR="$PWD/.drive-output" \
+    OPENCODE_DRIVE_COMPACT_CASE="$scenario" OPENCODE_DRIVE_COLS="$cols" \
+      bun run --cwd packages/drive drive start --daemon \
+        --name "compact-$scenario-$cols" \
+        --script test/manual/tui-regressions/compact-admission.ts \
+        --dev "$OPENCODE_DEV" || exit 1
+  done
+done
+```
+
+`--daemon` keeps the script owner in the foreground so the loop observes its
+completion and exit status. Successful runs print `verdict: "pass"`; failures
+preserve their case, viewport, checkpoint trace, server events, messages, inbox,
+and terminal frame in `state-machine-failure.json`.
+
+| Case        | Invariant                                                                                                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ordered`   | Render exactly one queued row during the partition, despite repeated gestures. Render a following prompt locally, then admit it exactly once after compaction.                                                   |
+| `coalesce`  | An unseen server-side queued compaction replaces the speculative ID without a duplicate row. A following admission provides a send-chain barrier before checking reconciliation.                                 |
+| `consumed`  | A known queued ID completes while model setup is blocked. Submit a fresh control ID after healing; with no new history it settles as `compaction.unavailable`, not a conflict, with no queued row remaining.     |
+| `cancelled` | Cancellation removes the known pending item while setup is blocked. The client still proposes a fresh compaction ID and completes it after healing; cancellation itself does not permanently reserve the old ID. |
+| `rollback`  | Killing connections before admission removes the unacknowledged row and displays the transport error. After healing, retry compaction and submit a recovery prompt successfully.                                 |
+
+The simulated model paces a busy-step checkpoint before holding the response
+open; this isolates admission behavior from stream-publication behavior. The
+bounded-flush tests separately verify complete single bursts without a later
+sentinel. Assertions distinguish durable admission from model execution,
+including a legitimately unavailable second compaction.
+
+This TCP-level probe checks queued checkpoints and settled convergence; it does
+not establish continuous absence of transient rows, force every HTTP-response/SSE
+permutation, or count raw mutation RPCs. OpenCode's
+`packages/client/test/solid-compaction.test.ts` covers deferred-response
+interleavings, positive pending-read acknowledgements, listener ownership, and
+cross-session observation isolation.
+
+## Open picker
+
+`open-picker.ts` exercises OpenCode PR #45977 against a real isolated server and
+the production TUI. SDK-created sessions exist before frontend launch, so the
+initial picker cannot rely on open tabs or event-hydrated metadata. A second Git
+project supplies a distinct placement target. Run each case at narrow and wide
+sizes; repeat from fresh instances rather than carrying state between cases:
+
+```sh
+bun run --cwd packages/drive drive check test/manual/tui-regressions/open-picker.ts
+for scenario in cold warm dispose selection deletion failure; do
+  for cols in 44 100; do
+    OPENCODE_DRIVE_MEDIA_DIR="$PWD/.drive-output" \
+    OPENCODE_DRIVE_OPEN_CASE="$scenario" OPENCODE_DRIVE_COLS="$cols" \
+      bun run --cwd packages/drive drive start --daemon \
+        --name "open-picker-$scenario-$cols" \
+        --script test/manual/tui-regressions/open-picker.ts \
+        --dev "$OPENCODE_DEV" || exit 1
+  done
+done
+```
+
+| Case | Invariant |
+| --- | --- |
+| `cold` | With both reads blackholed, show an actionable loading shell instead of a false empty result; Escape dismisses it and healing does not reopen it. |
+| `warm` | Retained cached-only rows remain selectable while blackholed; repeated Ctrl-O preserves the input and selected identity. A committed move received while dismissed must affect the local inherited location before any correcting GET can complete. |
+| `dispose` | Disposing a pending refresh and reopening preserves the new filter and the latest retained row titles after healing. |
+| `selection` | A newer recent row arriving during refresh does not change the selected session; a subsequent real prompt must be admitted into the intended session. |
+| `deletion` | Observed server deletion removes the open row and the retained row used by a later blackholed opening. |
+| `failure` | Failed reads report an inline error while retaining usable rows; healthy reopening clears the error and selection still targets the right session. |
+
+The SDK and UI RPC channel stay clean; only TUI HTTP/SSE crosses the TCP proxy.
+There is no selected-row semantic surface in `DialogSelect`, so the probe uses
+real interactive row positions for keyboard navigation and verifies Enter's
+destination through exactly-once prompt admission in the server projection.
+Filtering may put a matching project before a session; the probe does not assume
+an exact-title match must rank first. The movement case uses a later visible
+rename as an ordered-SSE receipt barrier, then inspects the new-session footer
+while blackholed and verifies the new Session's actual inherited placement after
+healing.
+
+Drive writes current V2 `cli.json` under its isolated `OPENCODE_CONFIG_DIR`.
+The probe expresses `session.new_location: "inherit"` and a `Ctrl-N` binding
+through `tuiConfig`, making the movement check an explicit fixture contract
+without a manual config-file workaround or installed-client changes. Fixture
+sessions also select the simulation model and build agent explicitly.
+
+Successful runs write `open-picker-report.json` and print `passed: true`.
+Failures retain the case, viewport, marker seed, checkpoint trace, server
+sessions/messages, and terminal frame in `state-machine-failure.json`. The seed
+labels prompts; this is a deterministic case suite, not randomized state-machine
+coverage.
+
+TCP-level checks do not force older/newer GET response order or independently
+gate sessions and projects. OpenCode's production-component tests in
+`packages/tui/test/app-lifecycle.test.tsx` and
+`packages/tui/test/cli/tui/dialog-open.test.tsx` cover those exact read/event
+interleavings, including deletion resurrection, movement during a read, uncached
+moved rows, and filtered selection remaining visible after an overflowing
+refresh. The Drive cases establish their stated checkpoints and convergence,
+not continuous absence of transient rows.
 
 ## Probe helpers
 

--- a/packages/drive/test/manual/tui-regressions/compact-admission.ts
+++ b/packages/drive/test/manual/tui-regressions/compact-admission.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict"
+import { Deferred, Effect, Stream } from "effect"
+import { defineScript, Llm } from "../../../src/index.js"
+import { latestSessionId, settled } from "./support.js"
+import { saveFailure } from "./state-machine.js"
+
+// Run each scenario independently so a failed checkpoint cannot mask later cases.
+const scenario = process.env.OPENCODE_DRIVE_COMPACT_CASE ?? "ordered"
+const cols = Number(process.env.OPENCODE_DRIVE_COLS ?? 100)
+
+export default defineScript({
+  network: true,
+  project: { git: true, files: { "README.md": "# Admission fixture\n" } },
+  config: { autoupdate: false, username: "Drive" },
+  tui: { viewport: { cols, rows: 36 } },
+  llm: { settlementTimeout: 60_000 },
+  run: ({ ui, llm, network, opencode, artifacts }) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        assert(
+          ["ordered", "coalesce", "consumed", "cancelled", "rollback"].includes(scenario),
+          "unknown compaction case",
+        )
+        const hold = yield* Deferred.make<void>()
+        const trace: string[] = []
+        const events: Array<Stream.Success<ReturnType<typeof opencode.event.subscribe>>> = []
+        const checkpoint = (name: string) => {
+          trace.push(name)
+          console.error(JSON.stringify({ scenario, cols, checkpoint: name }))
+        }
+        const messages = (sessionID: Effect.Success<ReturnType<typeof latestSessionId>>) =>
+          opencode.message.list({ sessionID, limit: 100, order: "asc" }).pipe(Effect.map((result) => result.data))
+        const context = {
+          ui,
+          artifacts,
+          evidence: () =>
+            latestSessionId(opencode).pipe(
+              Effect.flatMap((sessionID) =>
+                Effect.all({
+                  events: Effect.succeed(events),
+                  messages: messages(sessionID),
+                  inbox: opencode.session.inbox.list({ sessionID }),
+                }),
+              ),
+            ),
+        }
+        yield* opencode.event.subscribe().pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event)
+            }),
+          ),
+          Effect.forkScoped,
+        )
+        yield* llm.serve((request) => {
+          const body = JSON.stringify(request.body)
+          if (body.includes("title generator")) return Stream.make(Llm.text("Admission fixture"))
+          if (body.includes("Create a new anchored summary") || body.includes("Update the anchored summary below"))
+            return Stream.make(Llm.text("The fixture README was inspected."))
+          // History includes previous markers. Only the newest prompt selects a reply.
+          const marker = ["CA_WARM", "CA_HOLD", "CA_NEXT"].reduce((latest, candidate) =>
+            body.lastIndexOf(candidate) > body.lastIndexOf(latest) ? candidate : latest,
+          )
+          // Pace the busy-step checkpoint independently of stream-publication behavior.
+          if (marker === "CA_HOLD")
+            return Stream.make(Llm.text("CA_HOLD_WORKING "), Llm.pause(150), Llm.text("waiting ")).pipe(
+              Stream.concat(Stream.fromEffect(Deferred.await(hold).pipe(Effect.as(Llm.text("CA_HOLD_DONE"))))),
+            )
+          return Stream.make(Llm.text(`${marker}_DONE`))
+        })
+
+        yield* Effect.gen(function* () {
+          yield* ui.submit("CA_WARM inspect the README")
+          yield* ui.waitFor("CA_WARM_DONE", { timeout: 20_000 })
+          const sessionID = yield* latestSessionId(opencode)
+          yield* opencode.session.wait({ sessionID })
+          assert((yield* settled(ui)).stable, "warmup did not settle")
+          const compactions = messages(sessionID).pipe(
+            Effect.map((rows) => rows.filter((row) => row.type === "compaction")),
+          )
+          const enqueued = () =>
+            events
+              .filter((event) => event.type === "session.inbox.enqueued")
+              .filter((event) => event.data.sessionID === sessionID)
+          const queuedRows = ui.capture().pipe(
+            Effect.map(
+              (frame) =>
+                (
+                  frame.lines
+                    .map((line) => line.spans.map((span) => span.text).join(""))
+                    .join("\n")
+                    .match(/Compaction queued/g) ?? []
+                ).length,
+            ),
+          )
+          const converge = (statuses: ReadonlyArray<"completed" | "failed">) =>
+            Effect.gen(function* () {
+              yield* until(
+                compactions,
+                (rows) => rows.length === statuses.length && rows.every((row, index) => row.status === statuses[index]),
+                "settled compactions",
+              )
+              yield* opencode.session.wait({ sessionID })
+              yield* ui.waitFor(() => queuedRows.pipe(Effect.map((count) => count === 0)), { timeout: 20_000 })
+              assert.equal((yield* opencode.session.inbox.list({ sessionID })).length, 0, "server inbox did not drain")
+              assert((yield* settled(ui)).stable, "terminal did not settle")
+              assert.deepEqual(
+                (yield* compactions).map((row) => row.status),
+                statuses,
+                "extra compaction after settlement",
+              )
+              yield* ui.waitFor((state) => state.focused.editor)
+              yield* ui.screenshot(`${scenario}-settled`)
+            })
+
+          if (scenario === "ordered" || scenario === "rollback") {
+            checkpoint("blackhole-before-model-setup")
+            yield* network.set({ blackhole: true })
+            yield* ui.submit("/compact")
+            yield* ui.waitFor("Compaction queued")
+            yield* ui.submit("/compact")
+            assert.equal(yield* queuedRows, 1, "repeat gesture duplicated the speculative row")
+            assert.equal(
+              (yield* opencode.session.inbox.list({ sessionID })).length,
+              0,
+              "admission crossed the partition",
+            )
+            assert.equal((yield* compactions).length, 0, "compaction executed before admission")
+            yield* ui.screenshot(`${scenario}-pending`)
+
+            if (scenario === "rollback") {
+              checkpoint("kill-before-admission")
+              yield* network.set({ blackhole: true, refuseNew: true })
+              yield* network.killConnections()
+              yield* ui.waitFor("Transport", { timeout: 15_000 })
+              assert.equal(yield* queuedRows, 0, "unacknowledged row survived rejection")
+              assert.equal((yield* compactions).length, 0, "failed request created a compaction")
+              yield* ui.screenshot("rollback-error")
+              yield* network.clear()
+              yield* ui.waitFor((state) => state.focused.editor, {
+                timeout: 30_000,
+              })
+              checkpoint("retry-after-heal")
+              yield* ui.submit("/compact")
+              yield* converge(["completed"])
+              yield* ui.submit("CA_NEXT recovery prompt")
+              yield* ui.waitFor("CA_NEXT_DONE", { timeout: 20_000 })
+              yield* converge(["completed"])
+            }
+
+            if (scenario === "ordered") {
+              checkpoint("following-prompt-before-heal")
+              yield* ui.submit("CA_NEXT following prompt")
+              yield* ui.waitFor("CA_NEXT following prompt")
+              assert(
+                !(yield* messages(sessionID)).some((row) => row.type === "user" && row.text.includes("CA_NEXT")),
+                "following prompt crossed the partition",
+              )
+              yield* network.clear()
+              yield* ui.waitFor("CA_NEXT_DONE", { timeout: 30_000 })
+              yield* converge(["completed"])
+              const admissions = enqueued()
+              const compactIndex = admissions.findIndex((event) => event.data.item.type === "compaction")
+              const promptIndex = admissions.findIndex(
+                (event) => event.data.item.type === "user" && event.data.item.payload.text.includes("CA_NEXT"),
+              )
+              assert(compactIndex >= 0 && promptIndex > compactIndex, "following prompt overtook compaction admission")
+            }
+            const users = (yield* messages(sessionID)).filter(
+              (row) => row.type === "user" && row.text.includes("CA_NEXT"),
+            )
+            assert.equal(users.length, 1, "following prompt was lost or admitted twice")
+            assert.equal(
+              enqueued().filter((event) => event.data.item.type === "compaction").length,
+              1,
+              "repeat gesture issued another admission",
+            )
+            checkpoint("verified")
+            return
+          }
+
+          checkpoint("hold-active-step")
+          yield* ui.submit("CA_HOLD keep this step open")
+          yield* ui.waitFor("CA_HOLD_WORKING", { timeout: 20_000 })
+          if (scenario === "coalesce") yield* network.set({ blackhole: true })
+          const canonical = yield* opencode.session.compact({ sessionID })
+          assert.deepEqual(
+            (yield* opencode.session.inbox.list({ sessionID })).map((row) => row.id),
+            [canonical.id],
+          )
+          if (scenario !== "coalesce") {
+            yield* ui.waitFor("Compaction queued")
+            yield* network.set({ blackhole: true })
+          }
+          checkpoint("submit-while-model-setup-blocked")
+          yield* ui.submit("/compact")
+          yield* ui.waitFor("Compaction queued")
+          assert.equal(yield* queuedRows, 1, "known canonical and speculative rows were both shown")
+
+          if (scenario === "coalesce") {
+            checkpoint("heal-with-canonical-still-pending")
+            yield* network.clear()
+            // A following prompt is a send-chain barrier: when it reaches the
+            // server, the TUI's compaction POST has settled and reconciled its ID.
+            yield* ui.submit("CA_NEXT coalescing barrier")
+            yield* until(
+              opencode.session.inbox.list({ sessionID }),
+              (rows) => rows.some((row) => row.type === "user" && row.payload.text.includes("CA_NEXT")),
+              "following admission",
+            )
+            assert.equal(yield* queuedRows, 1, "canonical response left duplicate queued rows")
+            assert.deepEqual(
+              (yield* opencode.session.inbox.list({ sessionID }))
+                .filter((row) => row.type === "compaction")
+                .map((row) => row.id),
+              [canonical.id],
+            )
+            yield* Deferred.succeed(hold, undefined)
+            yield* ui.waitFor("CA_NEXT_DONE", { timeout: 30_000 })
+            yield* converge(["completed"])
+            assert.equal((yield* compactions)[0]?.id, canonical.id, "canonical ID was not retained")
+          }
+
+          if (scenario === "consumed" || scenario === "cancelled") {
+            checkpoint(`${scenario}-before-heal`)
+            if (scenario === "cancelled")
+              yield* opencode.session.inbox.cancel({
+                sessionID,
+                inboxID: canonical.id,
+              })
+            yield* Deferred.succeed(hold, undefined)
+            yield* opencode.session.wait({ sessionID })
+            assert.equal((yield* compactions).length, scenario === "consumed" ? 1 : 0)
+            assert.equal((yield* opencode.session.inbox.list({ sessionID })).length, 0)
+            // The TUI still knows the old queued ID. The client proposes a
+            // fresh ID when that item completes or is removed during setup.
+            yield* network.clear()
+            // With no new history, the second operation is durably admitted but
+            // legitimately unavailable. It must not conflict or return to queued.
+            yield* converge(scenario === "consumed" ? ["completed", "failed"] : ["completed"])
+            if (scenario === "consumed") {
+              const failed = (yield* compactions).find((row) => row.status === "failed")
+              assert.equal(failed?.error.type, "compaction.unavailable")
+              yield* ui.waitFor("Nothing to compact yet")
+            }
+            assert(
+              (yield* compactions).some((row) => row.id !== canonical.id),
+              "new compaction did not use a fresh control ID",
+            )
+            assert.equal(enqueued().filter((event) => event.data.item.type === "compaction").length, 2)
+          }
+          checkpoint("verified")
+        }).pipe(
+          Effect.catchCause((cause) =>
+            saveFailure(context, { scenario, cols, trace }).pipe(Effect.andThen(Effect.failCause(cause))),
+          ),
+          Effect.ensuring(Deferred.succeed(hold, undefined).pipe(Effect.andThen(network.clear()), Effect.orDie)),
+        )
+        console.log(JSON.stringify({ scenario, cols, trace, verdict: "pass" }))
+      }),
+    ),
+})
+
+function until<A, E>(read: Effect.Effect<A, E>, predicate: (value: A) => boolean, label: string) {
+  return Effect.gen(function* () {
+    while (true) {
+      const value = yield* read
+      if (predicate(value)) return value
+      yield* Effect.sleep(50)
+    }
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: 20_000,
+      orElse: () => Effect.fail(new Error(`timed out waiting for ${label}`)),
+    }),
+  )
+}

--- a/packages/drive/test/manual/tui-regressions/lifecycle-properties.ts
+++ b/packages/drive/test/manual/tui-regressions/lifecycle-properties.ts
@@ -1,7 +1,8 @@
 import { defineScript, Llm } from "../../../src/index.js"
 import type { OpenCode } from "../../../src/index.js"
 import { Deferred, Effect, Queue, Stream } from "effect"
-import { run } from "./state-machine.js"
+import { run, saveFailure } from "./state-machine.js"
+import type { Transition } from "./state-machine.js"
 
 const seed = readInteger("OPENCODE_DRIVE_SEED", 1, Number.MAX_SAFE_INTEGER)
 const steps = readInteger("OPENCODE_DRIVE_STEPS", 12, 1_000)
@@ -33,6 +34,7 @@ type Model =
       readonly prompt: string
       readonly output?: string
       readonly reasoning?: string
+      readonly retried?: boolean
       readonly queuedPrompt?: string
       readonly tool?: {
         readonly callID: string
@@ -42,9 +44,7 @@ type Model =
       }
     }
 
-type SessionID = Effect.Success<
-  ReturnType<OpenCode["session"]["list"]>
->["data"][number]["id"]
+type SessionID = Effect.Success<ReturnType<OpenCode["session"]["list"]>>["data"][number]["id"]
 
 interface ResponseControl {
   readonly id: string
@@ -54,582 +54,564 @@ interface ResponseControl {
 
 export default defineScript({
   run: ({ ui, llm, opencode, artifacts }) =>
-    Effect.scoped(Effect.gen(function* () {
-      const responses = yield* Queue.unbounded<ResponseControl>()
-      const eventQueue = yield* Queue.unbounded<RecordedEvent>()
-      const events: Array<RecordedEvent> = []
-      let activeResponse: ResponseControl | undefined
-      let eventSequence = 0
+    Effect.scoped(
+      Effect.gen(function* () {
+        const responses = yield* Queue.unbounded<ResponseControl>()
+        const eventQueue = yield* Queue.unbounded<RecordedEvent>()
+        const events: Array<RecordedEvent> = []
+        const trace: Array<{ step: number; transition: string }> = []
+        const context = { ui, artifacts, evidence: () => Effect.succeed({ events }) }
+        let activeResponse: ResponseControl | undefined
+        let eventSequence = 0
 
-      yield* llm.serve((request) =>
-        Stream.unwrap(Effect.gen(function* () {
-          const output = yield* Queue.unbounded<Llm.Output>()
-          const ended = yield* Deferred.make<void>()
-          yield* Queue.offer(responses, { id: request.id, output, ended })
-          return Stream.fromQueue(output).pipe(
-            Stream.takeUntil((item) => item.type === "finish" || item.type === "disconnect"),
-            Stream.ensuring(Deferred.succeed(ended, undefined).pipe(Effect.asVoid)),
-          )
-        })),
-      )
-      yield* opencode.event.subscribe().pipe(
-        Stream.runForEach((event) => {
-          const recorded: RecordedEvent = {
-            index: eventSequence++,
-            type: event.type,
-            ...(event.data !== null &&
-            typeof event.data === "object" &&
-            "sessionID" in event.data
-              ? { sessionID: event.data.sessionID }
-              : {}),
-            data: event.data,
-          }
-          events.push(recorded)
-          if (events.length > 100) events.shift()
-          return Queue.offer(eventQueue, recorded).pipe(Effect.asVoid)
-        }),
-        Effect.forkScoped,
-      )
-
-      const currentSession = Effect.fn("LifecycleProperties.currentSession")(function* () {
-        const sessions = yield* opencode.session.list({ limit: 1, order: "desc" })
-        const sessionID = sessions.data[0]?.id
-        if (sessionID === undefined) return yield* Effect.fail(new Error("no current session"))
-        return sessionID
-      })
-
-      const waitForEvent = Effect.fn("LifecycleProperties.waitForEvent")(function* (
-        type: string,
-        sessionID: SessionID | undefined,
-        after: number,
-      ) {
-        while (true) {
-          const event = yield* Queue.take(eventQueue)
-          if (
-            event.index > after &&
-            event.type === type &&
-            (sessionID === undefined || event.sessionID === sessionID)
-          ) return event
-        }
-      }, (effect, type) =>
-        effect.pipe(
-          Effect.timeoutOrElse({
-            duration: 10_000,
-            orElse: () => Effect.fail(new Error(`timed out waiting for ${type}`)),
-          }),
-        ))
-
-      const waitForResponse = Effect.fn("LifecycleProperties.waitForResponse")(function* () {
-        if (activeResponse !== undefined)
-          return yield* Effect.fail(new Error(`LLM response ${activeResponse.id} is already active`))
-        while (true) {
-          const response = yield* Queue.take(responses)
-          if (yield* Deferred.isDone(response.ended)) continue
-          activeResponse = response
-          return
-        }
-      }, (effect) =>
-        effect.pipe(
-          Effect.timeoutOrElse({
-            duration: 10_000,
-            orElse: () => Effect.fail(new Error("timed out waiting for an LLM response")),
-          }),
-        ))
-
-      const sendOutput = Effect.fn("LifecycleProperties.sendOutput")(function* (
-        item: Llm.Output,
-      ) {
-        const response = activeResponse
-        if (response === undefined) return yield* Effect.fail(new Error("no active LLM response"))
-        yield* Queue.offer(response.output, item)
-      })
-
-      const endResponse = Effect.fn("LifecycleProperties.endResponse")(function* (item: Llm.Output) {
-        const response = activeResponse
-        if (response === undefined) return yield* Effect.fail(new Error("no active LLM response"))
-        yield* Queue.offer(response.output, item)
-        yield* Deferred.await(response.ended)
-        activeResponse = undefined
-      }, (effect) =>
-        effect.pipe(
-          Effect.timeoutOrElse({
-            duration: 10_000,
-            orElse: () => Effect.fail(new Error("timed out waiting for the LLM response to end")),
-          }),
-        ))
-
-      const promptOwners = Effect.fn("LifecycleProperties.promptOwners")(function* (
-        sessionID: SessionID,
-        prompt: string,
-      ) {
-        const [messages, pending] = yield* Effect.all([
-          opencode.message.list({ sessionID, limit: 20, order: "desc" }),
-          opencode.session.inbox.list({ sessionID }),
-        ], { concurrency: "unbounded" })
-        return {
-          projected: messages.data.filter(
-            (message) => message.type === "user" && message.text === prompt,
-          ).length,
-          pending: pending.filter(
-            (input) => input.type === "user" && input.payload.text === prompt,
-          ).length,
-        }
-      })
-
-      const assertAssistantContent = Effect.fn("LifecycleProperties.assertAssistantContent")(function* (
-        state: Extract<Model, { phase: "streaming" }>,
-      ) {
-        if (
-          state.output === undefined &&
-          state.reasoning === undefined &&
-          state.tool === undefined
-        ) return
-        const messages = yield* opencode.message.list({
-          sessionID: state.sessionID,
-          limit: 20,
-          order: "desc",
-        })
-        const assistant = messages.data.find((message) => message.type === "assistant")
-        if (
-          assistant?.type === "assistant" &&
-          (state.output === undefined ||
-            assistant.content.some(
-              (part) => part.type === "text" && part.text === state.output,
-            )) &&
-          (state.reasoning === undefined ||
-            assistant.content.some(
-              (part) => part.type === "reasoning" && part.text === state.reasoning,
-            )) &&
-          (state.tool === undefined ||
-            assistant.content.some(
-              (part) =>
-                part.type === "tool" &&
-                part.id === state.tool?.callID &&
-                part.state.status === "error" &&
-                part.state.error.type === "aborted",
-            ))
-        ) return
-        return yield* Effect.fail(new Error("server projection lost settled assistant content"))
-      })
-
-      const idleAfter = (
-        state: Extract<Model, { phase: "streaming" }>,
-      ): Model => ({
-        phase: "idle",
-        sessionID: state.sessionID,
-        prompt: state.prompt,
-        output: state.output,
-      })
-
-      const afterInterrupted = Effect.fn("LifecycleProperties.afterInterrupted")(function* (
-        state: Extract<Model, { phase: "streaming" }>,
-      ) {
-        if (state.queuedPrompt === undefined) return idleAfter(state)
-        const owners = yield* promptOwners(state.sessionID, state.queuedPrompt)
-        if (owners.pending === 1 && owners.projected === 0)
-          return {
-            phase: "pending",
-            sessionID: state.sessionID,
-            prompt: state.prompt,
-            output: state.output,
-            pendingPrompt: state.queuedPrompt,
-          } satisfies Model
-        return yield* Effect.fail(
-          new Error(
-            `interrupted prompt has ${owners.projected} projected and ${owners.pending} pending owners`,
+        yield* llm.serve((request) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const output = yield* Queue.unbounded<Llm.Output>()
+              const ended = yield* Deferred.make<void>()
+              yield* Queue.offer(responses, { id: request.id, output, ended })
+              return Stream.fromQueue(output).pipe(
+                Stream.takeUntil((item) => item.type === "finish" || item.type === "disconnect"),
+                Stream.ensuring(Deferred.succeed(ended, undefined).pipe(Effect.asVoid)),
+              )
+            }),
           ),
         )
-      })
+        yield* opencode.event.subscribe().pipe(
+          Stream.runForEach((event) => {
+            const recorded: RecordedEvent = {
+              index: eventSequence++,
+              type: event.type,
+              ...(event.data !== null && typeof event.data === "object" && "sessionID" in event.data
+                ? { sessionID: event.data.sessionID }
+                : {}),
+              data: event.data,
+            }
+            events.push(recorded)
+            if (events.length > 100) events.shift()
+            return Queue.offer(eventQueue, recorded).pipe(Effect.asVoid)
+          }),
+          Effect.forkScoped,
+        )
 
-      const afterProviderFailure = Effect.fn("LifecycleProperties.afterProviderFailure")(function* (
-        state: Extract<Model, { phase: "streaming" }>,
-        after: number,
-      ) {
-        if (state.queuedPrompt === undefined) return idleAfter(state)
-        const started = yield* waitForEvent("session.execution.started", state.sessionID, after)
-        yield* waitForEvent("session.input.promoted", state.sessionID, started.index)
-        const owners = yield* promptOwners(state.sessionID, state.queuedPrompt)
-        if (owners.pending !== 0 || owners.projected !== 1)
-          return yield* Effect.fail(
-            new Error(
-              `recovered prompt has ${owners.projected} projected and ${owners.pending} pending owners`,
+        const currentSession = Effect.fn("LifecycleProperties.currentSession")(function* () {
+          const sessions = yield* opencode.session.list({ limit: 1, order: "desc" })
+          const sessionID = sessions.data[0]?.id
+          if (sessionID === undefined) return yield* Effect.fail(new Error("no current session"))
+          return sessionID
+        })
+
+        const waitForEvent = Effect.fn("LifecycleProperties.waitForEvent")(
+          function* (type: string, sessionID: SessionID | undefined, after: number) {
+            while (true) {
+              const event = yield* Queue.take(eventQueue)
+              if (
+                event.index > after &&
+                event.type === type &&
+                (sessionID === undefined || event.sessionID === sessionID)
+              )
+                return event
+            }
+          },
+          (effect, type) =>
+            effect.pipe(
+              Effect.timeoutOrElse({
+                duration: 10_000,
+                orElse: () => Effect.fail(new Error(`timed out waiting for ${type}`)),
+              }),
             ),
-          )
-        yield* waitForResponse()
-        return {
-          phase: "streaming",
-          sessionID: state.sessionID,
-          prompt: state.queuedPrompt,
-        } satisfies Model
-      })
+        )
 
-      const final = yield* run<Model>({
-        context: {
-          ui,
-          artifacts,
-          evidence: () => Effect.succeed({ events }),
-        },
-        initial: { phase: "idle" },
-        seed,
-        steps,
-        transitions: [
-          {
-            name: "submit",
-            enabled: (state) => state.phase !== "streaming",
-            run: (state, step) =>
-              Effect.gen(function* () {
-                if (state.phase === "streaming") return state
-                const prompt = `lifecycle-prompt-${step}`
-                const after = eventSequence - 1
-                yield* ui.submit(prompt)
-                const admitted = state.phase === "pending"
-                  ? yield* waitForEvent("session.input.admitted", state.sessionID, after)
-                  : undefined
-                const started = yield* waitForEvent(
-                  "session.execution.started",
-                  state.phase === "pending" ? state.sessionID : undefined,
-                  admitted?.index ?? after,
-                )
-                const sessionID = state.phase === "pending" ? state.sessionID : yield* currentSession()
-                if (started.sessionID !== sessionID)
-                  return yield* Effect.fail(new Error("execution started for an unexpected session"))
-                if (state.phase === "pending") {
-                  const first = yield* waitForEvent("session.input.promoted", sessionID, started.index)
-                  yield* waitForEvent("session.input.promoted", sessionID, first.index)
-                  const [previous, current] = yield* Effect.all([
-                    promptOwners(sessionID, state.pendingPrompt),
-                    promptOwners(sessionID, prompt),
-                  ], { concurrency: "unbounded" })
-                  if (
-                    previous.projected !== 1 ||
-                    previous.pending !== 0 ||
-                    current.projected !== 1 ||
-                    current.pending !== 0
-                  )
-                    return yield* Effect.fail(
-                      new Error(
-                        `resumed prompts have previous ${previous.projected}/${previous.pending} and current ${current.projected}/${current.pending} projected/pending owners`,
-                      ),
+        const waitForResponse = Effect.fn("LifecycleProperties.waitForResponse")(
+          function* () {
+            if (activeResponse !== undefined)
+              return yield* Effect.fail(new Error(`LLM response ${activeResponse.id} is already active`))
+            while (true) {
+              const response = yield* Queue.take(responses)
+              if (yield* Deferred.isDone(response.ended)) continue
+              activeResponse = response
+              return
+            }
+          },
+          (effect) =>
+            effect.pipe(
+              Effect.timeoutOrElse({
+                duration: 10_000,
+                orElse: () => Effect.fail(new Error("timed out waiting for an LLM response")),
+              }),
+            ),
+        )
+
+        const sendOutput = Effect.fn("LifecycleProperties.sendOutput")(function* (item: Llm.Output) {
+          const response = activeResponse
+          if (response === undefined) return yield* Effect.fail(new Error("no active LLM response"))
+          yield* Queue.offer(response.output, item)
+        })
+
+        const endResponse = Effect.fn("LifecycleProperties.endResponse")(
+          function* (item: Llm.Output) {
+            const response = activeResponse
+            if (response === undefined) return yield* Effect.fail(new Error("no active LLM response"))
+            yield* Queue.offer(response.output, item)
+            yield* Deferred.await(response.ended)
+            activeResponse = undefined
+          },
+          (effect) =>
+            effect.pipe(
+              Effect.timeoutOrElse({
+                duration: 10_000,
+                orElse: () => Effect.fail(new Error("timed out waiting for the LLM response to end")),
+              }),
+            ),
+        )
+
+        const promptOwners = Effect.fn("LifecycleProperties.promptOwners")(function* (
+          sessionID: SessionID,
+          prompt: string,
+        ) {
+          const [messages, pending] = yield* Effect.all(
+            [
+              opencode.message.list({ sessionID, limit: 20, order: "desc" }),
+              opencode.session.inbox.list({ sessionID }),
+            ],
+            { concurrency: "unbounded" },
+          )
+          return {
+            projected: messages.data.filter((message) => message.type === "user" && message.text === prompt).length,
+            pending: pending.filter((input) => input.type === "user" && input.payload.text === prompt).length,
+          }
+        })
+
+        const assertAssistantContent = Effect.fn("LifecycleProperties.assertAssistantContent")(function* (
+          state: Extract<Model, { phase: "streaming" }>,
+        ) {
+          if (state.output === undefined && state.reasoning === undefined && state.tool === undefined) return
+          const messages = yield* opencode.message.list({
+            sessionID: state.sessionID,
+            limit: 20,
+            order: "desc",
+          })
+          // Incomplete-stream continuation can persist one logical Step across assistant messages.
+          const content = messages.data.flatMap((message) => (message.type === "assistant" ? message.content : []))
+          if (
+            (state.output === undefined ||
+              content.some((part) => part.type === "text" && part.text === state.output)) &&
+            (state.reasoning === undefined ||
+              content.some((part) => part.type === "reasoning" && part.text === state.reasoning)) &&
+            (state.tool === undefined ||
+              content.some(
+                (part) =>
+                  part.type === "tool" &&
+                  part.id === state.tool?.callID &&
+                  part.state.status === "error" &&
+                  part.state.error.type === "aborted",
+              ))
+          )
+            return
+          return yield* Effect.fail(new Error("server projection lost settled assistant content"))
+        })
+
+        const idleAfter = (state: Extract<Model, { phase: "streaming" }>): Model => ({
+          phase: "idle",
+          sessionID: state.sessionID,
+          prompt: state.prompt,
+          output: state.output,
+        })
+
+        const afterInterrupted = Effect.fn("LifecycleProperties.afterInterrupted")(function* (
+          state: Extract<Model, { phase: "streaming" }>,
+        ) {
+          if (state.queuedPrompt === undefined) return idleAfter(state)
+          const owners = yield* promptOwners(state.sessionID, state.queuedPrompt)
+          if (owners.pending === 1 && owners.projected === 0)
+            return {
+              phase: "pending",
+              sessionID: state.sessionID,
+              prompt: state.prompt,
+              output: state.output,
+              pendingPrompt: state.queuedPrompt,
+            } satisfies Model
+          return yield* Effect.fail(
+            new Error(`interrupted prompt has ${owners.projected} projected and ${owners.pending} pending owners`),
+          )
+        })
+
+        const final = yield* run<Model>({
+          context,
+          initial: { phase: "idle" },
+          seed,
+          steps,
+          transitions: (
+            [
+              {
+                name: "submit",
+                enabled: (state) => state.phase !== "streaming",
+                run: (state, step) =>
+                  Effect.gen(function* () {
+                    if (state.phase === "streaming") return state
+                    const prompt = `lifecycle-prompt-${step}`
+                    const after = eventSequence - 1
+                    yield* ui.submit(prompt)
+                    const admitted =
+                      state.phase === "pending"
+                        ? yield* waitForEvent("session.inbox.enqueued", state.sessionID, after)
+                        : undefined
+                    const started = yield* waitForEvent(
+                      "session.execution.started",
+                      state.phase === "pending" ? state.sessionID : undefined,
+                      admitted?.index ?? after,
                     )
-                  yield* waitForResponse()
-                  return { phase: "streaming", sessionID, prompt }
-                }
-                yield* waitForResponse()
-                return { phase: "streaming", sessionID, prompt }
-              }),
-          },
-          {
-            name: "emit-text",
-            enabled: (state) =>
-              state.phase === "streaming" &&
-              state.output === undefined &&
-              state.tool === undefined,
-            run: (state, step) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const text = `lifecycle-output-${step}`
-                const after = eventSequence - 1
-                yield* sendOutput(Llm.text(text, { delay: 0, chunkSize: 100 }))
-                yield* waitForEvent("session.text.started", state.sessionID, after)
-                return { ...state, output: text }
-              }),
-          },
-          {
-            name: "emit-reasoning",
-            enabled: (state) =>
-              state.phase === "streaming" &&
-              state.reasoning === undefined &&
-              state.tool === undefined,
-            run: (state, step) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const reasoning = `lifecycle-reasoning-${step}`
-                const after = eventSequence - 1
-                yield* sendOutput(Llm.reasoning(reasoning, { delay: 0, chunkSize: 100 }))
-                yield* waitForEvent("session.reasoning.started", state.sessionID, after)
-                return { ...state, reasoning }
-              }),
-          },
-          {
-            name: "start-tool-input",
-            enabled: (state) => state.phase === "streaming" && state.tool === undefined,
-            run: (state, step) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const callID = `call_lifecycle_${step}`
-                const question = `lifecycle-tool-question-${step}`
-                const after = eventSequence - 1
-                yield* sendOutput(
-                  Llm.toolCall(
-                    {
-                      index: 0,
-                      id: callID,
-                      name: "question",
-                      input: {
-                        questions: [
-                          {
-                            question,
-                            header: "Lifecycle",
-                            options: [
+                    const sessionID = state.phase === "pending" ? state.sessionID : yield* currentSession()
+                    if (started.sessionID !== sessionID)
+                      return yield* Effect.fail(new Error("execution started for an unexpected session"))
+                    if (state.phase === "pending") {
+                      const first = yield* waitForEvent("session.inbox.delivered", sessionID, started.index)
+                      yield* waitForEvent("session.inbox.delivered", sessionID, first.index)
+                      const [previous, current] = yield* Effect.all(
+                        [promptOwners(sessionID, state.pendingPrompt), promptOwners(sessionID, prompt)],
+                        { concurrency: "unbounded" },
+                      )
+                      if (
+                        previous.projected !== 1 ||
+                        previous.pending !== 0 ||
+                        current.projected !== 1 ||
+                        current.pending !== 0
+                      )
+                        return yield* Effect.fail(
+                          new Error(
+                            `resumed prompts have previous ${previous.projected}/${previous.pending} and current ${current.projected}/${current.pending} projected/pending owners`,
+                          ),
+                        )
+                      yield* waitForResponse()
+                      return { phase: "streaming", sessionID, prompt }
+                    }
+                    yield* waitForResponse()
+                    return { phase: "streaming", sessionID, prompt }
+                  }),
+              },
+              {
+                name: "emit-text",
+                enabled: (state) =>
+                  state.phase === "streaming" && state.output === undefined && state.tool === undefined,
+                run: (state, step) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const text = `lifecycle-output-${step}`
+                    const after = eventSequence - 1
+                    yield* sendOutput(Llm.text(text, { delay: 0, chunkSize: 100 }))
+                    yield* waitForEvent("session.text.started", state.sessionID, after)
+                    yield* waitForEvent("session.text.delta", state.sessionID, after)
+                    return { ...state, output: text }
+                  }),
+              },
+              {
+                name: "emit-reasoning",
+                enabled: (state) =>
+                  state.phase === "streaming" && state.reasoning === undefined && state.tool === undefined,
+                run: (state, step) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const reasoning = `lifecycle-reasoning-${step}`
+                    const after = eventSequence - 1
+                    yield* sendOutput(Llm.reasoning(reasoning, { delay: 0, chunkSize: 100 }))
+                    yield* waitForEvent("session.reasoning.started", state.sessionID, after)
+                    yield* waitForEvent("session.reasoning.delta", state.sessionID, after)
+                    return { ...state, reasoning }
+                  }),
+              },
+              {
+                name: "start-tool-input",
+                enabled: (state) => state.phase === "streaming" && state.tool === undefined,
+                run: (state, step) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const callID = `call_lifecycle_${step}`
+                    const question = `lifecycle-tool-question-${step}`
+                    const after = eventSequence - 1
+                    yield* sendOutput(
+                      Llm.toolCall(
+                        {
+                          index: 0,
+                          id: callID,
+                          name: "question",
+                          input: {
+                            questions: [
                               {
-                                label: "Continue",
-                                description: "Continue the lifecycle simulation.",
+                                question,
+                                header: "Lifecycle",
+                                options: [
+                                  {
+                                    label: "Continue",
+                                    description: "Continue the lifecycle simulation.",
+                                  },
+                                ],
+                                multiple: false,
                               },
                             ],
-                            multiple: false,
                           },
-                        ],
+                        },
+                        { delay: 20, chunkSize: 100 },
+                      ),
+                    )
+                    const started = yield* waitForEvent("session.tool.input.started", state.sessionID, after)
+                    return {
+                      ...state,
+                      tool: {
+                        callID,
+                        question,
+                        phase: "input" as const,
+                        startedAfter: started.index,
                       },
-                    },
-                    { delay: 20, chunkSize: 100 },
-                  ),
-                )
-                const started = yield* waitForEvent(
-                  "session.tool.input.started",
-                  state.sessionID,
-                  after,
-                )
-                return {
-                  ...state,
-                  tool: {
-                    callID,
-                    question,
-                    phase: "input" as const,
-                    startedAfter: started.index,
-                  },
-                }
-              }),
-          },
-          {
-            name: "await-tool-execution",
-            enabled: (state) => state.phase === "streaming" && state.tool?.phase === "input",
-            run: (state) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming" || state.tool?.phase !== "input") return state
-                yield* endResponse(Llm.finish("tool-calls"))
-                yield* waitForEvent(
-                  "session.tool.called",
-                  state.sessionID,
-                  state.tool.startedAfter,
-                )
-                yield* ui.waitFor(state.tool.question, { timeout: 10_000 })
-                return { ...state, tool: { ...state.tool, phase: "running" as const } }
-              }),
-          },
-          {
-            name: "queue-prompt",
-            enabled: (state) =>
-              state.phase === "streaming" &&
-              state.queuedPrompt === undefined &&
-              state.tool === undefined,
+                    }
+                  }),
+              },
+              {
+                name: "await-tool-execution",
+                enabled: (state) => state.phase === "streaming" && state.tool?.phase === "input",
+                run: (state) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming" || state.tool?.phase !== "input") return state
+                    yield* endResponse(Llm.finish("tool-calls"))
+                    yield* waitForEvent("session.tool.called", state.sessionID, state.tool.startedAfter)
+                    yield* ui.waitFor(state.tool.question, { timeout: 10_000 })
+                    return { ...state, tool: { ...state.tool, phase: "running" as const } }
+                  }),
+              },
+              {
+                name: "queue-prompt",
+                enabled: (state) =>
+                  state.phase === "streaming" && state.queuedPrompt === undefined && state.tool === undefined,
+                run: (state, step) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const queuedPrompt = `queued-prompt-${step}`
+                    const after = eventSequence - 1
+                    yield* ui.submit(queuedPrompt)
+                    yield* waitForEvent("session.inbox.enqueued", state.sessionID, after)
+                    return { ...state, queuedPrompt }
+                  }),
+              },
+              {
+                name: "finish",
+                enabled: (state) =>
+                  state.phase === "streaming" &&
+                  state.tool === undefined &&
+                  (state.output !== undefined || state.reasoning !== undefined),
+                run: (state) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const after = eventSequence - 1
+                    yield* endResponse(Llm.finish())
+                    if (state.queuedPrompt !== undefined) {
+                      yield* waitForEvent("session.inbox.delivered", state.sessionID, after)
+                      yield* assertAssistantContent(state)
+                      const owners = yield* promptOwners(state.sessionID, state.queuedPrompt)
+                      if (owners.projected !== 1 || owners.pending !== 0)
+                        return yield* Effect.fail(
+                          new Error(
+                            `promoted prompt has ${owners.projected} projected and ${owners.pending} pending owners`,
+                          ),
+                        )
+                      yield* waitForResponse()
+                      return {
+                        phase: "streaming",
+                        sessionID: state.sessionID,
+                        prompt: state.queuedPrompt,
+                      }
+                    }
+                    yield* waitForEvent("session.execution.succeeded", state.sessionID, after)
+                    yield* assertAssistantContent(state)
+                    return idleAfter(state)
+                  }),
+              },
+              {
+                name: "interrupt",
+                enabled: (state) => state.phase === "streaming",
+                run: (state) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const after = eventSequence - 1
+                    yield* opencode.session.interrupt({ sessionID: state.sessionID })
+                    yield* waitForEvent("session.execution.interrupted", state.sessionID, after)
+                    if (state.tool?.phase !== "running")
+                      yield* endResponse(Llm.text("discarded-after-interrupt", { delay: 0, chunkSize: 100 }))
+                    yield* assertAssistantContent(state)
+                    return yield* afterInterrupted(state)
+                  }),
+              },
+              {
+                name: "provider-disconnect-and-retry",
+                enabled: (state) => state.phase === "streaming" && state.tool === undefined && !state.retried,
+                run: (state) =>
+                  Effect.gen(function* () {
+                    if (state.phase !== "streaming") return state
+                    const after = eventSequence - 1
+                    yield* endResponse(Llm.disconnect())
+                    yield* waitForEvent("session.retry.scheduled", state.sessionID, after)
+                    yield* assertAssistantContent(state)
+                    yield* waitForResponse()
+                    // One injected failure per logical Step tests recovery rather than retry-budget exhaustion.
+                    return { ...state, retried: true }
+                  }),
+              },
+            ] satisfies ReadonlyArray<Transition<Model>>
+          ).map((transition) => ({
+            ...transition,
             run: (state, step) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const queuedPrompt = `queued-prompt-${step}`
-                const after = eventSequence - 1
-                yield* ui.submit(queuedPrompt)
-                yield* waitForEvent("session.input.admitted", state.sessionID, after)
-                return { ...state, queuedPrompt }
+              Effect.suspend(() => {
+                trace.push({ step, transition: transition.name })
+                return transition.run(state, step)
               }),
-          },
-          {
-            name: "finish",
-            enabled: (state) =>
-              state.phase === "streaming" &&
-              state.tool === undefined &&
-              (state.output !== undefined || state.reasoning !== undefined),
-            run: (state) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const after = eventSequence - 1
-                yield* endResponse(Llm.finish())
-                if (state.queuedPrompt !== undefined) {
-                  yield* waitForEvent("session.input.promoted", state.sessionID, after)
-                  yield* assertAssistantContent(state)
-                  const owners = yield* promptOwners(state.sessionID, state.queuedPrompt)
-                  if (owners.projected !== 1 || owners.pending !== 0)
-                    return yield* Effect.fail(
-                      new Error(
-                        `promoted prompt has ${owners.projected} projected and ${owners.pending} pending owners`,
-                      ),
-                    )
-                  yield* waitForResponse()
-                  return {
-                    phase: "streaming",
-                    sessionID: state.sessionID,
-                    prompt: state.queuedPrompt,
-                  }
-                }
-                yield* waitForEvent("session.execution.succeeded", state.sessionID, after)
-                yield* assertAssistantContent(state)
-                return idleAfter(state)
-              }),
-          },
-          {
-            name: "interrupt",
-            enabled: (state) => state.phase === "streaming",
-            run: (state) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const after = eventSequence - 1
-                yield* opencode.session.interrupt({ sessionID: state.sessionID })
-                yield* waitForEvent("session.execution.interrupted", state.sessionID, after)
-                if (state.tool?.phase !== "running")
-                  yield* endResponse(
-                    Llm.text("discarded-after-interrupt", { delay: 0, chunkSize: 100 }),
-                  )
-                yield* assertAssistantContent(state)
-                return yield* afterInterrupted(state)
-              }),
-          },
-          {
-            name: "provider-disconnect",
-            enabled: (state) => state.phase === "streaming" && state.tool === undefined,
-            run: (state) =>
-              Effect.gen(function* () {
-                if (state.phase !== "streaming") return state
-                const after = eventSequence - 1
-                yield* endResponse(Llm.disconnect())
-                const failed = yield* waitForEvent("session.execution.failed", state.sessionID, after)
-                yield* assertAssistantContent(state)
-                return yield* afterProviderFailure(state, failed.index)
-              }),
-          },
-        ],
-        invariants: [
-          {
-            name: "latest prompt remains visible",
-            check: (state) =>
-              state.phase === "streaming" && state.queuedPrompt !== undefined
-                ? ui.waitFor(state.queuedPrompt, { timeout: 10_000 }).pipe(Effect.asVoid)
-                : state.phase === "pending"
-                ? ui.waitFor(state.pendingPrompt, { timeout: 10_000 }).pipe(Effect.asVoid)
-                : state.prompt === undefined
-                ? Effect.void
-                : ui.waitFor(state.prompt, { timeout: 10_000 }).pipe(Effect.asVoid),
-          },
-          {
-            name: "settled output remains visible",
-            check: (state) =>
-              state.phase === "streaming" || state.output === undefined
-                ? Effect.void
-                : ui.waitFor(state.output, { timeout: 10_000 }).pipe(Effect.asVoid),
-          },
-          {
-            name: "active output remains visible",
-            check: (state) =>
-              state.phase !== "streaming" || state.output === undefined
-                ? Effect.void
-                : ui.waitFor(state.output, { timeout: 10_000 }).pipe(Effect.asVoid),
-          },
-          {
-            name: "running tool remains visible",
-            check: (state) =>
-              state.phase === "streaming" && state.tool?.phase === "running"
-                ? ui.waitFor(state.tool.question, { timeout: 10_000 }).pipe(Effect.asVoid)
-                : Effect.void,
-          },
-          {
-            name: "settled composer is actionable",
-            check: (state) =>
-              state.phase !== "streaming"
-                ? ui.waitFor((current) => current.focused.editor, { timeout: 10_000 }).pipe(Effect.asVoid)
-                : Effect.void,
-          },
-          {
-            name: "server projection retains the latest prompt",
-            check: (state) =>
-              state.sessionID === undefined || state.prompt === undefined
-                ? Effect.void
-                : Effect.gen(function* () {
-                    const sessionID = state.sessionID
-                    const prompt = state.prompt
-                    if (sessionID === undefined || prompt === undefined) return
-                    const messages = yield* opencode.message.list({
-                      sessionID,
-                      limit: 20,
-                      order: "desc",
-                    })
-                    if (messages.data.some((message) => message.type === "user" && message.text === prompt))
-                      return
-                    return yield* Effect.fail(new Error(`server projection lost prompt: ${prompt}`))
-                  }),
-          },
-          {
-            name: "queued prompt has exactly one owner",
-            check: (state) =>
-              (state.phase === "streaming"
-                ? state.queuedPrompt
-                : state.phase === "pending"
-                ? state.pendingPrompt
-                : undefined) === undefined ||
-              state.sessionID === undefined
-                ? Effect.void
-                : Effect.gen(function* () {
-                    const ownedPrompt = state.phase === "streaming"
-                      ? state.queuedPrompt
-                      : state.phase === "pending"
-                      ? state.pendingPrompt
-                      : undefined
-                    const sessionID = state.sessionID
-                    if (ownedPrompt === undefined || sessionID === undefined) return
-                    const owners = yield* promptOwners(sessionID, ownedPrompt)
-                    if (owners.projected + owners.pending === 1) return
-                    return yield* Effect.fail(
-                      new Error(
-                        `queued prompt has ${owners.projected} projected and ${owners.pending} pending owners: ${ownedPrompt}`,
-                      ),
-                    )
-                  }),
-          },
-          {
-            name: "settled session has no pending input",
-            check: (state) =>
-              state.phase !== "idle" || state.sessionID === undefined
-                ? Effect.void
-                : Effect.gen(function* () {
-                    const sessionID = state.sessionID
-                    if (sessionID === undefined) return
-                    const pending = yield* opencode.session.inbox.list({ sessionID })
-                    if (pending.length === 0) return
-                    return yield* Effect.fail(new Error(`settled session retained ${pending.length} pending input(s)`))
-                  }),
-          },
-          {
-            name: "transport defects are not rendered",
-            check: () =>
-              Effect.forEach(["UnknownError", "RpcClientDefect"], (text) =>
-                ui.matches(text).pipe(
-                  Effect.filterOrFail((visible) => !visible, () => new Error(`rendered internal error: ${text}`)),
-                ),
-              ).pipe(Effect.asVoid),
-          },
-        ],
-      })
+          })),
+          invariants: [
+            {
+              name: "latest prompt remains visible",
+              check: (state) =>
+                state.phase === "streaming" && state.queuedPrompt !== undefined
+                  ? ui.waitFor(state.queuedPrompt, { timeout: 10_000 }).pipe(Effect.asVoid)
+                  : state.phase === "pending"
+                    ? ui.waitFor(state.pendingPrompt, { timeout: 10_000 }).pipe(Effect.asVoid)
+                    : state.prompt === undefined
+                      ? Effect.void
+                      : ui.waitFor(state.prompt, { timeout: 10_000 }).pipe(Effect.asVoid),
+            },
+            {
+              name: "settled output remains visible",
+              check: (state) =>
+                state.phase === "streaming" || state.output === undefined
+                  ? Effect.void
+                  : ui.waitFor(state.output, { timeout: 10_000 }).pipe(Effect.asVoid),
+            },
+            {
+              name: "active output remains visible",
+              check: (state) =>
+                state.phase !== "streaming" || state.output === undefined
+                  ? Effect.void
+                  : ui.waitFor(state.output, { timeout: 10_000 }).pipe(Effect.asVoid),
+            },
+            {
+              name: "running tool remains visible",
+              check: (state) =>
+                state.phase === "streaming" && state.tool?.phase === "running"
+                  ? ui.waitFor(state.tool.question, { timeout: 10_000 }).pipe(Effect.asVoid)
+                  : Effect.void,
+            },
+            {
+              name: "settled composer is actionable",
+              check: (state) =>
+                state.phase !== "streaming"
+                  ? ui.waitFor((current) => current.focused.editor, { timeout: 10_000 }).pipe(Effect.asVoid)
+                  : Effect.void,
+            },
+            {
+              name: "server projection retains the latest prompt",
+              check: (state) =>
+                state.sessionID === undefined || state.prompt === undefined
+                  ? Effect.void
+                  : Effect.gen(function* () {
+                      const sessionID = state.sessionID
+                      const prompt = state.prompt
+                      if (sessionID === undefined || prompt === undefined) return
+                      const messages = yield* opencode.message.list({
+                        sessionID,
+                        limit: 20,
+                        order: "desc",
+                      })
+                      if (messages.data.some((message) => message.type === "user" && message.text === prompt)) return
+                      return yield* Effect.fail(new Error(`server projection lost prompt: ${prompt}`))
+                    }),
+            },
+            {
+              name: "queued prompt has exactly one owner",
+              check: (state) =>
+                (state.phase === "streaming"
+                  ? state.queuedPrompt
+                  : state.phase === "pending"
+                    ? state.pendingPrompt
+                    : undefined) === undefined || state.sessionID === undefined
+                  ? Effect.void
+                  : Effect.gen(function* () {
+                      const ownedPrompt =
+                        state.phase === "streaming"
+                          ? state.queuedPrompt
+                          : state.phase === "pending"
+                            ? state.pendingPrompt
+                            : undefined
+                      const sessionID = state.sessionID
+                      if (ownedPrompt === undefined || sessionID === undefined) return
+                      const owners = yield* promptOwners(sessionID, ownedPrompt)
+                      if (owners.projected + owners.pending === 1) return
+                      return yield* Effect.fail(
+                        new Error(
+                          `queued prompt has ${owners.projected} projected and ${owners.pending} pending owners: ${ownedPrompt}`,
+                        ),
+                      )
+                    }),
+            },
+            {
+              name: "settled session has no pending input",
+              check: (state) =>
+                state.phase !== "idle" || state.sessionID === undefined
+                  ? Effect.void
+                  : Effect.gen(function* () {
+                      const sessionID = state.sessionID
+                      if (sessionID === undefined) return
+                      const pending = yield* opencode.session.inbox.list({ sessionID })
+                      if (pending.length === 0) return
+                      return yield* Effect.fail(
+                        new Error(`settled session retained ${pending.length} pending input(s)`),
+                      )
+                    }),
+            },
+            {
+              name: "transport defects are not rendered",
+              check: () =>
+                Effect.forEach(["UnknownError", "RpcClientDefect"], (text) =>
+                  ui.matches(text).pipe(
+                    Effect.filterOrFail(
+                      (visible) => !visible,
+                      () => new Error(`rendered internal error: ${text}`),
+                    ),
+                  ),
+                ).pipe(Effect.asVoid),
+            },
+          ],
+        })
 
-      if (final.phase === "streaming") {
-        const after = eventSequence - 1
-        if (final.tool !== undefined) {
-          yield* opencode.session.interrupt({ sessionID: final.sessionID })
-          yield* waitForEvent("session.execution.interrupted", final.sessionID, after)
-          if (final.tool.phase === "input")
-            yield* endResponse(
-              Llm.text("discarded-after-interrupt", { delay: 0, chunkSize: 100 }),
-            )
-          yield* assertAssistantContent(final)
-        } else {
-          yield* endResponse(Llm.finish())
-          if (final.queuedPrompt !== undefined) {
-            const promoted = yield* waitForEvent("session.input.promoted", final.sessionID, after)
-            yield* waitForResponse()
-            yield* endResponse(Llm.finish())
-            yield* waitForEvent("session.execution.succeeded", final.sessionID, promoted.index)
+        yield* Effect.gen(function* () {
+          if (final.phase !== "streaming") return
+          const after = eventSequence - 1
+          if (final.tool !== undefined) {
+            yield* opencode.session.interrupt({ sessionID: final.sessionID })
+            yield* waitForEvent("session.execution.interrupted", final.sessionID, after)
+            if (final.tool.phase === "input")
+              yield* endResponse(Llm.text("discarded-after-interrupt", { delay: 0, chunkSize: 100 }))
           } else {
-            yield* waitForEvent("session.execution.succeeded", final.sessionID, after)
+            yield* endResponse(Llm.finish())
+            if (final.queuedPrompt !== undefined) {
+              const promoted = yield* waitForEvent("session.inbox.delivered", final.sessionID, after)
+              yield* waitForResponse()
+              yield* endResponse(Llm.finish())
+              yield* waitForEvent("session.execution.succeeded", final.sessionID, promoted.index)
+            } else {
+              yield* waitForEvent("session.execution.succeeded", final.sessionID, after)
+            }
           }
-        }
-      }
-    })),
+          yield* assertAssistantContent(final)
+          yield* ui.waitFor((state) => state.focused.editor, { timeout: 10_000 })
+        }).pipe(
+          Effect.tapCause(() =>
+            saveFailure(context, {
+              seed,
+              steps,
+              phase: "terminal-verify",
+              trace,
+              state: final,
+            }),
+          ),
+        )
+      }),
+    ),
 })
 
 function readInteger(name: string, fallback: number, maximum: number) {

--- a/packages/drive/test/manual/tui-regressions/open-picker.ts
+++ b/packages/drive/test/manual/tui-regressions/open-picker.ts
@@ -1,0 +1,403 @@
+import assert from "node:assert/strict"
+import { Effect, Stream } from "effect"
+import { defineScript, Llm } from "../../../src/index.js"
+import { appeared, settled } from "./support.js"
+import { saveFailure } from "./state-machine.js"
+
+// Each case gets a fresh server and TUI. The SDK and UI RPC channel stay clean;
+// only production TUI HTTP/SSE crosses Drive's coarse TCP chaos proxy.
+const scenario = process.env.OPENCODE_DRIVE_OPEN_CASE ?? "cold"
+const cols = Number(process.env.OPENCODE_DRIVE_COLS ?? 100)
+const seed = Number(process.env.OPENCODE_DRIVE_SEED ?? 1)
+
+export default defineScript({
+  launch: "manual",
+  network: true,
+  project: {
+    git: true,
+    files: {
+      "README.md": "# Open picker fixture\n",
+      "archive/README.md": "# Archive fixture\n",
+      "archive/zen/README.md": "# Moved fixture\n",
+    },
+  },
+  config: { autoupdate: false, username: "Drive" },
+  tuiConfig: {
+    session: { new_location: "inherit" },
+    keybinds: { "session.new": "ctrl+n" },
+  },
+  tui: { viewport: { cols, rows: 36 } },
+  run: ({ server, tuis, network, llm, artifacts }) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        assert(["cold", "warm", "dispose", "selection", "deletion", "failure"].includes(scenario))
+        yield* Effect.forEach(
+          [
+            ["init", "--initial-branch=main"],
+            ["add", "README.md"],
+            ["commit", "-m", "Archive fixture"],
+          ],
+          (args) =>
+            Effect.tryPromise(async () => {
+              const process = Bun.spawn(
+                ["git", "-c", "user.name=Drive", "-c", "user.email=drive@example.com", ...args],
+                {
+                  cwd: `${artifacts}/files/archive`,
+                  env: {
+                    ...Bun.env,
+                    GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
+                    GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+                  },
+                  stdout: "ignore",
+                  stderr: "pipe",
+                },
+              )
+              assert.equal(await process.exited, 0, await new Response(process.stderr).text())
+            }),
+        )
+        const opencode = yield* server.launch()
+        const location = yield* opencode.location.get({ location: { directory: `${artifacts}/files` } })
+        const archive = yield* opencode.location.get({ location: { directory: `${artifacts}/files/archive` } })
+        assert.notEqual(archive.project.id, location.project.id, "archive must be a distinct Git project")
+        const model = (yield* opencode.model.default({ location })).data
+        const agent = (yield* opencode.agent.list({ location })).data.find((agent) => agent.id === "build")
+        assert(model)
+        assert(agent)
+        // Created before frontend launch: these are neither open tabs nor event-
+        // hydrated sessions. Distinct titles fit the 44-column picker as well.
+        const older = yield* opencode.session
+          .create({
+            title: "Atlas archive",
+            location: archive,
+            model: { providerID: model.providerID, id: model.id },
+            agent: agent.id,
+          })
+          .pipe(Effect.map((session) => ({ id: session.id, location: session.location, title: "Atlas archive" })))
+        const newer = yield* opencode.session
+          .create({
+            title: "Atlas parser",
+            location,
+            model: { providerID: model.providerID, id: model.id },
+            agent: agent.id,
+          })
+          .pipe(Effect.map((session) => ({ id: session.id, location: session.location, title: "Atlas parser" })))
+        const observer = yield* tuis.launch("picker")
+        const ui = observer.ui
+        const trace: string[] = []
+        const checkpoint = (name: string) => {
+          trace.push(name)
+          console.error(JSON.stringify({ scenario, cols, seed, checkpoint: name }))
+        }
+        const evidence = () =>
+          Effect.all({
+            sessions: opencode.session.list({ limit: 100, order: "desc" }),
+            olderMessages: opencode.message.list({ sessionID: older.id, limit: 100 }).pipe(Effect.option),
+            newerMessages: opencode.message.list({ sessionID: newer.id, limit: 100 }),
+            snapshot: ui.snapshot(),
+            state: ui.state(),
+          })
+        const context = { ui, artifacts, evidence }
+        const absent = (text: string) => ui.matches(text).pipe(Effect.map((visible) => !visible))
+        const composer = () =>
+          ui.waitFor(
+            (state) => state.elements.some((element) => element.focused && element.id.startsWith("textarea-")),
+            { timeout: 15_000 },
+          )
+        const filter = (value: string) =>
+          Effect.gen(function* () {
+            yield* ui.type(value)
+            const input = yield* ui.getElement({ focused: true })
+            assert(input.id.startsWith("input-"))
+            yield* ui.waitFor(() =>
+              ui.capture().pipe(
+                Effect.map(
+                  (frame) =>
+                    frame.lines[input.y]?.spans
+                      .map((span) => span.text)
+                      .join("")
+                      .slice(input.x, input.x + input.width)
+                      .trim() === value,
+                ),
+              ),
+            )
+          })
+        const select = (title: string) =>
+          Effect.gen(function* () {
+            const input = yield* ui.getElement({ focused: true })
+            const frame = yield* ui.capture()
+            const row = frame.lines.findIndex(
+              (line, index) =>
+                index > input.y &&
+                line.spans
+                  .map((span) => span.text)
+                  .join("")
+                  .includes(title),
+            )
+            assert(row > input.y, "target row is not visible")
+            // Fuzzy matching can reorder whole categories, including project path
+            // matches. Navigate real interactive row positions, not guessed rank.
+            const rows = new Set(
+              (yield* ui.state()).elements
+                .filter(
+                  (element) =>
+                    element.clickable &&
+                    element.height === 1 &&
+                    element.width >= input.width &&
+                    element.y > input.y &&
+                    element.y <= row,
+                )
+                .map((element) => element.y),
+            )
+            assert(rows.has(row), "target row has no interactive element")
+            checkpoint(`select:${title}:index=${rows.size - 1}`)
+            yield* ui.arrow("down")
+            yield* ui.arrow("up")
+            yield* Effect.forEach(Array.from({ length: rows.size - 1 }), () => ui.arrow("down"))
+          })
+        const ready = () => ui.waitFor(() => absent("Refreshing sessions and projects"), { timeout: 15_000 })
+        const open = () =>
+          Effect.gen(function* () {
+            yield* ui.press("o", { ctrl: true })
+            yield* ui.waitFor("Search sessions and", { timeout: 3_000 })
+          })
+        const close = () =>
+          Effect.gen(function* () {
+            yield* ui.press("escape")
+            yield* ui.waitFor(() => absent("Search sessions and"))
+          })
+        const warm = () =>
+          Effect.gen(function* () {
+            yield* open()
+            yield* ui.waitFor(older.title)
+            yield* ui.waitFor(newer.title)
+            yield* ready()
+          })
+        // No selected-row semantic surface exists in DialogSelect. Prove the
+        // chosen identity by a real TUI prompt projected into that exact session.
+        const verifyDestination = (session: typeof older) =>
+          Effect.gen(function* () {
+            yield* composer()
+            yield* ui.waitFor("Simulated Model", { timeout: 15_000 })
+            const marker = `OPEN_${scenario}_${seed}`
+            yield* ui.submit(marker)
+            yield* ui.waitFor("OPEN_REPLY_DONE", { timeout: 20_000 })
+            yield* opencode.session.wait({ sessionID: session.id })
+            const messages = yield* opencode.message.list({ sessionID: session.id, limit: 100 })
+            assert.equal(
+              messages.data.filter((message) => message.type === "user" && message.text === marker).length,
+              1,
+              "Enter navigated to a different session",
+            )
+            assert.deepEqual((yield* opencode.session.get({ sessionID: session.id })).location, session.location)
+          })
+        yield* llm.serve((request) =>
+          Stream.make(
+            Llm.text(JSON.stringify(request.body).includes("title generator") ? "Atlas check" : "OPEN_REPLY_DONE"),
+          ),
+        )
+        yield* Effect.gen(function* () {
+          yield* composer()
+          assert(yield* absent(older.title), "fixture unexpectedly became an open tab")
+          assert(yield* absent(newer.title), "fixture unexpectedly became an open tab")
+
+          if (scenario === "cold") {
+            checkpoint("cold-open-with-both-reads-blocked")
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor("Refreshing sessions and")
+            assert(yield* absent("No items available"))
+            assert(yield* absent("No recent sessions or projects"))
+            assert(yield* absent(older.title), "cold fixture was already hydrated")
+            yield* filter("not-a-fixture")
+            yield* ui.waitFor("Searching sessions and")
+            assert(yield* absent("No matches"), "pending reads were misreported as empty")
+            yield* ui.screenshot("cold-blocked")
+            checkpoint("escape-before-heal")
+            yield* ui.press("escape")
+            yield* composer()
+            yield* network.clear()
+            assert(
+              !(yield* appeared(ui, "Search sessions and", { timeout: 1_500 })),
+              "late response reopened the picker",
+            )
+            assert((yield* settled(ui)).stable)
+          }
+
+          if (scenario === "warm") {
+            yield* warm()
+            yield* ui.enter()
+            yield* composer()
+            yield* ui.waitFor(newer.title)
+            checkpoint("move-cached-session-while-picker-dismissed")
+            const moved = yield* opencode.location.get({ location: { directory: `${artifacts}/files/archive/zen` } })
+            yield* opencode.session.move({ sessionID: older.id, directory: moved.directory })
+            yield* opencode.session.wait({ sessionID: older.id })
+            const movedSession = yield* opencode.session.get({ sessionID: older.id })
+            assert.equal(movedSession.location.directory, moved.directory)
+            // This visible rename is later on the same ordered SSE stream; seeing
+            // it proves this TUI processed the dismissed picker's earlier move.
+            yield* opencode.session.rename({ sessionID: newer.id, title: "Atlas barrier" })
+            yield* ui.waitFor("Atlas barrier")
+            checkpoint("retained-unhydrated-rows-usable-under-blackhole")
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor(older.title)
+            yield* ui.waitFor("Refreshing sessions and")
+            yield* filter("Atlas archive")
+            yield* ui.waitFor(() => absent("Search sessions and"))
+            yield* select(older.title)
+            const input = yield* ui.getElement({ focused: true })
+            checkpoint("repeat-ctrl-o-preserves-filter-and-selected-identity")
+            yield* ui.press("o", { ctrl: true })
+            assert(yield* absent("Search sessions and"), "repeat Ctrl-O reset the filter")
+            assert.equal((yield* ui.getElement({ focused: true })).num, input.num, "repeat Ctrl-O replaced the picker")
+            yield* ui.screenshot("warm-repeat-blocked")
+            yield* ui.enter()
+            yield* ui.waitFor(() => absent("Refreshing sessions and"))
+            assert(yield* absent("Sessions"), "cached row could not close the picker while partitioned")
+            // Inspect the local location ref through the new-session footer
+            // before a healed session GET could correct a stale cached placement.
+            yield* ui.press("n", { ctrl: true })
+            yield* ui.getElement("prompt.footer.location")
+            yield* ui.waitFor("zen")
+            yield* ui.screenshot("warm-moved-location-before-heal")
+            checkpoint("heal-then-prove-inherited-location-and-session-identity")
+            yield* network.clear()
+            yield* composer()
+            yield* ui.waitFor("Simulated Model", { timeout: 15_000 })
+            yield* ui.submit(`OPEN_MOVED_NEW_${seed}`)
+            yield* ui.waitFor("OPEN_REPLY_DONE", { timeout: 20_000 })
+            const created = (yield* opencode.session.list({ limit: 100 })).data.find(
+              (session) => session.id !== older.id && session.id !== newer.id,
+            )
+            assert(created)
+            yield* opencode.session.wait({ sessionID: created.id })
+            assert.deepEqual(created.location, movedSession.location, "picker lost the moved session's location")
+            const messages = yield* opencode.message.list({ sessionID: created.id, limit: 100 })
+            assert(
+              messages.data.some((message) => message.type === "user" && message.text === `OPEN_MOVED_NEW_${seed}`),
+            )
+            yield* open()
+            yield* filter("Atlas archive")
+            yield* ui.waitFor(older.title)
+            yield* select(older.title)
+            yield* ui.enter()
+            yield* verifyDestination({ ...older, location: movedSession.location })
+          }
+
+          if (scenario === "dispose") {
+            yield* warm()
+            yield* close()
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor("Refreshing sessions and")
+            yield* filter("discarded-query")
+            checkpoint("dispose-old-pending-refresh-and-reopen")
+            yield* ui.press("escape")
+            yield* open()
+            yield* ui.waitFor(older.title)
+            yield* filter("Atlas archive")
+            yield* opencode.session.rename({ sessionID: newer.id, title: "Boreal updated" })
+            yield* network.clear()
+            yield* ready()
+            assert(yield* absent("discarded-query"))
+            assert(yield* absent("Boreal updated"), "disposed refresh reset the new query")
+            yield* ui.press("escape")
+            yield* open()
+            yield* ready()
+            yield* ui.waitFor("Boreal updated")
+            assert(yield* absent(newer.title), "old refresh poisoned the retained snapshot")
+            yield* close()
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor("Boreal updated")
+            assert(yield* absent(newer.title))
+            yield* ui.screenshot("dispose-retained-latest")
+            yield* close()
+            yield* network.clear()
+            assert(!(yield* appeared(ui, "Search sessions and", { timeout: 1_500 })))
+          }
+
+          if (scenario === "selection") {
+            yield* warm()
+            yield* close()
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor(older.title)
+            yield* ui.arrow("down")
+            checkpoint("selected-row-survives-new-recent-row-arrival")
+            yield* opencode.session.create({ title: "Boreal newest", location })
+            yield* network.clear()
+            yield* ui.waitFor("Boreal newest")
+            yield* ready()
+            yield* ui.screenshot("selection-refreshed")
+            yield* ui.enter()
+            yield* verifyDestination(older)
+          }
+
+          if (scenario === "deletion") {
+            yield* warm()
+            checkpoint("server-delete-evicts-open-and-retained-rows")
+            yield* opencode.session.remove({ sessionID: older.id })
+            // Row removal is the causal barrier that SSE deletion reached this
+            // TUI. The next open cannot use a healthy list to hide a stale cache.
+            yield* ui.waitFor(() => absent(older.title))
+            yield* close()
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor(newer.title)
+            assert(yield* absent(older.title), "deleted session returned from retained snapshot")
+            const sessions = yield* opencode.session.list({ limit: 100 })
+            assert(!sessions.data.some((session) => session.id === older.id))
+            yield* ui.screenshot("deletion-blocked")
+            yield* ui.enter()
+            yield* network.clear()
+            yield* verifyDestination(newer)
+          }
+
+          if (scenario === "failure") {
+            yield* warm()
+            yield* close()
+            yield* network.set({ blackhole: true })
+            yield* open()
+            yield* ui.waitFor("Refreshing sessions and")
+            checkpoint("pending-reads-fail-but-retained-rows-remain")
+            yield* network.set({ refuseNew: true })
+            assert((yield* network.killConnections()) > 0)
+            yield* ui.waitFor("Could not refresh", { timeout: 5_000 })
+            assert(yield* ui.matches(older.title), "refresh failure discarded cached rows")
+            assert(yield* ui.matches(newer.title), "refresh failure discarded cached rows")
+            yield* ui.screenshot("failure-inline-error")
+            yield* network.clear()
+            yield* ui.press("escape")
+            checkpoint("healthy-reopen-recovers")
+            yield* open()
+            yield* ui.waitFor(older.title)
+            yield* ready()
+            assert(yield* absent("Could not refresh"), "healthy refresh retained the error")
+            yield* filter("Atlas archive")
+            yield* select(older.title)
+            yield* ui.screenshot("failure-recovered-filtered")
+            yield* ui.enter()
+            yield* verifyDestination(older)
+          }
+
+          yield* ui.screenshot(`${scenario}-passed`)
+          yield* Effect.tryPromise(() =>
+            Bun.write(
+              `${artifacts}/open-picker-report.json`,
+              JSON.stringify({ scenario, cols, seed, trace, passed: true }, null, 2),
+            ),
+          )
+          console.log(JSON.stringify({ scenario, cols, seed, passed: true, artifacts }))
+        }).pipe(
+          Effect.catchCause((cause) =>
+            saveFailure(context, { scenario, cols, seed, trace, cause: String(cause) }).pipe(
+              Effect.andThen(Effect.failCause(cause)),
+            ),
+          ),
+          Effect.ensuring(network.clear().pipe(Effect.orDie)),
+        )
+      }),
+    ),
+})

--- a/packages/drive/test/manual/tui-regressions/pending-form-restart.ts
+++ b/packages/drive/test/manual/tui-regressions/pending-form-restart.ts
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict"
 import { defineScript, Llm } from "../../../src/index.js"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
+import { latestSessionId, settled } from "./support.js"
+import { saveFailure } from "./state-machine.js"
 
 const question = {
   question: "Which runtime should the restart regression use?",
@@ -10,43 +13,106 @@ const question = {
   ],
   multiple: false,
 }
+const recovered = "restart-form-recovery-complete"
 
 export default defineScript({
   launch: "manual",
   run: ({ server, tuis, llm, artifacts }) =>
     Effect.gen(function* () {
-      yield* server.launch()
-      const tui = yield* tuis.launch("pending-form-restart")
-      yield* llm.queue(
-        Llm.toolCall({
-          index: 0,
-          id: "call_pending_form_restart",
-          name: "question",
-          input: { questions: [question] },
-        }),
-        Llm.finish("tool-calls"),
+      assert(
+        process.env.OPENCODE_DRIVE_DB && process.env.OPENCODE_DRIVE_DB !== ":memory:",
+        "pending-form-restart requires OPENCODE_DRIVE_DB for durable recovery",
       )
-      yield* tui.ui.submit("Ask one runtime question and wait for my answer.")
-      yield* tui.ui.waitFor(question.question, { timeout: 15_000 })
-
-      yield* server.kill()
-      yield* server.launch()
-      yield* Effect.sleep(3_000)
-      if (!(yield* tui.ui.matches(question.question))) return
-      yield* llm.queue(Llm.text("restart-form-answer-accepted"))
-      yield* tui.ui.enter()
-      yield* tui.ui.enter()
-      yield* tui.ui.waitFor("Review", { timeout: 5_000 })
-      yield* tui.ui.enter()
-      yield* Effect.sleep(1_000)
-
-      if (yield* tui.ui.matches("Form not found")) {
-        const frame = yield* tui.ui.capture()
-        yield* Effect.tryPromise(() =>
-          Bun.write(`${artifacts}/stale-form.frame.json`, JSON.stringify(frame, null, 2)),
-        )
-        return yield* Effect.fail(new Error("pending form became stale after server restart"))
+      const opencode = yield* server.launch()
+      const tui = yield* tuis.launch("pending-form-restart")
+      const trace: string[] = []
+      let requests = 0
+      yield* llm.serve((request) => {
+        if (JSON.stringify(request.body).includes("title generator")) return Stream.make(Llm.text("Form restart"))
+        requests++
+        return requests === 1
+          ? Stream.make(
+              Llm.toolCall({
+                index: 0,
+                id: "call_pending_form_restart",
+                name: "question",
+                input: { questions: [question] },
+              }),
+              Llm.finish("tool-calls"),
+            )
+          : Stream.make(Llm.text(recovered))
+      })
+      const checkpoint = (name: string) => {
+        trace.push(name)
+        console.error(JSON.stringify({ checkpoint: name }))
       }
-      yield* tui.ui.waitFor("restart-form-answer-accepted", { timeout: 15_000 })
+      yield* Effect.gen(function* () {
+        yield* tui.ui.submit("Ask one runtime question and wait for my answer.")
+        yield* tui.ui.waitFor(question.question, { timeout: 15_000 })
+        const sessionID = yield* latestSessionId(opencode)
+        assert.equal((yield* opencode.form.list({ sessionID })).length, 1)
+        checkpoint("open-form-before-restart")
+        yield* tui.ui.screenshot("pending-form-before-restart")
+
+        yield* server.kill()
+        const resumed = yield* server.launch()
+        // Form state is process-local; recovery aborts the old tool and makes a new model request.
+        checkpoint("serve-durable-recovery")
+        yield* tui.ui.waitFor(recovered, { timeout: 30_000 })
+        yield* resumed.session.wait({ sessionID })
+        assert.equal(
+          (yield* resumed.session.get({ sessionID })).outcome,
+          "succeeded",
+          "recovery settled without succeeding",
+        )
+        assert.equal((yield* resumed.form.list({ sessionID })).length, 0, "stale form stayed open")
+        assert(!(yield* tui.ui.matches("Form not found")), "stale form accepted local interaction")
+        yield* tui.ui.waitFor((state) => state.focused.editor, { timeout: 10_000 })
+        assert((yield* settled(tui.ui)).stable, "recovered UI did not settle")
+
+        const messages = (yield* resumed.message.list({ sessionID, limit: 100 })).data
+        assert(
+          messages.some(
+            (message) =>
+              message.type === "assistant" &&
+              message.content.some((part) => part.type === "text" && part.text === recovered),
+          ),
+          "recovery output was not durably preserved",
+        )
+        assert.equal(
+          messages.filter((message) => message.type === "user").length,
+          1,
+          "recovery required another user admission",
+        )
+        assert(
+          messages.some((message) => message.type === "synthetic" && message.text.includes("The server restarted")),
+          "durable recovery continuation is missing",
+        )
+        const tool = messages
+          .flatMap((message) => (message.type === "assistant" ? message.content : []))
+          .find((part) => part.type === "tool" && part.id === "call_pending_form_restart")
+        assert(
+          tool?.type === "tool" && tool.state.status === "error" && tool.state.error.type === "aborted",
+          "old question did not settle as interrupted",
+        )
+        assert.equal(requests, 2, "fixture did not serve exactly the original request and its recovery")
+        checkpoint("verified-stale-form-dismissal-and-recovery")
+        yield* tui.ui.screenshot("pending-form-recovered")
+        console.log(JSON.stringify({ sessionID, requests, trace, passed: true }))
+      }).pipe(
+        Effect.catchCause((cause) =>
+          saveFailure(
+            {
+              ui: tui.ui,
+              artifacts,
+              evidence: () =>
+                latestSessionId(opencode).pipe(
+                  Effect.flatMap((sessionID) => opencode.message.list({ sessionID, limit: 100 })),
+                ),
+            },
+            { trace, requests, cause: String(cause) },
+          ).pipe(Effect.andThen(Effect.failCause(cause))),
+        ),
+      )
     }),
 })

--- a/packages/drive/test/manual/tui-regressions/reconnect-modal-submit.ts
+++ b/packages/drive/test/manual/tui-regressions/reconnect-modal-submit.ts
@@ -1,65 +1,98 @@
+import assert from "node:assert/strict"
 import { defineScript } from "../../../src/index.js"
 import { Effect } from "effect"
-import { admissions, appeared, serveMarkers } from "./support.js"
+import { latestSessionId, serveMarkers, settled } from "./support.js"
+import { saveFailure } from "./state-machine.js"
 
-// Classifies what happens to a prompt submitted while the TUI shows its
-// reconnect overlay during a network partition. Distinguishes:
-//   A. POST admitted (buffered by the partition, flushed on heal) — reply lands.
-//   B. POST rejected — prompt rolls back and its text is restored to the composer.
-//   C. Enter swallowed — no POST, text stays in the composer, nothing happens
-//      after heal until a second enter.
-// Note: a quiet blackhole alone does not raise the overlay; it needs a
-// dropped connection (killConnections) while traffic is pending.
-// (Result: B, and it is the honest path — the POST is rejected fast with a
-// "Failed to send prompt · Transport" toast and the text stays in the
-// composer through heal, awaiting a manual resend. The remaining issue is
-// the overlay copy: "Restarting service..." during a pure network fault.)
-//
-//   bun run --cwd packages/drive drive start --name tui-reconnect-modal-submit \
-//     --script test/manual/tui-regressions/reconnect-modal-submit.ts \
-//     --dev "$OPENCODE_DEV"
-
+// A refused connection cannot admit input. Rejection must preserve the draft,
+// and an explicit resend after healing must admit it exactly once.
 export default defineScript({
   network: true,
-  llm: { settlementTimeout: 120_000 },
-
-  run: ({ ui, llm, network, opencode }) =>
+  run: ({ ui, llm, network, opencode, artifacts }) =>
     Effect.gen(function* () {
-      const model = yield* serveMarkers(llm, { title: "Reconnect modal probe" })
+      const model = yield* serveMarkers(llm, { title: "Reconnect submission" })
       model.track("FIRST")
       model.track("SECOND")
+      const trace: string[] = []
+      const checkpoint = (name: string) => {
+        trace.push(name)
+        console.error(JSON.stringify({ checkpoint: name }))
+      }
+      yield* Effect.gen(function* () {
+        yield* ui.submit("FIRST probe")
+        yield* ui.waitFor("FIRST_DONE", { timeout: 20_000 })
+        const sessionID = yield* latestSessionId(opencode)
+        yield* opencode.session.wait({ sessionID })
+        const owners = Effect.all({
+          messages: opencode.message.list({ sessionID, limit: 100 }),
+          pending: opencode.session.inbox.list({ sessionID }),
+        }).pipe(
+          Effect.map((result) => ({
+            projected: result.messages.data.filter(
+              (message) => message.type === "user" && message.text === "SECOND probe",
+            ).length,
+            pending: result.pending.filter((item) => item.type === "user" && item.payload.text === "SECOND probe")
+              .length,
+          })),
+        )
 
-      // Establish the session on a healthy network.
-      yield* ui.submit("FIRST probe")
-      yield* ui.waitFor("FIRST_DONE", { timeout: 20_000 })
+        checkpoint("refuse-connections-and-show-overlay")
+        yield* network.set({ refuseNew: true })
+        assert((yield* network.killConnections()) > 0)
+        yield* ui.waitFor("Connection lost", { timeout: 10_000 })
+        yield* ui.screenshot("reconnect-overlay")
+        yield* ui.submit("SECOND probe")
+        yield* ui.waitFor("Transport", { timeout: 10_000 })
+        assert.deepEqual(yield* owners, { projected: 0, pending: 0 })
+        yield* ui.screenshot("reconnect-rejected")
 
-      // Drop every connection and refuse new ones so the overlay appears.
-      yield* network.set({ refuseNew: true })
-      yield* network.killConnections()
-      const overlay = yield* appeared(ui, "Restarting service", { timeout: 30_000 })
-      yield* ui.screenshot("overlay")
-      yield* ui.submit("SECOND probe")
-      yield* Effect.sleep(1_500)
-      yield* ui.screenshot("after-submit")
+        checkpoint("heal-and-check-restored-composer")
+        yield* network.clear()
+        yield* ui.waitFor(() => ui.matches("Connection lost").pipe(Effect.map((visible) => !visible)), {
+          timeout: 30_000,
+        })
+        const input = yield* ui.getElement({ focused: true, editor: true })
+        const frame = yield* ui.capture()
+        const draft = frame.lines
+          .slice(input.y, input.y + input.height)
+          .map((line) =>
+            line.spans
+              .map((span) => span.text)
+              .join("")
+              .slice(input.x, input.x + input.width),
+          )
+          .join("\n")
+        assert(draft.includes("SECOND probe"), "failed input was not restored to the composer")
+        assert.deepEqual(
+          yield* owners,
+          { projected: 0, pending: 0 },
+          "input was admitted at the healed observation boundary",
+        )
+        yield* ui.screenshot("reconnect-draft-restored")
 
-      yield* network.clear()
-      yield* Effect.sleep(8_000)
-      yield* ui.screenshot("healed")
-
-      const admitted = yield* admissions(opencode, "SECOND")
-      const replied = yield* appeared(ui, "SECOND_DONE", { timeout: 20_000 })
-      console.log(
-        JSON.stringify({
-          overlay,
-          admitted,
-          replied,
-          verdict:
-            admitted === 1 && replied
-              ? "A: admitted and replied after heal"
-              : admitted === 1
-                ? "A': admitted after heal, reply missing on screen"
-                : "B or C: prompt never admitted — check screenshots for restore vs swallowed enter",
-        }),
+        checkpoint("explicit-resend-converges-once")
+        yield* ui.enter()
+        yield* ui.waitFor("SECOND_DONE", { timeout: 20_000 })
+        yield* opencode.session.wait({ sessionID })
+        assert.equal(
+          (yield* opencode.session.get({ sessionID })).outcome,
+          "succeeded",
+          "resend settled without succeeding",
+        )
+        assert.deepEqual(yield* owners, { projected: 1, pending: 0 })
+        assert.equal((yield* opencode.session.inbox.list({ sessionID })).length, 0)
+        yield* ui.waitFor((state) => state.focused.editor)
+        assert((yield* settled(ui)).stable, "resend left the UI busy")
+        yield* ui.screenshot("reconnect-resend-complete")
+        console.log(JSON.stringify({ sessionID, trace, passed: true }))
+      }).pipe(
+        Effect.catchCause((cause) =>
+          saveFailure(
+            { ui, artifacts, evidence: () => opencode.session.list({ limit: 10 }) },
+            { trace, cause: String(cause) },
+          ).pipe(Effect.andThen(Effect.failCause(cause))),
+        ),
+        Effect.ensuring(network.clear().pipe(Effect.orDie)),
       )
     }),
 })

--- a/packages/drive/test/manual/tui-regressions/tool-transport-death.ts
+++ b/packages/drive/test/manual/tui-regressions/tool-transport-death.ts
@@ -1,80 +1,81 @@
-import { defineScript, Llm } from "../../../src/index.js"
-import { Effect, Stream } from "effect"
-import { settled } from "./support.js"
+import { Llm, OpenCodeDriver } from "opencode-drive"
+import { Effect, Schedule, Stream } from "effect"
+import { makeTransport } from "../../tool/transport.js"
+import { latestSessionId, serveMarkers, settled } from "./support.js"
 
-// Reproduces the stuck-running tool part: a plugin-controlled tool whose
-// transport dies mid-execution (here: drive's tool controller idle timeout)
-// fails the tool and the step correctly continues with the failure result —
-// but the tool part's failure is never published. The row keeps its spinner
-// after the continuation completes, and only an unrelated later drain's
-// settleStaleToolCalls sweep settles it.
+// Drop the real static tool HTTP connection after progress has reached Core.
+// The fixture uses Drive's existing TCP proxy without changing production idle
+// timeouts, the public tool API, or the TUI's connection to Core.
 //
-// Run with the drive tool controller idleTimeout temporarily lowered (and its
-// /execute `server.timeout(request, 0)` exemption removed) so the transport
-// dies in seconds instead of never.
-//
-//   bun run --cwd packages/drive drive start --name tui-tool-transport-death \
-//     --script test/manual/tui-regressions/tool-transport-death.ts \
-//     --dev "$OPENCODE_DEV"
+//   OPENCODE_DEV=/path/to/opencode OPENCODE_DRIVE_MEDIA_DIR=$PWD/.drive-output \
+//     bun run --cwd packages/drive drive run \
+//     test/manual/tui-regressions/tool-transport-death.ts
 
-export default defineScript({
-  tools: ["shell"],
-  llm: { settlementTimeout: 180_000 },
-
-  run: ({ ui, llm, tools, opencode }) =>
-    Effect.gen(function* () {
-      const toolCalled = new Set<string>()
-      yield* llm.serve((request) => {
-        const body = JSON.stringify(request.body)
-        if (body.includes("title generator")) return Stream.make(Llm.text("Tool transport death"))
-        if (body.lastIndexOf("T0X") >= 0 && !toolCalled.has("T0X")) {
-          toolCalled.add("T0X")
-          return Stream.make(
-            Llm.toolCall({ index: 0, id: "call_T0X", name: "shell", input: { command: "gauntlet hold" } }),
-            Llm.finish("tool-calls"),
-          )
-        }
-        return Stream.make(Llm.text("T0X_CONTINUED"))
-      })
-
-      const shells = yield* tools.control("shell")
-      yield* ui.submit("T0X hold a silent shell")
-      const held = yield* shells.take("call_T0X")
-      yield* held.progress("one progress line, then silence\n")
-
-      // Outlive the (lowered) idle timeout without sending bytes; the tool
-      // controller kills the connection and the plugin's execute fetch dies.
-      yield* held.awaitInterrupted()
-      console.error(JSON.stringify({ observed: "transport interruption" }))
-
-      // The step continues with the failure result and completes.
-      yield* ui.waitFor("T0X_CONTINUED", { timeout: 30_000 })
-
-      // Now the turn is over. The tool part must be terminal and the UI must
-      // settle. No further prompts: nothing may rely on a later drain sweep.
-      const report = yield* settled(ui, { deadlineMs: 15_000 })
-      const sessions = yield* opencode.session.list({ limit: 1, order: "desc" })
-      const sessionID = sessions.data[0]!.id
-      const messages = yield* opencode.message.list({ sessionID, limit: 10, order: "desc" })
-      const toolStates = messages.data.flatMap((message) =>
-        message.type === "assistant"
-          ? message.content.flatMap((part) =>
-              part.type === "tool"
-                ? [
-                    {
-                      status: part.state?.status,
-                      error: part.state?.status === "error" ? part.state.error : undefined,
-                    },
-                  ]
-                : [],
-            )
-          : [],
-      )
-      console.log(JSON.stringify({ quiescent: report.stable, unstable: report.unstable, toolStates }))
-      yield* ui.screenshot("after-continuation")
-      if (!report.stable || toolStates.some((tool) => tool.status === "running"))
-        return yield* Effect.fail(
-          new Error("tool part left running after its transport died and the step completed"),
+export default Effect.gen(function* () {
+  const dev = process.env.OPENCODE_DEV
+  if (!dev) return yield* Effect.die(new Error("OPENCODE_DEV is required for the transport-death probe"))
+  const { config, proxy, shells } = yield* makeTransport()
+  return yield* OpenCodeDriver.use({
+    config,
+    opencode: { dev },
+    keepArtifacts: true,
+    llm: { settlementTimeout: 15_000 },
+  }, ({ ui, llm, opencode }) => Effect.gen(function* () {
+    let called = false
+    const markers = yield* serveMarkers(llm, {
+      title: "Tool transport death",
+      reply: (marker) => {
+        if (called) return Stream.make(Llm.text(`${marker}_CONTINUED`))
+        called = true
+        return Stream.make(
+          Llm.toolCall({ index: 0, id: "call_T0X", name: "shell", input: { command: "gauntlet hold" } }),
+          Llm.finish("tool-calls"),
         )
-    }),
-})
+      },
+    })
+    markers.track("T0X")
+    yield* ui.submit("T0X hold a silent shell")
+    const held = yield* shells.take("call_T0X").pipe(Effect.timeout("10 seconds"))
+    const progress = "one progress line, then silence\n"
+    yield* held.progress(progress)
+    const sessionID = yield* latestSessionId(opencode)
+    // V2 hides running tool content; the projection proves Core consumed the
+    // progress frame before the socket is dropped.
+    yield* opencode.message.list({ sessionID, limit: 10, order: "desc" }).pipe(
+      Effect.map((messages) => messages.data.some((message) =>
+        message.type === "assistant" && message.content.some((part) =>
+          part.type === "tool" && part.name === "shell" && part.state.status === "running" &&
+          part.state.metadata?.output === progress,
+        ),
+      )),
+      Effect.repeat({ until: (received) => received, schedule: Schedule.spaced("25 millis") }),
+      Effect.timeout("10 seconds"),
+    )
+
+    const killed = yield* Effect.sync(() => proxy.killConnections())
+    if (killed !== 1)
+      return yield* Effect.fail(new Error(`expected one active tool connection, dropped ${killed}`))
+    yield* held.awaitInterrupted().pipe(Effect.timeout("1 second"))
+    const late = yield* held.succeed({ output: "late result" }).pipe(Effect.flip)
+    if (late.reason !== "transport-interrupted") return yield* Effect.fail(late)
+    console.error(JSON.stringify({ observed: "transport interruption", killed }))
+
+    // No further prompts: a later drain must not be needed to settle the part.
+    yield* ui.waitFor("T0X_CONTINUED", { timeout: 15_000 })
+    const report = yield* settled(ui, { deadlineMs: 10_000 })
+    const messages = yield* opencode.message.list({ sessionID, limit: 10, order: "desc" })
+    const toolStates = messages.data.flatMap((message) =>
+      message.type === "assistant"
+        ? message.content.flatMap((part) =>
+          part.type === "tool" && part.name === "shell"
+            ? [{ status: part.state?.status, error: part.state?.status === "error" ? part.state.error : undefined }]
+            : [],
+        )
+        : [],
+    )
+    console.log(JSON.stringify({ quiescent: report.stable, unstable: report.unstable, toolStates }))
+    yield* ui.screenshot("after-continuation")
+    if (!report.stable || toolStates.length !== 1 || toolStates[0]?.status !== "error" || !toolStates[0].error)
+      return yield* Effect.fail(new Error("expected one failed tool part and a stable continuation after transport death"))
+  }))
+}).pipe(Effect.scoped)

--- a/packages/drive/test/manual/tui-regressions/tool-transport-death.ts
+++ b/packages/drive/test/manual/tui-regressions/tool-transport-death.ts
@@ -1,5 +1,6 @@
 import { Llm, OpenCodeDriver } from "opencode-drive"
-import { Effect, Schedule, Stream } from "effect"
+import assert from "node:assert/strict"
+import { Effect, Option, Queue, Stream } from "effect"
 import { makeTransport } from "../../tool/transport.js"
 import { latestSessionId, serveMarkers, settled } from "./support.js"
 
@@ -15,67 +16,91 @@ export default Effect.gen(function* () {
   const dev = process.env.OPENCODE_DEV
   if (!dev) return yield* Effect.die(new Error("OPENCODE_DEV is required for the transport-death probe"))
   const { config, proxy, shells } = yield* makeTransport()
-  return yield* OpenCodeDriver.use({
-    config,
-    opencode: { dev },
-    keepArtifacts: true,
-    llm: { settlementTimeout: 15_000 },
-  }, ({ ui, llm, opencode }) => Effect.gen(function* () {
-    let called = false
-    const markers = yield* serveMarkers(llm, {
-      title: "Tool transport death",
-      reply: (marker) => {
-        if (called) return Stream.make(Llm.text(`${marker}_CONTINUED`))
-        called = true
-        return Stream.make(
-          Llm.toolCall({ index: 0, id: "call_T0X", name: "shell", input: { command: "gauntlet hold" } }),
-          Llm.finish("tool-calls"),
+  return yield* OpenCodeDriver.use(
+    {
+      config,
+      opencode: { dev },
+      keepArtifacts: true,
+      llm: { settlementTimeout: 15_000 },
+    },
+    ({ ui, llm, opencode, artifacts }) =>
+      Effect.gen(function* () {
+        console.error(JSON.stringify({ observed: "runtime ready", artifacts }))
+        let called = false
+        const markers = yield* serveMarkers(llm, {
+          title: "Tool transport death",
+          reply: (marker) => {
+            if (called) return Stream.make(Llm.text(`${marker}_CONTINUED`))
+            called = true
+            return Stream.make(
+              Llm.toolCall({ index: 0, id: "call_T0X", name: "shell", input: { command: "gauntlet hold" } }),
+              Llm.finish("tool-calls"),
+            )
+          },
+        })
+        const events = yield* opencode.event.subscribe().pipe(Stream.toQueue({ capacity: "unbounded" }))
+        assert.equal((yield* Queue.take(events).pipe(Effect.timeout("10 seconds"))).type, "server.connected")
+        markers.track("T0X")
+        yield* ui.submit("T0X hold a silent shell")
+        const held = yield* shells.take("call_T0X").pipe(Effect.timeout("10 seconds"))
+        console.error(JSON.stringify({ observed: "tool held", id: held.id, connections: proxy.connections() }))
+        const progress = "one progress line, then silence\n"
+        yield* held.progress(progress)
+        console.error(JSON.stringify({ observed: "progress sent" }))
+        const sessionID = yield* latestSessionId(opencode)
+        // Running progress is ephemeral, absent from message.list. Establish the
+        // live subscription before sending progress so this event cannot be missed.
+        const received = yield* Stream.fromQueue(events).pipe(
+          Stream.filter((event) => event.type === "session.tool.progress"),
+          Stream.filter((event) => event.data.sessionID === sessionID && event.data.id === held.id),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+          Effect.timeout("10 seconds"),
         )
-      },
-    })
-    markers.track("T0X")
-    yield* ui.submit("T0X hold a silent shell")
-    const held = yield* shells.take("call_T0X").pipe(Effect.timeout("10 seconds"))
-    const progress = "one progress line, then silence\n"
-    yield* held.progress(progress)
-    const sessionID = yield* latestSessionId(opencode)
-    // V2 hides running tool content; the projection proves Core consumed the
-    // progress frame before the socket is dropped.
-    yield* opencode.message.list({ sessionID, limit: 10, order: "desc" }).pipe(
-      Effect.map((messages) => messages.data.some((message) =>
-        message.type === "assistant" && message.content.some((part) =>
-          part.type === "tool" && part.name === "shell" && part.state.status === "running" &&
-          part.state.metadata?.output === progress,
-        ),
-      )),
-      Effect.repeat({ until: (received) => received, schedule: Schedule.spaced("25 millis") }),
-      Effect.timeout("10 seconds"),
-    )
+        assert.deepEqual(received.data.metadata, { output: progress })
+        console.error(JSON.stringify({ observed: "Core progress received", metadata: received.data.metadata }))
 
-    const killed = yield* Effect.sync(() => proxy.killConnections())
-    if (killed !== 1)
-      return yield* Effect.fail(new Error(`expected one active tool connection, dropped ${killed}`))
-    yield* held.awaitInterrupted().pipe(Effect.timeout("1 second"))
-    const late = yield* held.succeed({ output: "late result" }).pipe(Effect.flip)
-    if (late.reason !== "transport-interrupted") return yield* Effect.fail(late)
-    console.error(JSON.stringify({ observed: "transport interruption", killed }))
+        const droppedAt = performance.now()
+        const killed = yield* Effect.sync(() => proxy.killConnections())
+        if (killed !== 1) return yield* Effect.fail(new Error(`expected one active tool connection, dropped ${killed}`))
+        yield* held.awaitInterrupted().pipe(Effect.timeout("1 second"))
+        const notifiedMs = performance.now() - droppedAt
+        const late = yield* held.succeed({ output: "late result" }).pipe(Effect.flip)
+        if (late.reason !== "transport-interrupted") return yield* Effect.fail(late)
+        console.error(JSON.stringify({ observed: "transport interruption", killed, notifiedMs }))
 
-    // No further prompts: a later drain must not be needed to settle the part.
-    yield* ui.waitFor("T0X_CONTINUED", { timeout: 15_000 })
-    const report = yield* settled(ui, { deadlineMs: 10_000 })
-    const messages = yield* opencode.message.list({ sessionID, limit: 10, order: "desc" })
-    const toolStates = messages.data.flatMap((message) =>
-      message.type === "assistant"
-        ? message.content.flatMap((part) =>
-          part.type === "tool" && part.name === "shell"
-            ? [{ status: part.state?.status, error: part.state?.status === "error" ? part.state.error : undefined }]
+        // No further prompts: a later drain must not be needed to settle the part.
+        yield* ui.waitFor("T0X_CONTINUED", { timeout: 15_000 })
+        const report = yield* settled(ui, { deadlineMs: 10_000 })
+        const messages = yield* opencode.message.list({ sessionID, limit: 10, order: "desc" })
+        const toolStates = messages.data.flatMap((message) =>
+          message.type === "assistant"
+            ? message.content.flatMap((part) =>
+                part.type === "tool" && part.name === "shell"
+                  ? [
+                      {
+                        status: part.state?.status,
+                        error: part.state?.status === "error" ? part.state.error : undefined,
+                      },
+                    ]
+                  : [],
+              )
             : [],
         )
-        : [],
-    )
-    console.log(JSON.stringify({ quiescent: report.stable, unstable: report.unstable, toolStates }))
-    yield* ui.screenshot("after-continuation")
-    if (!report.stable || toolStates.length !== 1 || toolStates[0]?.status !== "error" || !toolStates[0].error)
-      return yield* Effect.fail(new Error("expected one failed tool part and a stable continuation after transport death"))
-  }))
+        const screenshot = yield* ui.screenshot("after-continuation")
+        console.log(
+          JSON.stringify({
+            quiescent: report.stable,
+            waitedMs: report.waitedMs,
+            unstable: report.unstable,
+            toolStates,
+            screenshot,
+          }),
+        )
+        if (!report.stable || toolStates.length !== 1 || toolStates[0]?.status !== "error" || !toolStates[0].error)
+          return yield* Effect.fail(
+            new Error("expected one failed tool part and a stable continuation after transport death"),
+          )
+      }),
+  )
 }).pipe(Effect.scoped)

--- a/packages/drive/test/tool/controller.test.ts
+++ b/packages/drive/test/tool/controller.test.ts
@@ -7,6 +7,7 @@ import * as ToolController from "../../src/tool/controller.js"
 import { Failure } from "../../src/tool/index.js"
 import plugin from "../../src/tool/plugin.js"
 import type { OpenCodeConfig } from "../../src/script/types.js"
+import { makeTransport } from "./transport.js"
 
 interface RegisteredTool {
   readonly name: string
@@ -865,16 +866,20 @@ it.effect("interrupts a handler when its transport disconnects", () =>
   ),
 )
 
-it.effect("interrupts a handler with its plugin execution", () =>
+it.live("interrupts a callback handler once after receiving plugin progress", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const started = Promise.withResolvers<void>()
       const interrupted = Promise.withResolvers<void>()
+      let interruptions = 0
       const controller = yield* ToolController.make((tools) => {
-        tools.handle("shell", () =>
-          Effect.sync(() => started.resolve()).pipe(
+        tools.handle("shell", ({ progress }) =>
+          progress("running\n").pipe(
             Effect.andThen(Effect.never),
-            Effect.onInterrupt(() => Effect.sync(() => interrupted.resolve())),
+            Effect.onInterrupt(() => Effect.sync(() => {
+              interruptions++
+              interrupted.resolve()
+            })),
           ),
         )
       })
@@ -902,13 +907,112 @@ it.effect("interrupts a handler with its plugin execution", () =>
 
       const execution = yield* shell.execute(
         { command: "wait" },
-        { sessionID: "ses_interrupt", id: "call_interrupt" },
+        {
+          sessionID: "ses_interrupt",
+          id: "call_interrupt",
+          progress: () => Effect.sync(() => started.resolve()),
+        },
       ).pipe(Effect.forkScoped)
       yield* Effect.promise(() => started.promise)
-      yield* Fiber.interrupt(execution)
-      yield* Effect.promise(() => interrupted.promise)
+      yield* Fiber.interrupt(execution).pipe(
+        Effect.andThen(Effect.promise(() => interrupted.promise)),
+        Effect.timeout("1 second"),
+      )
+      expect(interruptions).toBe(1)
     }),
   ),
+)
+
+it.live("reports plugin interruption after receiving tool progress", () =>
+  Effect.gen(function* () {
+    const controller = yield* ToolController.make(["shell"])
+    const config: OpenCodeConfig = {}
+    controller.configure(config)
+    const injected = Schema.decodeUnknownSync(Schema.Array(Schema.Struct({ options: Schema.Unknown })))(config.plugins)[0]
+    const registered: RegisteredTool[] = []
+    yield* plugin.effect({
+      options: injected?.options,
+      tool: {
+        transform: (register: (tools: { add: (tool: RegisteredTool) => void }) => void) =>
+          Effect.sync(() => register({ add: (tool) => registered.push(tool) })),
+      },
+    })
+    const shell = registered.find((tool) => tool.name === "shell")
+    if (shell === undefined) return yield* Effect.die(new Error("shell tool was not registered"))
+    const received = yield* Deferred.make<void>()
+    const updates: Readonly<Record<string, unknown>>[] = []
+    const execution = yield* shell.execute(
+      { command: "hold after progress" },
+      {
+        sessionID: "ses_interrupt_progress",
+        id: "call_interrupt_progress",
+        progress: (update) => Effect.sync(() => { updates.push(update) }).pipe(
+          Effect.andThen(Deferred.succeed(received, undefined)),
+          Effect.asVoid,
+        ),
+      },
+    ).pipe(Effect.forkScoped)
+    const shells = yield* controller.controls.control("shell")
+    const held = yield* shells.take("call_interrupt_progress")
+    yield* held.progress("running\n")
+    yield* Deferred.await(received)
+    yield* Fiber.interrupt(execution).pipe(
+      Effect.andThen(held.awaitInterrupted()),
+      Effect.timeout("1 second"),
+    )
+    expect(updates).toEqual([{ output: "running\n" }])
+    expect(yield* held.succeed({ output: "late" }).pipe(Effect.flip)).toMatchObject({
+      reason: "transport-interrupted",
+    })
+    expect(yield* held.progress("late").pipe(Effect.flip)).toMatchObject({
+      reason: "transport-interrupted",
+    })
+    expect(yield* held.fail("late").pipe(Effect.flip)).toMatchObject({
+      reason: "transport-interrupted",
+    })
+  }),
+)
+
+it.live("fails a plugin execution and notifies its held call when the streaming socket is dropped", () =>
+  Effect.gen(function* () {
+    const { options, proxy, shells } = yield* makeTransport()
+    const registered: RegisteredTool[] = []
+    yield* plugin.effect({
+      options,
+      tool: {
+        transform: (register: (tools: { add: (tool: RegisteredTool) => void }) => void) =>
+          Effect.sync(() => register({ add: (tool) => registered.push(tool) })),
+      },
+    })
+    const shell = registered.find((tool) => tool.name === "shell")
+    if (shell === undefined) return yield* Effect.die(new Error("shell tool was not registered"))
+    const received = yield* Deferred.make<void>()
+    const updates: Readonly<Record<string, unknown>>[] = []
+    const execution = yield* shell.execute(
+      { command: "drop after progress" },
+      {
+        sessionID: "ses_transport_drop",
+        id: "call_transport_drop",
+        progress: (update) => Effect.sync(() => { updates.push(update) }).pipe(
+          Effect.andThen(Deferred.succeed(received, undefined)),
+          Effect.asVoid,
+        ),
+      },
+    ).pipe(Effect.flip, Effect.forkScoped)
+    const held = yield* shells.take("call_transport_drop")
+    yield* held.progress("running\n")
+    yield* Deferred.await(received)
+    expect(proxy.killConnections()).toBe(1)
+    yield* held.awaitInterrupted().pipe(Effect.timeout("1 second"))
+    expect(yield* Fiber.join(execution).pipe(Effect.timeout("1 second"))).toMatchObject({
+      _tag: "Tool.Error",
+    })
+    expect(updates).toEqual([{ output: "running\n" }])
+    expect(yield* held.succeed({ output: "late" }).pipe(Effect.flip)).toMatchObject({
+      reason: "transport-interrupted",
+    })
+    expect(proxy.connections()).toBe(0)
+  }),
 )
 
 it.live("uses native V2 tool progress, result metadata, and failure tags", () =>
@@ -932,7 +1036,7 @@ it.live("uses native V2 tool progress, result metadata, and failure tags", () =>
       },
     })
     const shell = registered.find((tool) => tool.name === "shell")
-    if (shell === undefined) return yield* Effect.dieMessage("shell tool was not registered")
+    if (shell === undefined) return yield* Effect.die(new Error("shell tool was not registered"))
     const updates: Readonly<Record<string, unknown>>[] = []
     const context = {
       sessionID: "ses_plugin",

--- a/packages/drive/test/tool/transport.ts
+++ b/packages/drive/test/tool/transport.ts
@@ -1,0 +1,41 @@
+import { Effect, Schema } from "effect"
+import { fileURLToPath } from "node:url"
+import { makeChaosProxy } from "../../src/instance/proxy.js"
+import type { OpenCodeConfig } from "../../src/project.js"
+import { make } from "../../src/tool/controller.js"
+
+// Test-only transport control: neither the tool API nor the TUI network is
+// involved in dropping this real plugin/controller HTTP connection.
+export const makeTransport = Effect.fn("ToolTransport.make")(function* () {
+  const controller = yield* make(["shell"])
+  const config: OpenCodeConfig = {}
+  controller.configure(config)
+  const injected = yield* Schema.decodeUnknownEffect(Schema.Array(Schema.Struct({
+    package: Schema.String,
+    options: Schema.Struct({
+      endpoint: Schema.String,
+      token: Schema.String,
+      tools: Schema.Array(Schema.String),
+      schemas: Schema.Record(Schema.String, Schema.Json),
+    }),
+  })))(config.plugins)
+  const plugin = injected[0]
+  if (plugin === undefined) return yield* Effect.die(new Error("tool plugin was not configured"))
+  const endpoint = new URL(plugin.options.endpoint)
+  const proxy = yield* Effect.acquireRelease(
+    Effect.sync(() => makeChaosProxy({
+      resolveTarget: () => Promise.resolve({ hostname: endpoint.hostname, port: Number(endpoint.port) }),
+    })),
+    (proxy) => Effect.sync(() => proxy.close()),
+  )
+  const options = { ...plugin.options, endpoint: proxy.url }
+  // `drive run` bundles this internal fixture, so locate the unbundled plugin
+  // through the package entrypoint rather than the compiled module's URL.
+  config.plugins = [{
+    ...plugin,
+    package: fileURLToPath(new URL("./tool/plugin.js", import.meta.resolve("opencode-drive"))),
+    options,
+  }]
+  const shells = yield* controller.controls.control("shell")
+  return { config, options, proxy, shells }
+})

--- a/skills/opencode-drive/SKILL.md
+++ b/skills/opencode-drive/SKILL.md
@@ -100,14 +100,14 @@ export default OpenCodeDriver.use(
       username: "Drive",
     },
     tuiConfig: {
-      theme: "system",
-      scroll_speed: 1,
+      theme: { name: "opencode", mode: "dark" },
+      scroll: { speed: 1 },
     },
     setup: ({ fs, config, tuiConfig }) =>
       Effect.gen(function* () {
         yield* fs.writeFile("src/setup.ts", "export const ready = true\n")
         config.username = "Setup wins"
-        tuiConfig.scroll_speed = 2
+        tuiConfig.scroll = { speed: 2 }
       }),
   },
   ({ ui }) => ui.screenshot("home"),
@@ -117,11 +117,17 @@ export default OpenCodeDriver.use(
 The DSL is applied in this order:
 
 1. `project.files` is written into the isolated project.
-2. `config` and `tuiConfig` are deeply merged over `.opencode/opencode.jsonc` and `.opencode/tui.jsonc` fixture values. Objects merge recursively; arrays and scalar values replace existing values.
+2. `config` and `tuiConfig` are deeply merged over `.opencode/opencode.jsonc` and `.opencode/cli.json` fixture values. Objects merge recursively; arrays and scalar values replace existing values.
 3. `setup` runs and may write project files or mutate the merged `config` and `tuiConfig` objects. Its mutations take final precedence.
 4. Drive writes both configs as stable, formatted JSON. With `project.git: true`, it creates a repository and commits the complete pre-launch state with fixed Git identity and timestamps.
 
 `fs.writeFile` is rooted inside the simulated project and creates parent directories. `project.git: true` refuses to replace existing Git metadata; omit it when prepared fixtures already include a repository.
+
+`tuiConfig` contains current V2 CLI settings despite retaining its public option
+name. Drive pins `OPENCODE_CONFIG_DIR` to the isolated project's `.opencode`, so
+`cli.json` is the fixture's global terminal configuration. Do not write legacy
+`tui.jsonc`, or write `cli.json` manually in `setup` instead of mutating
+`tuiConfig`: the normalized object is written after setup finishes.
 
 ### UI And LLM
 
@@ -249,6 +255,13 @@ dropped connection (`killConnections`) while traffic is pending.
   replacement service. Pass `OPENCODE_DRIVE_DB=...` so both generations share
   a database.
 
+Scripted TUIs always use an explicit connection to the script-owned server (or
+the chaos proxy). HTTP address and existing credentials stay stable across
+server generations, so retained TUIs and SDK clients can reconnect without
+electing a competing service. After `server.kill()`, call `server.launch()`;
+do not wait for the TUI to create a server on the script's behalf. This does not
+change non-scripted live launches' managed-service behavior.
+
 ### Reports And Paths
 
 `OpenCodeDriver` exports a branded `AbsolutePath` schema and a compact `RunReport` containing the artifact root, retention, recording paths, and endpoint compatibility. It also exports `decodeAbsolutePath` and `decodeRunReport` for validating unknown values.
@@ -366,7 +379,7 @@ import { defineScript, Llm } from "opencode-drive"
 
 export default defineScript({
   config: { autoupdate: false },
-  tuiConfig: { theme: "system" },
+  tuiConfig: { theme: { name: "opencode", mode: "dark" } },
   project: {
     git: true,
     files: { "src/value.ts": "export const value = 1\n" },


### PR DESCRIPTION
## Why

The V2 regression gauntlet exposed three Drive bugs that made valid OpenCode behavior look broken: terminal config was written to a legacy filename, static tool interruption stopped propagating after response headers, and a retained scripted TUI could elect a competing service during a Drive-owned restart. Several probes also still expected terminal failure instead of the current retry/recovery behavior.

## What Changes

| Situation | Corrected behavior |
| --- | --- |
| Supply `tuiConfig` | Merge current V2 `.opencode/cli.json` fixtures, options, and setup mutations in that order; write normalized `cli.json` into the isolated config directory. |
| Interrupt a static tool after receiving progress | Retain the native fetch cancellation signal for the whole response body; notify the held call and stop foreground callbacks. Detached background shells retain their existing lifetime. |
| Stop and relaunch a script-owned server | Keep one HTTP endpoint across generations and explicitly connect scripted TUIs to it, using the existing registered credential. A TUI cannot elect a competing managed server during the outage. |
| Use network chaos | Pin that same explicit connection to the proxy; the SDK control plane stays clean. |
| Use a non-scripted live launch | Preserve existing managed-service behavior. |
| Disconnect a simulated provider | Drive the scheduled retry or incomplete-stream continuation rather than waiting forever for terminal execution failure. |
| Restart with a pending form | Serve durable recovery, verify stale-form dismissal and old-tool interruption, and require successful projected recovery without another user prompt. |
| Submit during a refused connection | Assert send-path rejection, actual composer draft restoration, bounded pending/projected ownership checks, and exactly-once successful settlement after explicit resend. |
| Kill a static tool transport | Drop one established TCP connection after an exact live Core progress event; no manual idle-timeout edits or synthetic cancellation. |

The public `tuiConfig` option name is retained. This corrects the V2 destination and examples rather than adding a legacy fallback or emitting both configuration files.

## Lifecycle Ownership

The tool fetch previously used the signal supplied to `Effect.tryPromise`. That Effect finishes at response headers, so later interruption of body consumption called `reader.cancel()` without aborting Bun's request socket. An execution-local scoped signal now outlives headers and closes with body consumption.

Default scripted TUIs previously used implicit managed discovery. During an outage they could start an unowned service while Drive independently launched its replacement. Both inherited the same simulation backend WebSocket endpoint; in the retained failure, the competing service replaced registration and failed binding that endpoint, shutting down Drive's backend. Explicit owned-server connections and a stable HTTP endpoint remove the competing authority. Genuine boot failures, including an occupied owned port, remain visible; no generic retries or arbitrary recovery sleeps were added.

## Scope

The first three commits isolate the runtime repairs and their tests/patch changesets. The fourth updates the related probes and documentation and adds the compaction/picker regressions used to discover these gaps. Existing local probe migration and failure-evidence improvements were preserved in a dedicated worktree; the original checkout was not changed.

This does not change OpenCode's public protocol or general managed-service election. The Core bounded text/reasoning flush is a separate OpenCode change: https://github.com/anomalyco/opencode/pull/46048. The lifecycle probe now deliberately requires its desired single-burst live-publication behavior rather than injecting a second sentinel to hide the Core bug. The question-answer UI revision is also separate, not included in this combined tree.

## Verification

```sh
# packages/drive
bun run test
bun typecheck
bun run lint

# Repository root
bun run check
git diff --check

# packages/drive, against the explicit development checkout
OPENCODE_DRIVE_DB=restart.sqlite bun run src/cli/index.ts start --daemon --name restart-ownership --script test/manual/service-restart-ownership.ts --dev "$OPENCODE_DEV"
OPENCODE_DEV="$OPENCODE_DEV" bun run src/cli/index.ts run test/manual/tui-regressions/tool-transport-death.ts
```

- Config tests reproduced five failures before the filename correction; config and Git-safety tests then passed. A real V2 fixture proved file → options → setup precedence with a non-conflicting F6 command-palette binding, observing the actual Commands heading and focus change. A first Ctrl-K proof collided with an existing input binding and was retained as a probe-design failure, not reported as a runtime bug.
- After-progress cancellation failed before the fix with a one-second timeout and passed after it in about 29ms. All 54 tool tests pass; the cancellation/socket-drop trio passed ten repetitions. The unchanged quiescence-tool probe passed three runs, reaching both scenarios every time.
- Restart ownership reproduced unwanted TUI election in 3/3 before-fix runs. Three gated 10-second outage proofs and 20 unchanged restart runs then passed, with exactly two owned server starts and zero implicit elections per run, stable HTTP URLs, and retained SDKs reaching replacement PIDs. All 40 quiescence checkpoints passed. The original negative remains retained.
- The repaired transport-death program verified exact ephemeral `session.tool.progress` before dropping one socket, native interruption within one second, rejected late success, exactly one failed shell part, model continuation, and terminal stability. An initial probe incorrectly looked for running progress in durable message metadata; that fixture-only mistake was corrected to the live event contract and retained separately.
- **Final integrated sweep: 42/42 ordinary real-TUI cases passed on the first run**, plus **2/2 intended negative controls**, on clean Drive `77937563` and clean Core `6efafba1188b`. No unexpected failures, timeouts, or retries. The ordinary set is the 25 expanded existing probes, five compaction cases at 100 columns, and six picker cases at both 44 and 100 columns.
- Both negative controls run the actual recovery/resend probes with a visible marker followed by a terminal content filter. They fail at the specific successful-outcome assertion with projected `failed`, proving that idle/stable output alone cannot be misreported as success.
- All 44 physical runs completed their contract checks: 43 standalone script checks and one program's built-in check. Failure artifacts, source/probe hashes, projected state, traces, and first-pass results are retained separately. All task-owned processes and descriptors were closed.
- Final committed-head package suite: **252 Vitest tests and 58 CLI tests passed**. The repaired lifecycle seeds completed all 96 transitions, including running-tool interruption, and the network seeds completed all 96 transitions. This is measured coverage from the final run, not reuse of earlier truncated gauntlet results.
- Typechecks and configured lint pass. Lint retains one pre-existing unsafe-assertion warning in `recording/marks.ts`; manual probe lint also has existing generator consistent-return warnings. Repository checks include 40 passing catalog tests.

Runtime verification is macOS ARM64/Bun 1.3.14, not Windows Drive coverage. TCP probes assert explicit checkpoints and convergence, not every possible wire ordering or absence of arbitrarily delayed resends. Focused component/native tests cover exact timing, ownership, and failure boundaries. No package was published as part of this work.
